### PR TITLE
switch to "basic"

### DIFF
--- a/app.json
+++ b/app.json
@@ -123,7 +123,7 @@
       "formation": {
         "web": {
           "quantity": 1,
-          "size": "eco"
+          "size": "basic"
         }
       }
     }


### PR DESCRIPTION
"eco" requires a $5/mo plan, whereas "basic" is up to $7/mo but pay-per-hour, which may work better for occasional review apps