### PR TITLE
fix ElectionPageTests.test_election_pages

### DIFF
--- a/common/testUtils.py
+++ b/common/testUtils.py
@@ -71,6 +71,7 @@ class TestHelpers():
         chromeOptions.add_argument("--no-sandbox")
         chromeOptions.add_argument("--disable-dev-shm-usage")
         chromeOptions.add_argument("--shm-size=512m")
+        chromeOptions.add_argument("--force-device-scale-factor=1")
 
         if 'CHROMEDRIVER_PATH' in os.environ:
             chromeOptions.add_argument("--remote-debugging-port=9222")

--- a/electionpage/tests.py
+++ b/electionpage/tests.py
@@ -54,6 +54,7 @@ class ElectionPageTests(liveServerTestBaseClass.LiveServerTestBaseClass):
             date=datetime.datetime.utcnow())
         for _ in range(numElections):
             epModel.listOfElections.add(cls._create_json_config())
+        epModel.save()
         return epModel
 
     @classmethod
@@ -120,7 +121,7 @@ class ElectionPageTests(liveServerTestBaseClass.LiveServerTestBaseClass):
 
         # And the height was correctly set via PostMessages
         self._ensure_eventually_asserts(lambda: self.assertEqual(bargraphIframeWrapper.find_element(
-            By.TAG_NAME, 'iframe').get_attribute('height'), '328px'))
+            By.TAG_NAME, 'iframe').get_attribute('height'), '335px'))
 
     @Mocker()
     def test_scrape_all(self, requestMock):

--- a/static/visualizer/freelancer-purged.css
+++ b/static/visualizer/freelancer-purged.css
@@ -61,7 +61,7 @@ footer, header, nav, section {
 
 body {
   margin: 0;
-  font-family-sans-serif: "Montserrat", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  font-family: "Montserrat", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5;

--- a/visualizer/tests/liveServerTestBaseClass.py
+++ b/visualizer/tests/liveServerTestBaseClass.py
@@ -62,6 +62,7 @@ class LiveServerTestBaseClass(StaticLiveServerTestCase):
             self.browser = webdriver.Remote(command_executor=seleniumEndpoint, options=options)
         else:
             self.browser = TestHelpers.get_headless_browser()
+            self.browser.set_window_size(1280, 1024)
 
         self.browser.implicitly_wait(10)
         self._screenshotCount = 0
@@ -254,7 +255,7 @@ class LiveServerTestBaseClass(StaticLiveServerTestCase):
 
     def _debug_screenshot(self):
         """ Saves a screenshot in the current directory for debugging """
-        # First, ensure we're not on Travis. This is only for local debugging.
+        # First, ensure we're not connected to SauceLabs: this is only for local debugging.
         assert not self.isUsingSauceLabs
 
         # Save a screenshot


### PR DESCRIPTION
This test depended on the device scale and browser size, which weren't hardcoded and could vary across machines, even on CI. By locking down both, we get more consistent test behavior.