### PR TITLE
Add trail of lighter colors in table for winners, eliminated

### DIFF
--- a/templates/tabular/tabular-candidate-by-round.html
+++ b/templates/tabular/tabular-candidate-by-round.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load tableHelpers %}
 <link rel="stylesheet" type="text/css" href="{% static 'tabular/style.css' %}">
 
 <div class="shadow-wrapper responsive-table-wrapper" id="single-table-summary-wrapper">
@@ -18,18 +19,13 @@
         <tr>
             <th scope="row">{{ candidateTabulation.name }}</th>
             {% for round in candidateTabulation.eachRound %}
-                {% if not round %}
-                 <td style="background-color: #FFBFBF"></td>
-                 {% else %}
-                 <td
-                     {% if round.isWinner %}
-                     style="background-color: #BFFFCC"
-                     {% endif %}
-                 >
+                {% get_round_background_color candidateTabulation.name round as roundBg %}
+                 <td style="background-color: {{ roundBg }}">
+                    {% if round %}
                       <h3 class="primaryLabel">{{ round.primaryLabel }}</h3>
                                               {{ round.secondaryLabel }}
+                    {% endif %}
                  </td>
-                 {% endif %}
             {% endfor %}
         </tr>
         {% endfor %}

--- a/visualizer/templatetags/tableHelpers.py
+++ b/visualizer/templatetags/tableHelpers.py
@@ -1,0 +1,27 @@
+"""Module for helpers related to table rendering"""
+from django import template
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def get_round_background_color(context, candidateName, round_item):
+    """Track candidate status through iterations and return cell background color"""
+    candidateKey = f"round_state_{candidateName}"
+    if candidateKey not in context:
+        context[candidateKey] = {
+            "wasWinner": False,
+            "wasEliminated": False,
+        }
+    if round_item is None and not context[candidateKey]["wasEliminated"]:
+        context[candidateKey]["wasEliminated"] = True
+        return "#FFBFBF"
+    if context[candidateKey]["wasEliminated"]:
+        return "pink"
+    if round_item and round_item.isWinner:
+        context[candidateKey]["wasWinner"] = True
+        return "#BFFFCC"
+    if context[candidateKey]["wasWinner"]:
+        return "limegreen"
+
+    return "rgba(0,0,0,0)"

--- a/visualizer/templatetags/tableHelpers.py
+++ b/visualizer/templatetags/tableHelpers.py
@@ -22,6 +22,6 @@ def get_round_background_color(context, candidateName, round_item):
         context[candidateKey]["wasWinner"] = True
         return "#A0FFB5"
     if context[candidateKey]["wasWinner"]:
-        return "#BFFFCC"
+        return "#DCFFE1"
 
     return "rgba(0,0,0,0)"

--- a/visualizer/templatetags/tableHelpers.py
+++ b/visualizer/templatetags/tableHelpers.py
@@ -15,13 +15,13 @@ def get_round_background_color(context, candidateName, round_item):
         }
     if round_item is None and not context[candidateKey]["wasEliminated"]:
         context[candidateKey]["wasEliminated"] = True
-        return "#FFBFBF"
+        return "#FFBEBE"
     if context[candidateKey]["wasEliminated"]:
-        return "pink"
+        return "#FAD7D7"
     if round_item and round_item.isWinner:
         context[candidateKey]["wasWinner"] = True
-        return "#BFFFCC"
+        return "#A0FFB5"
     if context[candidateKey]["wasWinner"]:
-        return "limegreen"
+        return "#BFFFCC"
 
     return "rgba(0,0,0,0)"


### PR DESCRIPTION
### Description

Sets the colors of table cells after a candidate has either won or been eliminated to lighter colors so that it's easier for users to follow when they've scrolled over to the right. This implements the existing mockups so it should be relatively straightforward.

This isn't a high priority, but wanted to include it here because it was on the list of issues, quick, and doesn't overlap with the other work in progress. We can definitely hold off on any review for now to

### Screenshot

![table-trailing-colors](https://github.com/user-attachments/assets/fcc742f2-cc02-44e6-9020-47c193f2245d)
