### PR TITLE
Feat/animate start button scrollbar fix

### DIFF
--- a/electionpage/tests.py
+++ b/electionpage/tests.py
@@ -121,7 +121,7 @@ class ElectionPageTests(liveServerTestBaseClass.LiveServerTestBaseClass):
 
         # And the height was correctly set via PostMessages
         self._ensure_eventually_asserts(lambda: self.assertEqual(bargraphIframeWrapper.find_element(
-            By.TAG_NAME, 'iframe').get_attribute('height'), '695px'))
+            By.TAG_NAME, 'iframe').get_attribute('height'), '397px'))
 
     @Mocker()
     def test_scrape_all(self, requestMock):

--- a/static/bargraph/style.css
+++ b/static/bargraph/style.css
@@ -72,6 +72,7 @@ path.domain {
   margin-bottom: 12px;
   margin-left: auto;
   margin-right: auto;
+  display: none;
 }
 
 .faq-q {

--- a/templates/bargraph/barchart-interactive-nonblocking.html
+++ b/templates/bargraph/barchart-interactive-nonblocking.html
@@ -85,7 +85,12 @@ function updateFaqText(round) {
 }
 
 function showFaqs() {
+  makeFaqSectionVisible();
   document.getElementById("faq-text").scrollIntoView({ behavior: "smooth" })
+}
+
+function makeFaqSectionVisible() {
+  document.getElementById("faq-text").style.display = "block";
 }
 
 function makeInteractiveGraph() {
@@ -134,6 +139,11 @@ function makeInteractiveGraph() {
   // After creating the slider, make the default text the summary
   // round summary, with the FAQ button showing.
   showTextOnRoundDescriber(humanFriendlySummary, false);
+
+  // On load, show the FAQs if not in an iframe
+  if (window.self === window.top) {
+    makeFaqSectionVisible();
+  }
 
   // Populate the FAQ with initial description for the last round
   updateFaqText(numRounds - 1);

--- a/templates/bargraph/barchart-interactive-nonblocking.html
+++ b/templates/bargraph/barchart-interactive-nonblocking.html
@@ -5,6 +5,7 @@
 const idOfWhyButton = "#bargraph-interactive-why-button";
 // Raising the scope for other methods to access
 let barchartRoundPlayer = null;
+let scrollbarLocked = false;
 
 function showTextOnRoundDescriber(description, keepFAQButtonHidden) {
   // While playing, don't update the description text for the round
@@ -58,6 +59,20 @@ function descriptionOfCurrRound(round) {
   return roundIdentifier + roundText;
 }
 
+
+function lockScrollbarIfNeeded() {
+  // Don't allow the animation to shift horizontally when a scrollbar is added
+  // and removed -- if a scrollbar is ever visible, keep it there.
+  if (scrollbarLocked) return;
+
+  const hasVerticalScrollbar = document.documentElement.scrollHeight > window.innerHeight;
+
+  if (hasVerticalScrollbar) {
+    document.body.style.overflowY = 'scroll';
+    scrollbarLocked = true;
+  }
+}
+
 function updateFaqText(round) {
   const faqsPerRound = {{ faqsPerRound|safe }};
   const idOfFaqTextDiv = "faq-text";
@@ -66,6 +81,7 @@ function updateFaqText(round) {
                         "<p class='faq-a'>" + d['answer'] + "</p>")
               .reduce((accum, val) => accum + val);
   document.getElementById(idOfFaqTextDiv).innerHTML = `<h3 class="faq-description-header">Round ${round + 1} Explanation</h3> ${text}`;
+  setTimeout(lockScrollbarIfNeeded, 0); // Needs to run after the DOM is updated
 }
 
 function showFaqs() {

--- a/visualizer/tests/testLiveBrowserHeadless.py
+++ b/visualizer/tests/testLiveBrowserHeadless.py
@@ -635,3 +635,32 @@ class LiveBrowserHeadlessTests(liveServerTestBaseClass.LiveServerTestBaseClass):
             candidateLabels[0].get_attribute("style"),
             "font-weight: bold;",
             "Winner name SHOULD BE bold."))
+
+    def test_faq_visibility_wrt_iframes(self):
+        """ FAQ visibility with respect to iframes: visibility = not in iframe """
+        self._upload_something_if_needed()
+
+        # Ensure that the FAQs are visible outside an iframe
+        faq = self.browser.find_element(By.ID, 'faq-text')
+        self.assertEqual(faq.value_of_css_property("display"), "block")
+
+        # Get the iframe HTML
+        self._go_to_tab("share-tab")
+        htmlTextarea = self.browser.find_element(By.ID, 'htmlembedexport')
+        iframeHtml = htmlTextarea.get_attribute("value")
+
+        # Render that HTML in a separate page
+        self.browser.get("data:text/html,<html><head></head><body></body></html>")
+        self.browser.execute_script("document.body.innerHTML = arguments[0];", iframeHtml)
+
+        # Get the iframe's body by going into the iframe in the source
+        iframe = self.browser.find_element(By.TAG_NAME, 'iframe')
+        self.browser.switch_to.frame(iframe)
+
+        # Check that the FAQs are hidden
+        faq = self.browser.find_element(By.ID, 'faq-text')
+        self.assertEqual(faq.value_of_css_property("display"), "none")
+
+        # After clicking "Read a detailed explanation" it becomes visible
+        self.browser.find_element(By.LINK_TEXT, "Read a detailed explanation").click()
+        self.assertEqual(faq.value_of_css_property("display"), "block")


### PR DESCRIPTION
This PR fixes two issues:
1. [nit] lock the scrollbar in place to avoid horizontal "bouncing" during animation:
https://github.com/user-attachments/assets/5562e569-58e3-436c-8353-3fdf38301342

2. The FAQs are too verbose for embeds. See [this for an example](https://fairvote.org/preliminary-results-in-alaskas-rcv-elections-november-2022/) -- FAQs aren't appropriate on that page. Hide them whenever embedded.