### PR TITLE
Update round navigation player

### DIFF
--- a/common/viewUtils.py
+++ b/common/viewUtils.py
@@ -128,8 +128,8 @@ def get_script_to_disable_animations():
                                       transition-property: none !important; }';\
             document.head.appendChild(animDisabler);\
             \
-            let fakeTime = 0;\
-            window.requestAnimationFrame = function(f) { fakeTime += 300; f(fakeTime); }"
+            if (barchartRoundPlayer) { barchartRoundPlayer.setTimeBetweenStepsMs(0); };\
+            if (roundPlayer) { roundPlayer.setTimeBetweenStepsMs(0); };"
 
 
 def request_to_domain(request):

--- a/static/bargraph/style.css
+++ b/static/bargraph/style.css
@@ -37,9 +37,12 @@ path.domain {
   height: 65px;  /* Note: sync with hideFaqs() */
   font-size: 0.9em;
   background-color: #fafdff;
+  margin-left: auto;
+  margin-right: auto;
   margin-top: 15px;
   display: none; /* Disable for now */
   overflow-y: auto;
+  max-width: 750px;
 }
 .round-description-text {
   line-height: normal;

--- a/static/visualizer/round-player.css
+++ b/static/visualizer/round-player.css
@@ -1,0 +1,67 @@
+.round-player-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.round-player-wrapper,
+.round-steps-wrapper {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+}
+
+.round-steps-wrapper {
+  flex-wrap: wrap;
+}
+
+.round-player-wrapper {
+  margin-bottom: 16px;
+}
+
+.round-player-step-btn {
+  border-color:#636161;
+  color: #636161;
+  margin: 8px;
+  font-size: 20px;
+  width: 52px;
+  max-width: 52px;
+  min-width: 52px;
+  padding: 8px 0;
+  flex: 1 1 calc(20% - 60px);
+  box-sizing: border-box;
+}
+
+.round-player-step-btn.round-player-active {
+  font-weight: bold;
+  border-width: 3px;
+}
+
+.round-player-play-btn {
+  background-color: #1922da;
+  font-weight: bold;
+  color: #fff;
+  padding: 8px 16px;
+  font-size: 16px;
+  min-width: 120px;
+}
+
+.range-player-nav {
+  font-size: 48px;
+  line-height: 0.5;
+  padding: 4px 12px;
+  color: #1922da;
+}
+
+.range-player-nav svg {
+  width: 24px;
+}
+
+.range-player-nav.range-player-prev svg {
+  transform: rotate(180deg);
+}
+
+.range-player-hidden {
+  visibility: hidden;
+}

--- a/static/visualizer/round-player.css
+++ b/static/visualizer/round-player.css
@@ -24,12 +24,13 @@
   border-color:#636161;
   color: #636161;
   margin: 8px;
-  font-size: 20px;
-  width: 52px;
-  max-width: 52px;
-  min-width: 52px;
-  padding: 8px 0;
-  flex: 1 1 calc(20% - 60px);
+  font-size: 16px;
+  min-width: 32px;
+  padding: 0 4px;
+  flex: 0 1 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   box-sizing: border-box;
 }
 
@@ -42,16 +43,23 @@
   background-color: #1922da;
   font-weight: bold;
   color: #fff;
-  padding: 8px 16px;
+  padding: 2px 10px;
   font-size: 16px;
