### PR TITLE
Condense FAQ round display

### DIFF
--- a/visualizer/descriptors/roundDescriber.py
+++ b/visualizer/descriptors/roundDescriber.py
@@ -86,10 +86,13 @@ class Describer:
           {summary: "Baz ate", verb: "ate", description: "Baz at chips"} ]
         listOfNames can be empty, in which case an empty list is returned.
         """
-        return [{'summary': name + verb,
-                 'description': whatHappenedToThemDescription.format(name=name),
-                 'verb': verb}
-                for name in listOfNames]
+        return [{
+            'summary': common.text_to_describe_list_of_names(
+                listOfNames, "{name} " + verb),
+            'description': common.text_to_describe_list_of_names(
+                listOfNames, whatHappenedToThemDescription),
+            'verb': verb
+        }]
 
     def _describe_list_of_names(self, listOfNames, verb, whatHappenedToThemDescription):
         """
@@ -115,7 +118,8 @@ class Describer:
             Returns empty string if nobody was eliminated."""
         rounds = self.graph.summarize().rounds
         eliminated = rounds[roundNum].eliminatedNames
-        whatHappened = "{name} had the fewest votes and was eliminated. "
+        wasWere = "was" if len(eliminated) == 0 else "were"
+        whatHappened = "{name} had the fewest votes and " + wasWere + " eliminated."
         return self._describe_list_of_names(eliminated, " eliminated", whatHappened)
 
     def _describe_transfers_this_round(self, roundNum):
@@ -149,10 +153,7 @@ class Describer:
         winnerNames = rounds[roundNum].winnerNames
         winnerItems = rounds[roundNum].winnerItems
 
-        # Note: each event shows just one winner. If there are multiple winners,
-        # there will be multiple sentences in the main vis. (Not true in the video...)
-        # So, set numWinners to 1, not len(winners)
-        event = textForWinnerUtils.as_event(self.config, 1)
+        event = textForWinnerUtils.as_event(self.config, len(winnerNames))
 
         if self.graph.threshold is not None:
             # Did all candidates pass the threshold?

--- a/visualizer/tests/testFaq.py
+++ b/visualizer/tests/testFaq.py
@@ -3,6 +3,7 @@ Testing the FAQ Generator
 """
 
 import json
+from collections import Counter
 
 from django.test import TestCase
 from mock import Mock
@@ -274,3 +275,12 @@ class FAQTests(TestCase):
         desc = allRoundsDesc[-1][-1]
         self.assertIn("is among the top vote-getters", desc['description'])
         self.assertNotIn("reached the threshold", desc['description'])
+
+    def test_describer_consolidates_events(self):
+        """Describer should always consolidate events, no more than 1 record per verb"""
+        with open(filenames.RESIDUAL_SURPLUS_MAIN, 'r', encoding='utf-8') as f:
+            graph = make_graph_with_file(f, False)
+        allRounds = Describer(graph, self.config, False).describe_all_rounds()
+        for round in allRounds:
+            verbCounter = Counter([r['verb'] for r in round])
+            self.assertTrue([verb <= 1 for verb in verbCounter.values()])


### PR DESCRIPTION
## Description

Consolidates the round description display that plays above the chart to group each event by category so that there's only one event for all candidates eliminated, winning, or other activity.

I found the places where I noticed this was used, but let me know if there are other spots I'm missing

## Screenshot

![faq-consolidation-screenshot](https://github.com/user-attachments/assets/764d6fd9-bc41-41c5-a8de-edcdb04ac4a7)
