### PR TITLE
update RCVformats to allow it to catch manual data entry issues

### DIFF
--- a/infra/requirements-core.txt
+++ b/infra/requirements-core.txt
@@ -9,7 +9,7 @@ django-social-share==2.3.0
 django-sortedm2m==3.1.1
 django-storages==1.13.2
 Django==4.2.20
-rcvformats==0.0.42
+rcvformats==0.0.46
 selenium==4.25.0
 psycopg2-binary==2.9.10
 pytz==2023.3

--- a/visualizer/tests/testDataTables.py
+++ b/visualizer/tests/testDataTables.py
@@ -177,9 +177,8 @@ class DataTablesTests(TestCase):
             data['data'][0][1]['# Votes'] = 1
         formOutput = self._get_simplified_post_data_with_modifier(modifier)
 
-        self._ajax_starts_with(formOutput, 'Error #10: Data is not valid: '
-                               + 'Round 3 has 1200.0 votes, which is more than the previous round, '
-                               + 'which only has 826.0. This should not be possible.')
+        self._ajax_starts_with(formOutput, 'Error #10: Data is not valid: Vote counts should '
+                               + 'never decrease')
 
     def test_invalid_votes(self):
         """


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/395f42f4-5dd2-4cb9-899c-de74ca4f4ac3)

Previously, only the frontend validated vote count decreasing. If this data reached the backend validation, it would give the confusing message, "could not add transfers."

While it's hard to get this data to the backend currently, it is possible. In #531 , it will become the default check. All other checks like this happen in RCVformats, so this should too.

This pulls in the change from https://github.com/artoonie/rcvformats/pull/50