-  min-width: 120px;
+  min-width: 80px;
 }
 
 .range-player-nav {
-  font-size: 48px;
   line-height: 0.5;
-  padding: 4px 12px;
+  padding: 0 8px;
   color: #1922da;
+}
+
+.range-player-nav.range-player-prev {
+  margin-right: 8px;
+}
+
+.range-player-nav.range-player-next {
+  margin-left: 8px;
 }
 
 .range-player-nav svg {

--- a/static/visualizer/round-player.js
+++ b/static/visualizer/round-player.js
@@ -1,0 +1,157 @@
+function RoundPlayer({ container, onChange, totalRounds }) {
+  let isPlaying = false;
+  let currentStep = totalRounds - 1;
+  // Imported from visualize-common.js
+  let stepTimeMs = getTimeBetweenAnimationStepsMs(totalRounds);
+  let timer = null;
+  const svgNS = "http://www.w3.org/2000/svg";
+  const MIN_ROUNDS_FOR_NAV = 3;
+  const ARROW_SVG_VIEWBOX = "0 0 185.343 185.343";
+  const ARROW_SVG_PATH =
+    "M51.707,185.343c-2.741,0-5.493-1.044-7.593-3.149c-4.194-4.194-4.194-10.981,0-15.175    l74.352-74.347L44.114,18.32c-4.194-4.194-4.194-10.987,0-15.175c4.194-4.194,10.987-4.194,15.18,0l81.934,81.934    c4.194,4.194,4.194,10.987,0,15.175l-81.934,81.939C57.201,184.293,54.454,185.343,51.707,185.343z";
+
+  function createNavButton(isNext) {
+    const navBtn = document.createElement("button");
+    navBtn.classList.add(
+      "btn",
+      "range-player-nav",
+      isNext ? "range-player-next" : "range-player-prev"
+    );
+    // Including at the beginning because we start at the last round
+    // Also including if there aren't more than two rounds
+    if (isNext || totalRounds < MIN_ROUNDS_FOR_NAV) {
+      navBtn.classList.add("range-player-hidden");
+    }
+    const navSvg = document.createElementNS(svgNS, "svg");
+    navSvg.setAttribute("viewBox", ARROW_SVG_VIEWBOX);
+    navSvg.setAttribute("aria-hidden", "true");
+
+    const navPath = document.createElementNS(svgNS, "path");
+    navPath.setAttribute("fill", "currentColor");
+    navPath.setAttribute("d", ARROW_SVG_PATH);
+    navSvg.appendChild(navPath);
+    navBtn.appendChild(navSvg);
+
+    navBtn.setAttribute("aria-label", isNext ? "Next" : "Previous");
+    navBtn.addEventListener("click", () =>
+      setStep(currentStep + (isNext ? 1 : -1))
+    );
+    return navBtn;
+  }
+
+  function createStepButton(round) {
+    let stepBtn = document.createElement("button");
+    stepBtn.classList.add("btn", "round-player-step-btn");
+    if (round === currentStep) {
+      stepBtn.classList.add("round-player-active");
+    }
+    if (round === 0 && totalRounds === 1) {
+      stepBtn.innerText = "Round 1";
+    } else {
+      stepBtn.innerText = round + 1;
+    }
+    stepBtn.dataset.round = round;
+    stepBtn.addEventListener("click", () => setStep(round));
+    return stepBtn;
+  }
+
+  function createPlayButton() {
+    const playBtn = document.createElement("button");
+    playBtn.classList.add("btn", "round-player-play-btn");
+    playBtn.innerText = "Play";
+    playBtn.addEventListener("click", () => {
+      isPlaying ? stop() : play();
+    });
+    return playBtn;
+  }
+
+  function init() {
+    const playerEl = document.createElement("div");
+    playerEl.classList.add("round-player-container");
+
+    const wrapperEl = document.createElement("div");
+    wrapperEl.classList.add("round-player-wrapper");
+    wrapperEl.appendChild(createNavButton(false));
+
+    const stepsWrapperEl = document.createElement("div");
+    stepsWrapperEl.classList.add("round-steps-wrapper");
+
+    for (let round = 0; round < totalRounds; ++round) {
+      stepsWrapperEl.appendChild(createStepButton(round));
+    }
+    wrapperEl.appendChild(stepsWrapperEl);
+
+    wrapperEl.appendChild(createNavButton(true));
+    playerEl.appendChild(wrapperEl);
+    playerEl.appendChild(createPlayButton());
+
+    container.appendChild(playerEl);
+  }
+
+  function changeStep(step) {
+    // This shouldn't get triggered, but short-circuit if out of bounds
+    if (step >= totalRounds || step < 0) {
+      stop();
+      return;
+    }
+
+    // Remove from previous element
+    const previousStepEl = container.querySelector(
+      `[data-round="${currentStep}"]`
+    );
+    if (previousStepEl) {
+      previousStepEl.classList.remove("round-player-active");
+    }
+    currentStep = step;
+
+    container
+      .querySelector(`[data-round="${currentStep}"]`)
+      .classList.add("round-player-active");
+
+    if (totalRounds >= MIN_ROUNDS_FOR_NAV) {
+      container
+        .querySelector(".range-player-next")
+        .classList.toggle(
+          "range-player-hidden",
+          currentStep >= totalRounds - 1
+        );
+
+      container
+        .querySelector(".range-player-prev")
+        .classList.toggle("range-player-hidden", currentStep <= 0);
+    }
+
+    onChange(step);
+  }
+
+  function setStep(step) {
+    stop();
+    changeStep(step);
+  }
+
+  function nextStep() {
+    if (!isPlaying) return;
+
+    timer = window.setTimeout(() => {
+      changeStep(currentStep + 1);
+      nextStep();
+    }, stepTimeMs);
+  }
+
+  function play() {
+    isPlaying = true;
+    container.querySelector(".round-player-play-btn").innerText = "Stop";
+    changeStep(0);
+    nextStep();
+  }
+
+  function stop() {
+    isPlaying = false;
+    window.clearTimeout(timer);
+    container.querySelector(".round-player-play-btn").innerText = "Play";
+  }
+
+  init();
+
+  return { play, stop, setStep };
+}

--- a/static/visualizer/round-player.js
+++ b/static/visualizer/round-player.js
@@ -1,8 +1,9 @@
-function RoundPlayer({ container, onChange, totalRounds }) {
+function RoundPlayer({ container, onChange, onChangeWhilePlaying, totalRounds, timeBetweenStepsMs }) {
   let isPlaying = false;
   let currentStep = totalRounds - 1;
   // Imported from visualize-common.js
-  let stepTimeMs = getTimeBetweenAnimationStepsMs(totalRounds);
+  let stepTimeMs =
+    timeBetweenStepsMs || getTimeBetweenAnimationStepsMs(totalRounds);
   let timer = null;
   const svgNS = "http://www.w3.org/2000/svg";
   const MIN_ROUNDS_FOR_NAV = 3;
@@ -121,7 +122,11 @@ function RoundPlayer({ container, onChange, totalRounds }) {
         .classList.toggle("range-player-hidden", currentStep <= 0);
     }
 
-    onChange(step);
+    if (isPlaying && onChangeWhilePlaying) {
+      onChangeWhilePlaying(step) ;
+    } else {
+      onChange(step)
+    }
   }
 
   function setStep(step) {
@@ -132,6 +137,7 @@ function RoundPlayer({ container, onChange, totalRounds }) {
   function nextStep() {
     if (!isPlaying) return;
 
+    console.log(stepTimeMs);
     timer = window.setTimeout(() => {
       changeStep(currentStep + 1);
       nextStep();
@@ -151,7 +157,15 @@ function RoundPlayer({ container, onChange, totalRounds }) {
     container.querySelector(".round-player-play-btn").innerText = "Play";
   }
 
+  function playing() {
+    return isPlaying;
+  }
+
+  function setTimeBetweenStepsMs(timeBetweenStepsMs) {
+    stepTimeMs = timeBetweenStepsMs;
+  }
+
   init();
 
-  return { play, stop, setStep };
+  return { play, stop, setStep, setTimeBetweenStepsMs, playing };
 }

--- a/static/visualizer/round-player.js
+++ b/static/visualizer/round-player.js
@@ -1,4 +1,10 @@
-function RoundPlayer({ container, onChange, onChangeWhilePlaying, totalRounds, timeBetweenStepsMs }) {
+function RoundPlayer({
+  container,
+  onChange,
+  onChangeWhilePlaying,
+  totalRounds,
+  timeBetweenStepsMs,
+}) {
   let isPlaying = false;
   let currentStep = totalRounds - 1;
   // Imported from visualize-common.js
@@ -7,9 +13,9 @@ function RoundPlayer({ container, onChange, onChangeWhilePlaying, totalRounds, t
   let timer = null;
   const svgNS = "http://www.w3.org/2000/svg";
   const MIN_ROUNDS_FOR_NAV = 3;
-  const ARROW_SVG_VIEWBOX = "0 0 185.343 185.343";
+  const ARROW_SVG_VIEWBOX = "0 0 24 28";
   const ARROW_SVG_PATH =
-    "M51.707,185.343c-2.741,0-5.493-1.044-7.593-3.149c-4.194-4.194-4.194-10.981,0-15.175    l74.352-74.347L44.114,18.32c-4.194-4.194-4.194-10.987,0-15.175c4.194-4.194,10.987-4.194,15.18,0l81.934,81.934    c4.194,4.194,4.194,10.987,0,15.175l-81.934,81.939C57.201,184.293,54.454,185.343,51.707,185.343z";
+    "M21.981 16.5981C23.981 15.4434 23.981 12.5566 21.981 11.4019L3.22017 0.570383C2.01129 -0.127565 0.500193 0.744867 0.500193 2.14076C0.500193 2.81278 0.871843 3.42969 1.46593 3.7438L15.7356 11.2887C17.8878 12.4266 17.8597 15.5191 15.6872 16.6179L1.59932 23.7428C0.925186 24.0837 0.500193 24.7749 0.500193 25.5304C0.500193 27.0724 2.16952 28.0362 3.50498 27.2652L21.981 16.5981Z";
 
   function createNavButton(isNext) {
     const navBtn = document.createElement("button");
@@ -123,9 +129,9 @@ function RoundPlayer({ container, onChange, onChangeWhilePlaying, totalRounds, t
     }
 
     if (isPlaying && onChangeWhilePlaying) {
-      onChangeWhilePlaying(step) ;
+      onChangeWhilePlaying(step);
     } else {
-      onChange(step)
+      onChange(step);
     }
   }
 

--- a/static/visualizer/tabs-nonblocking.js
+++ b/static/visualizer/tabs-nonblocking.js
@@ -37,8 +37,6 @@ function goToTab(newTabName) {
   const canBeDynamic = newTabName == 'barchart' || newTabName == 'round-by-round';
   document.getElementById('toggle-dynamic').style.display = canBeDynamic ? 'block' : 'none';
 
-  animateIfNeeded(newTabName);
-
   // Sankey wants a special resize
   if (newTabName == 'sankey') {
     fitSankeyViewboxToContents();

--- a/static/visualizer/visualize-nonblocking.js
+++ b/static/visualizer/visualize-nonblocking.js
@@ -1,34 +1,3 @@
-var hasAnimatedSlider = false;
-
-function animationForBarchartCompleted() {
-    isBargraphAnimationInProgress = false;
-    showFaqButton();
-}
-
-function animateIfNeeded(newTabName) {
-  if (hasAnimatedSlider) {
-    return;
-  }
-
-  animateNow(newTabName);
-}
-
-function animateNow(newTabName) {
-  // TODO only run animation on interactive visualizations
-  if (newTabName == 'barchart') {
-    hideFaqs();
-
-    showTextOnRoundDescriber(humanFriendlySummary, true);
-    isBargraphAnimationInProgress = true;
-
-    trs_animate('bargraph-slider-container', animationForBarchartCompleted);
-    hasAnimatedSlider = true;
-  } else if (newTabName == 'round-by-round') {
-    trs_animate('tabular-by-round-slider-container');
-    hasAnimatedSlider = true;
-  }
-}
-
 function chooseBetweenTimelineAndDescription() {
   // Pretty hacky - just for evaluation
   if (!config.doUseDescriptionInsteadOfTimeline) {

--- a/templates/bargraph/barchart-interactive-nonblocking.html
+++ b/templates/bargraph/barchart-interactive-nonblocking.html
@@ -123,16 +123,14 @@ function makeInteractiveGraph() {
     updateFaqText(round);
   }
 
-  trs_createSliderAndTimeline({
-    wrapperDivId: 'bargraph-slider-container',
-    numTicks: numRounds,
-    color: colorsPerRound,
-    tickText: generateTickTexts(numRounds),
-    hideActiveTickText: doHideActiveTickText(numRounds),
-    sliderValueChanged: sliderValueChangedCallback,
-    timelineData: generateTimelineData(humanFriendlyEventsPerRound),
-    timelinePeeking: !config.doUseDescriptionInsteadOfTimeline,
-    timeBetweenStepsMs: getTimeBetweenAnimationStepsMs(numRounds)
+  const roundPlayer = RoundPlayer({
+    container: document.getElementById("bargraph-slider-container"),
+    totalRounds: numRounds,
+    onChange: sliderValueChangedCallback,
+  });
+
+  document.getElementById("barchart-play-link").addEventListener("click", function () {
+    roundPlayer.play();
   });
 
   // After creating the slider, make the default text the summary

--- a/templates/bargraph/barchart-interactive-nonblocking.html
+++ b/templates/bargraph/barchart-interactive-nonblocking.html
@@ -4,6 +4,8 @@
 
 var isBargraphAnimationInProgress = false;
 const idOfWhyButton = "#bargraph-interactive-why-button";
+// Raising the scope to give tests easier access
+let barchartRoundPlayer = null;
 
 function showTextOnRoundDescriber(description, keepFAQButtonHidden) {
   if (isBargraphAnimationInProgress) {
@@ -123,14 +125,20 @@ function makeInteractiveGraph() {
     updateFaqText(round);
   }
 
-  const roundPlayer = RoundPlayer({
+  barchartRoundPlayer = RoundPlayer({
     container: document.getElementById("bargraph-slider-container"),
     totalRounds: numRounds,
     onChange: sliderValueChangedCallback,
+    // While playing, don't update the description text for the round
+    onChangeWhilePlaying: function (round) {
+      hideFaqs();
+      transitionEachBarForRound(round);
+      updateFaqText(round);
+    },
   });
 
   document.getElementById("barchart-play-link").addEventListener("click", function () {
-    roundPlayer.play();
+    barchartRoundPlayer.play();
   });
 
   // After creating the slider, make the default text the summary

--- a/templates/bargraph/barchart-interactive.html
+++ b/templates/bargraph/barchart-interactive.html
@@ -10,19 +10,16 @@
     <div class="shadow-wrapper col-md-12 col-xl-10" id="bargraph-interactive-body">
       <div id="bargraph-slider-container" class="ml-auto mr-auto">
       </div>
-
-      <div id="round-description-wrapper" class="round-description-wrapper" role="alert">
-        <div class="round-description-text">
-          <span id="bargraph-interactive-round-description">
-          </span>
-          <span id="bargraph-interactive-why-button">
-            <a role="button" tabindex="0" onclick="showFaqs()">Read the FAQs</a> or <a role="button" tabindex="0" onclick="animateNow('barchart')">play the animation</a>.
-          </span>
-          <div id="faq-text"></div>
-        </div>
+    </div>
+    <div id="round-description-wrapper" class="round-description-wrapper" role="alert">
+      <div class="round-description-text">
+        <span id="bargraph-interactive-round-description">
+        </span>
+        <span id="bargraph-interactive-why-button">
+          <a role="button" tabindex="0" onclick="showFaqs()">Read the FAQs</a> or <a role="button" tabindex="0" id="barchart-play-link">play the animation</a>.
+        </span>
+        <div id="faq-text"></div>
       </div>
-
-
     </div>
   </div>
 </div>

--- a/templates/tabular/tabular-by-round-interactive-nonblocking.html
+++ b/templates/tabular/tabular-by-round-interactive-nonblocking.html
@@ -15,15 +15,10 @@ function showRound(round) {
 
 showRound(numRounds-1)
 
-trs_createSliderAndTimeline({
-  wrapperDivId: 'tabular-by-round-slider-container',
-  numTicks: numRounds,
-  tickText: generateTickTexts(numRounds),
-  hideActiveTickText: doHideActiveTickText(numRounds),
-  sliderValueChanged: showRound,
-  timelineData: generateTimelineData(humanFriendlyEventsPerRound),
-  timelinePeeking: !config.doUseDescriptionInsteadOfTimeline,
-  timeBetweenStepsMs: getTimeBetweenAnimationStepsMs(numRounds) / 2 // hack: make this twice as fast as barchart
+const roundPlayer = RoundPlayer({
+  container: document.getElementById("tabular-by-round-slider-container"),
+  totalRounds: numRounds,
+  onChange: showRound,
 });
 
 </script>

--- a/templates/visualizer/common-visualizer-nonblocking.html
+++ b/templates/visualizer/common-visualizer-nonblocking.html
@@ -17,12 +17,14 @@
 {% compress css file %}
   <link rel="stylesheet" href="{% static '@artoonie/timeline-range-slider/timeline-range-slider/slider.css' %}">
   <link rel="stylesheet" href="{% static 'visualizer/visualize-common.css' %}">
+  <link rel="stylesheet" href="{% static 'visualizer/round-player.css' %}">
   <link rel="stylesheet" href="{% static 'tabular/style.css' %}">
 {% endcompress %}
 
 <!-- Shared resources for multiple visualizations-->
 {% compress js file %}
   <script src="{% static 'visualizer/visualize-common.js' %}" />
+  <script src="{% static 'visualizer/round-player.js' %}"></script>
   <script src="{% static 'visualizer/colors.js' %}" />
   <script src="{% static '@artoonie/timeline-range-slider/timeline-range-slider/slider.js' %}"></script>
   <script src="{% static 'visualizer/visualize-nonblocking.js' %}"/>

--- a/visualizer/descriptors/roundDescriber.py
+++ b/visualizer/descriptors/roundDescriber.py
@@ -3,8 +3,7 @@ Describes what happened in each round of an RCV Election in plain English.
 """
 
 from visualizer.common import intify
-from visualizer.descriptors import common
-from visualizer.descriptors import textForWinnerUtils
+from visualizer.descriptors import common, textForWinnerUtils
 
 
 class Describer:
@@ -236,6 +235,6 @@ class Describer:
                    f"after which {winnerText}. Here's what happened in each round. "
         else:
             text = f"After {numRounds} rounds of this {electionType}, "\
-                   f"{winnerText}. Move the slider to see what happened in each round."
+                   f"{winnerText}."
 
         return text

--- a/visualizer/tests/liveServerTestBaseClass.py
+++ b/visualizer/tests/liveServerTestBaseClass.py
@@ -11,7 +11,6 @@ from django.db.models import BooleanField
 from django.urls import reverse
 from selenium import webdriver
 from selenium.common.exceptions import WebDriverException
-from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
 
 from common.testUtils import TestHelpers
@@ -162,21 +161,6 @@ class LiveServerTestBaseClass(StaticLiveServerTestCase):
         """ Disables transitions on the current page """
         self.browser.execute_script(get_script_to_disable_animations())
 
-    def _disable_bargraph_slider_timer(self):
-        """
-        Changes the timeBetweenStepsMs to 1ms.
-        Note that this does not change the barchart's time between each step,
-        just the timeline. You still need to cancel the animation using trs_moveSliderTo.
-        """
-        key = "_sliderDiv_bargraph-slider-container"
-
-        # Ensure we're touching the right thing: 1200ms
-        oldTime = self.browser.execute_script(f"return sliders['{key}']['timeBetweenStepsMs'];")
-        self.assertEqual(oldTime, 1200)  # note: 1200 is only true if <= 7 rounds
-
-        # Change
-        self.browser.execute_script(f"sliders['{key}']['timeBetweenStepsMs'] = 1;")
-
     @classmethod
     def _ensure_eventually_asserts(cls, assertion):
         """ Waits up to waitTimeSeconds for the assertion to be true """
@@ -264,18 +248,11 @@ class LiveServerTestBaseClass(StaticLiveServerTestCase):
 
     def _go_to_round_by_clicking(self, round_i):
         """
-        trs_moveSliderTo does not cancel the animation, so this can be used if
-        you need to trigger the cancel-animation behavior.
+        Helper to trigger going to a specific round in the player
         """
         # Cancel animation by clicking on round_i'th element element
         container = self.browser.find_element(By.ID, 'bargraph-slider-container')
-        tick = container.find_elements(By.CLASS_NAME, 'slider-item')[round_i]
-
-        # Note - need an action chain because the first tick isn't actually receiving the click,
-        # the slider itself handles it, and selenium throws ElementClickInterceptedException
-        ActionChains(self.browser).move_to_element(tick)\
-            .click(tick)\
-            .perform()
+        container.find_elements(By.CLASS_NAME, 'round-player-step-btn')[round_i].click()
 
     def _set_input_to(self, inputId, value):
         """

--- a/visualizer/tests/testLiveBrowserHeadless.py
+++ b/visualizer/tests/testLiveBrowserHeadless.py
@@ -80,7 +80,8 @@ class LiveBrowserHeadlessTests(liveServerTestBaseClass.LiveServerTestBaseClass):
         """ Ensure eliminated color setting can be changed """
         def _get_eliminated_color():
             # Move the slider to stop animation
-            self.browser.execute_script("trs_moveSliderTo('bargraph-slider-container', 4)")
+            self.browser.find_element(
+                By.CSS_SELECTOR, '#bargraph-slider-container [data-round="3"]').click()
 
             # Get an eliminated bar by its text
             bargraph = self.browser.find_element(By.ID, 'bargraph-interactive-body')
@@ -358,30 +359,12 @@ class LiveBrowserHeadlessTests(liveServerTestBaseClass.LiveServerTestBaseClass):
         # Upload something with few rounds so the animation doesn't take too long
         self._upload(filenames.THREE_ROUND)
 
-        # Ensure the animation started
-        WebDriverWait(self.browser, timeout=0.5, poll_frequency=0.1).until(
-            lambda d: self.browser.execute_script("return hasAnimatedSlider;"))
+        # Start the animation
+        playbutton = self.browser.find_element(
+            By.CSS_SELECTOR, '#bargraph-slider-container .round-player-play-btn')
+        playbutton.click()
 
-        # Ensure description is inital summary
         desc = self.browser.find_element(By.ID, 'bargraph-interactive-round-description')
-        self._ensure_eventually_asserts(
-            lambda: self.assertIn('what happened in each round', desc.text))
-
-        # Now disable animations to speed them up
-        self._disable_all_animations()
-        self._disable_bargraph_slider_timer()
-
-        # Wait for animation to complete
-        WebDriverWait(self.browser, timeout=0.5, poll_frequency=0.1).until(
-            lambda d: self.browser.execute_script("return !isBargraphAnimationInProgress;"))
-
-        # Check that the text hasn't changed
-        self._ensure_eventually_asserts(
-            lambda: self.assertIn('what happened in each round', desc.text))
-
-        # Now move the slider
-        self.browser.execute_script("trs_moveSliderTo('bargraph-slider-container', 0)")
-
         # Check that the text updates now
         self._ensure_eventually_asserts(
             lambda: self.assertNotIn('what happened in each round', desc.text))
@@ -542,20 +525,15 @@ class LiveBrowserHeadlessTests(liveServerTestBaseClass.LiveServerTestBaseClass):
 
         # Look at the description, ensure it shows the summary
         span = self.browser.find_element(By.ID, 'bargraph-interactive-round-description')
-        self._ensure_eventually_asserts(
-            lambda: self.assertIn('Move the slider to see', span.get_attribute('innerHTML')))
-
-        # Ensure animation has not begun
-        self.assertFalse(self.browser.execute_script("return hasAnimatedSlider;"))
 
         # Hit play button
-        hackyXpathForPlayButton = '//*[@id="bargraph-interactive-why-button"]/a[2]'
-        playbutton = self.browser.find_element(By.XPATH, hackyXpathForPlayButton)
+        playbutton = self.browser.find_element(
+            By.CSS_SELECTOR, '#bargraph-slider-container .round-player-play-btn')
         playbutton.click()
 
         # Ensure animation has begun
-        WebDriverWait(self.browser, timeout=0.5, poll_frequency=0.1).until(
-            lambda d: self.browser.execute_script("return hasAnimatedSlider;"))
+        self._ensure_eventually_asserts(
+            lambda: self.assertIn('Round 2', span.get_attribute('innerHTML')))
 
         # Ensure animation stops and new text appears, and that new text starts with
         # the round number. Click twice in case we were already on the first round.
@@ -573,7 +551,6 @@ class LiveBrowserHeadlessTests(liveServerTestBaseClass.LiveServerTestBaseClass):
         thresholdStatic = self.browser.find_element(By.ID, 'thresholdbargraph-fixed-body')
 
         self._disable_all_animations()
-        self._disable_bargraph_slider_timer()
 
         # Round 1: Static is visible, interactive isn't
         self._go_to_round_by_clicking(0)

--- a/visualizer/tests/testLiveBrowserWithHead.py
+++ b/visualizer/tests/testLiveBrowserWithHead.py
@@ -242,7 +242,6 @@ class LiveBrowserWithHeadTests(liveServerTestBaseClass.LiveServerTestBaseClass):
 
         # Move the slider and complete all other animations
         self._disable_all_animations()
-        self._disable_bargraph_slider_timer()
         self.browser.execute_script("trs_moveSliderTo('bargraph-slider-container', 3);")
         self.browser.execute_script("showFaqButtonNow();")
 


### PR DESCRIPTION
## Description

Updates the round navigation to match the proposed designs in Figma. This replaces the existing component for the slider on the bar graph and tables by round for a component with defined steps for each round that does not automatically play unless triggered.

I tried to follow existing patterns that I saw and change as little code as possible, but if there's anything I should split out into separate files let me know.

Some of the items in Figma were images that didn't include the direct dimensions, so to start I got as close as I could and figured we could iron that out more easily in a PR.

Happy to make any changes here and figure out specifics!

## Screenshots, recording

https://github.com/user-attachments/assets/0ef200c5-b7cd-4195-81e1-de3b05e5b2c5

![2025-04-03_21-46](https://github.com/user-attachments/assets/704cb20a-37c5-4167-b009-4dfab720449f)

## Questions

- Is there anything else we want to test? I focused on updating the existing tests to work with the new component, but some parts were no longer relevant
- Are all of the tests expected to pass locally? I had a lot of errors at baseline that might be related to my environment so I focused on the tests I changed, but I imagine this could have cascading impacts