### PR TITLE
Update player to use dropdown

### DIFF
--- a/electionpage/tests.py
+++ b/electionpage/tests.py
@@ -121,7 +121,7 @@ class ElectionPageTests(liveServerTestBaseClass.LiveServerTestBaseClass):
 
         # And the height was correctly set via PostMessages
         self._ensure_eventually_asserts(lambda: self.assertEqual(bargraphIframeWrapper.find_element(
-            By.TAG_NAME, 'iframe').get_attribute('height'), '427px'))
+            By.TAG_NAME, 'iframe').get_attribute('height'), '734px'))
 
     @Mocker()
     def test_scrape_all(self, requestMock):

--- a/electionpage/tests.py
+++ b/electionpage/tests.py
@@ -121,7 +121,7 @@ class ElectionPageTests(liveServerTestBaseClass.LiveServerTestBaseClass):
 
         # And the height was correctly set via PostMessages
         self._ensure_eventually_asserts(lambda: self.assertEqual(bargraphIframeWrapper.find_element(
-            By.TAG_NAME, 'iframe').get_attribute('height'), '734px'))
+            By.TAG_NAME, 'iframe').get_attribute('height'), '695px'))
 
     @Mocker()
     def test_scrape_all(self, requestMock):

--- a/static/bargraph/style.css
+++ b/static/bargraph/style.css
@@ -31,7 +31,6 @@ path.domain {
   font-size: 0.6rem;
 }
 
-.round-description-header,
 .faq-description-header {
   font-size: 1.125rem;
   font-weight: bold;
@@ -46,10 +45,6 @@ path.domain {
   width: 100%;
   margin-left: auto;
   margin-right: auto;
-}
-
-.round-description-header {
-  padding: 5px 10px 0px 10px;
 }
 
 .round-description-wrapper {

--- a/static/bargraph/style.css
+++ b/static/bargraph/style.css
@@ -30,24 +30,53 @@ path.domain {
 .secondaryDataLabel {
   font-size: 0.6rem;
 }
+
+.round-description-header,
+.faq-description-header {
+  font-size: 1.125rem;
+  font-weight: bold;
+  margin-bottom: 0;
+  margin-top: 12px;
+  padding-left: 0;
+}
+
+.round-description-container {
+  box-shadow: 1px 5px 20px 0 #dedede;
+  max-width: 750px;
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.round-description-header {
+  padding: 5px 10px 0px 10px;
+}
+
 .round-description-wrapper {
   padding: 5px 10px 0px 10px;
-  box-shadow: 1px 5px 20px 0 #dedede;
-  border-radius: 10px;
   height: 65px;  /* Note: sync with hideFaqs() */
   font-size: 0.9em;
-  background-color: #fafdff;
   margin-left: auto;
   margin-right: auto;
   margin-top: 15px;
   display: none; /* Disable for now */
   overflow-y: auto;
-  max-width: 750px;
+  width: 100%;
 }
 .round-description-text {
   line-height: normal;
   vertical-align: middle;
   display: inline-block;
+}
+
+#faq-text {
+  width: 100%;
+  max-width: 750px;
+  padding: 5px 10px 0px 10px;
+  box-shadow: 1px 5px 20px 0 #dedede;
+  margin-bottom: 12px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .faq-q {
@@ -79,9 +108,6 @@ path.domain {
   font-weight: bold;
 }
 
-#faq-text {
-  display: none;
-}
 .prev-next-button {
   color: white;
 }

--- a/static/visualizer/round-player.css
+++ b/static/visualizer/round-player.css
@@ -20,11 +20,43 @@
   max-width: 750px;
 }
 
-.round-player-container select {
-  text-align: center;
-  padding: 4px 8px;
+.round-player-select-wrapper {
+  position: relative;
 }
 
+.round-player-select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+
+  width: 100%;
+  background-color: #fff;
+  border: 2px solid #4747ff;
+  border-radius: 4px;
+  padding: 4px 8px;
+  padding-right: 32px;
+  cursor: pointer;
+  text-align: center;
+}
+
+.round-player-select-wrapper::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: 12px;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-top: 6px solid #4747ff;
+  transform: translateY(-50%);
+  transition: transform 0.2s ease;
+}
+
+.round-player-select::-ms-expand {
+  display: none;
+}
 
 .round-player-play-btn {
   background-color: #4747ff;

--- a/static/visualizer/round-player.css
+++ b/static/visualizer/round-player.css
@@ -30,8 +30,8 @@
   background-color: #4747ff;
   color: #fff;
   padding: 2px 10px;
-  font-size: 16px;
-  width: 240px;
+  font-size: 1rem;
+  min-width: 160px;
 }
 
 .round-player-play-btn:hover {
@@ -44,7 +44,7 @@
   align-items: center;
   flex-direction: row;
   color: #4747ff;
-  font-size: 16px;
+  font-size: 1rem;
   padding: 4px 8px;
 }
 

--- a/static/visualizer/round-player.css
+++ b/static/visualizer/round-player.css
@@ -16,81 +16,71 @@
 
 .round-player-wrapper {
   width: 100%;
-  justify-content: space-between;
+  justify-content: center;
   max-width: 750px;
 }
 
-.round-steps-wrapper {
-  flex-wrap: wrap;
+.round-player-container select {
+  text-align: center;
+  padding: 4px 8px;
 }
 
-.round-player-step-btn {
-  border-color: #636161;
-  border-width: 1px;
-  color: #636161;
-  margin: 8px;
-  font-size: 16px;
-  min-width: 32px;
-  padding: 0 4px;
-  flex: 0 1 auto;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-sizing: border-box;
-}
-
-.round-player-step-btn.round-player-active {
-  font-weight: bold;
-  border-width: 3px;
-}
 
 .round-player-play-btn {
-  background-color: #1922da;
-  font-weight: bold;
+  background-color: #4747ff;
   color: #fff;
   padding: 2px 10px;
   font-size: 16px;
+  width: 240px;
 }
 
-@media screen and (min-width: 750px) {
-  .round-player-play-btn {
-    min-width: 160px;
-    width: 160px;
-  }
+.round-player-play-btn:hover {
+  color: #fff;
+  background-color: #4747c2;
 }
 
-.range-player-nav {
+.round-player-nav {
   display: flex;
   align-items: center;
   flex-direction: row;
-  justify-content: space-between;
-  font-weight: bold;
-  color: #1922da;
+  color: #4747ff;
   font-size: 16px;
   padding: 4px 8px;
-  min-width: 132px;
 }
 
-.range-player-nav.range-player-prev,
-.range-player-nav.range-player-prev svg {
-  margin-right: 8px;
+.round-player-nav.round-player-prev,
+.round-player-nav.round-player-prev svg {
+  margin-right: 4px;
   flex-direction: row-reverse;
 }
 
-.range-player-nav.range-player-next,
-.range-player-nav.range-player-next svg {
-  margin-left: 8px;
+.round-player-nav.round-player-next,
+.round-player-nav.round-player-next svg {
+  margin-left: 4px;
 }
 
-.range-player-nav svg {
+.round-player-nav-label {
+  display: none;
+}
+
+@media screen and (min-width: 750px) {
+  .round-player-nav {
+    min-width: 80px;
+  }
+  .round-player-nav-label {
+    display: inline-block;
+  }
+}
+
+.round-player-nav svg {
   scale: 50%;
   width: 24px;
 }
 
-.range-player-nav.range-player-prev svg {
+.round-player-nav.round-player-prev svg {
   transform: rotate(180deg);
 }
 
-.range-player-hidden {
+.round-player-hidden {
   visibility: hidden;
 }

--- a/static/visualizer/round-player.js
+++ b/static/visualizer/round-player.js
@@ -149,7 +149,6 @@ function RoundPlayer({
     window.clearTimeout(timer);
     container.querySelector(".round-player-play-btn").innerText =
       "Play round animation";
-    changeStep(currentStep);
   }
 
   function playing() {

--- a/static/visualizer/round-player.js
+++ b/static/visualizer/round-player.js
@@ -73,7 +73,7 @@ function RoundPlayer({
   function createPlayButton() {
     const playBtn = document.createElement("button");
     playBtn.classList.add("btn", "round-player-play-btn");
-    playBtn.innerText = "Play round animation";
+    playBtn.innerText = "Play animation";
     playBtn.addEventListener("click", () => {
       isPlaying ? stop() : play();
     });
@@ -148,7 +148,7 @@ function RoundPlayer({
     isPlaying = false;
     window.clearTimeout(timer);
     container.querySelector(".round-player-play-btn").innerText =
-      "Play round animation";
+      "Play animation";
   }
 
   function playing() {

--- a/static/visualizer/round-player.js
+++ b/static/visualizer/round-player.js
@@ -52,6 +52,9 @@ function RoundPlayer({
   }
 
   function createDropdown() {
+    const selectWrapper = document.createElement("div");
+    selectWrapper.classList.add("round-player-select-wrapper");
+
     const select = document.createElement("select");
     select.classList.add("round-player-select");
     for (let round = 0; round < totalRounds; ++round) {
@@ -67,7 +70,9 @@ function RoundPlayer({
     select.addEventListener("change", (e) => {
       setStep(+e.target.value);
     });
-    return select;
+
+    selectWrapper.appendChild(select);
+    return selectWrapper;
   }
 
   function createPlayButton() {

--- a/templates/bargraph/barchart-interactive-nonblocking.html
+++ b/templates/bargraph/barchart-interactive-nonblocking.html
@@ -65,34 +65,11 @@ function updateFaqText(round) {
               .map(d => "<p class='faq-q'>" + d['question'] + "</p>" +
                         "<p class='faq-a'>" + d['answer'] + "</p>")
               .reduce((accum, val) => accum + val);
-  document.getElementById(idOfFaqTextDiv).innerHTML = text;
+  document.getElementById(idOfFaqTextDiv).innerHTML = `<h3 class="faq-description-header">Round ${round + 1} Explanation</h3> ${text}`;
 }
 
 function showFaqs() {
-  const idRoundDescriptionText = "#round-description-wrapper";
-  d3.select(idRoundDescriptionText)
-    .style("height", "100%");
-
-  const idOfFaqTextDiv = "faq-text";
-  document.getElementById(idOfFaqTextDiv).style.display = "block"
-}
-
-function hideFaqs() {
-  if (barchartRoundPlayer.playing()) {
-    return;
-  }
-
-  const idRoundDescriptionText = "#round-description-wrapper";
-  const currHeight = d3.select(idRoundDescriptionText).node().offsetHeight;
-  d3.select(idRoundDescriptionText)
-    .style("height", currHeight + "px") // convert 100% to its actual height
-    .transition()
-      .delay(30)
-      .duration(600)
-      .style("height", "65px");  // Note: sync with bargraph/style.css
-
-  const idOfFaqTextDiv = "faq-text";
-  document.getElementById(idOfFaqTextDiv).style.display = "none"
+  document.getElementById("faq-text").scrollIntoView({ behavior: "smooth" })
 }
 
 function makeInteractiveGraph() {
@@ -124,7 +101,6 @@ function makeInteractiveGraph() {
   });
 
   function sliderValueChangedCallback(round) {
-    hideFaqs();
     transitionEachBarForRound(round);
     showTextOnRoundDescriber(descriptionOfCurrRound(round), false);
     updateFaqText(round);
@@ -142,6 +118,9 @@ function makeInteractiveGraph() {
   // After creating the slider, make the default text the summary
   // round summary, with the FAQ button showing.
   showTextOnRoundDescriber(humanFriendlySummary, false);
+
+  // Populate the FAQ with initial description for the last round
+  updateFaqText(numRounds - 1);
 }
 
 function showFaqButton() {

--- a/templates/bargraph/barchart-interactive.html
+++ b/templates/bargraph/barchart-interactive.html
@@ -7,19 +7,22 @@
 
 <div class="container-fluid">
   <div class="row d-flex flex-column justify-content-left align-items-start">
+    <div class="round-description-container">
+      <h2 class="round-description-header">Summary of Results</h2>
+      <div id="round-description-wrapper" class="round-description-wrapper" role="alert">
+        <div class="round-description-text">
+          <span id="bargraph-interactive-round-description">
+          </span>
+          <span id="bargraph-interactive-why-button">
+            <a role="button" tabindex="0" onclick="showFaqs()">Read the FAQs</a>.
+          </span>
+        </div>
+      </div>
+    </div>
     <div class="shadow-wrapper col-md-12 col-xl-10" id="bargraph-interactive-body">
       <div id="bargraph-slider-container" class="ml-auto mr-auto">
       </div>
     </div>
-    <div id="round-description-wrapper" class="round-description-wrapper" role="alert">
-      <div class="round-description-text">
-        <span id="bargraph-interactive-round-description">
-        </span>
-        <span id="bargraph-interactive-why-button">
-          <a role="button" tabindex="0" onclick="showFaqs()">Read the FAQs</a>.
-        </span>
-        <div id="faq-text"></div>
-      </div>
-    </div>
+    <div id="faq-text"></div>
   </div>
 </div>

--- a/templates/bargraph/barchart-interactive.html
+++ b/templates/bargraph/barchart-interactive.html
@@ -8,13 +8,12 @@
 <div class="container-fluid">
   <div class="row d-flex flex-column justify-content-left align-items-start">
     <div class="round-description-container">
-      <h2 class="round-description-header">Summary of Results</h2>
       <div id="round-description-wrapper" class="round-description-wrapper" role="alert">
         <div class="round-description-text">
           <span id="bargraph-interactive-round-description">
           </span>
           <span id="bargraph-interactive-why-button">
-            <a role="button" tabindex="0" onclick="showFaqs()">Read the FAQs</a>.
+            <a role="button" tabindex="0" onclick="showFaqs()">Read a detailed explanation</a>.
           </span>
         </div>
       </div>

--- a/visualizer/tests/liveServerTestBaseClass.py
+++ b/visualizer/tests/liveServerTestBaseClass.py
@@ -12,6 +12,7 @@ from django.urls import reverse
 from selenium import webdriver
 from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import Select
 
 from common.testUtils import TestHelpers
 from common.viewUtils import get_script_to_disable_animations
@@ -261,7 +262,9 @@ class LiveServerTestBaseClass(StaticLiveServerTestCase):
         """
         # Cancel animation by clicking on round_i'th element element
         container = self.browser.find_element(By.ID, 'bargraph-slider-container')
-        container.find_elements(By.CLASS_NAME, 'round-player-step-btn')[round_i].click()
+        selectEl = container.find_element(By.CSS_SELECTOR, ".round-player-select")
+        select = Select(selectEl)
+        select.select_by_value(str(round_i))
 
     def _set_input_to(self, inputId, value):
         """

--- a/visualizer/tests/testLiveBrowserHeadless.py
+++ b/visualizer/tests/testLiveBrowserHeadless.py
@@ -381,8 +381,7 @@ class LiveBrowserHeadlessTests(liveServerTestBaseClass.LiveServerTestBaseClass):
             lambda: self.assertIn('Ranked Choice Voting election', desc.text))
 
         # Now move the player
-        self.browser.find_element(
-            By.CSS_SELECTOR, '#bargraph-slider-container [data-round="0"]').click()
+        self._go_to_round_by_clicking(0)
 
         # Check that the text updates now
         self._ensure_eventually_asserts(

--- a/visualizer/tests/testLiveBrowserHeadless.py
+++ b/visualizer/tests/testLiveBrowserHeadless.py
@@ -80,8 +80,7 @@ class LiveBrowserHeadlessTests(liveServerTestBaseClass.LiveServerTestBaseClass):
         """ Ensure eliminated color setting can be changed """
         def _get_eliminated_color():
             # Move the slider to stop animation
-            self.browser.find_element(
-                By.CSS_SELECTOR, '#bargraph-slider-container [data-round="3"]').click()
+            self._go_to_round_by_clicking(3)
 
             # Get an eliminated bar by its text
             bargraph = self.browser.find_element(By.ID, 'bargraph-interactive-body')

--- a/visualizer/tests/testLiveBrowserWithHead.py
+++ b/visualizer/tests/testLiveBrowserWithHead.py
@@ -217,7 +217,7 @@ class LiveBrowserWithHeadTests(liveServerTestBaseClass.LiveServerTestBaseClass):
         self.assertEqual(elemsInOrder[3].get_attribute('innerHTML'), "Somebody")
 
     def test_faq(self):
-        """ Test the FAQ button works """
+        """ Test the FAQ section works """
         self._upload(filenames.MULTIWINNER)
 
         # Move the slider and complete all other animations
@@ -230,18 +230,8 @@ class LiveBrowserWithHeadTests(liveServerTestBaseClass.LiveServerTestBaseClass):
         div = self.browser.find_element(By.ID, 'round-description-wrapper')
         self._ensure_eventually_asserts(lambda: self.assertEqual(div.size['height'], 65))
 
-        # Expands to fit the FAQs
-        hackyXpathForWhyButton = '//*[@id="bargraph-interactive-why-button"]/a[1]'
-        whyButton = self.browser.find_element(By.XPATH, hackyXpathForWhyButton)
-        self._ensure_eventually_asserts(lambda: self.assertTrue(self._is_elem_visible(whyButton)))
-        whyButton.click()
-        self._ensure_eventually_asserts(lambda: self.assertGreater(div.size['height'], 65))
-
-        # Move the slider again
-        self._go_to_round_by_clicking(1)
-
-        # Restores size on new round
-        self._ensure_eventually_asserts(lambda: self.assertEqual(div.size['height'], 65))
+        faqHeader = self.browser.find_element(By.CSS_SELECTOR, '.faq-description-header')
+        self.assertEqual(faqHeader.get_attribute('innerHTML'), 'Round 4 Explanation')
 
     def test_embedded_scrollbars(self):
         """


### PR DESCRIPTION
### Description

Includes the updates from feedback that simplify the round player and move around the text.

- Changes round player to use dropdown
- Pulls out the round description and FAQ boxes, matches their styles to the bar chart box now that they're split
- Updated navigation styles
- Fixed some class-naming issues that were inconsistent between "range" and "round"

### Notes

- UI changes are easy here! I had to make some guesses from the quick mockups we did
- We can style the select box, but I didn't have strong thoughts there so I left it as-is

### Recording

https://github.com/user-attachments/assets/e7a0ab63-7230-4640-959e-87ae51a79c52