### PR TITLE
Set select font color on iOS

### DIFF
--- a/static/visualizer/round-player.css
+++ b/static/visualizer/round-player.css
@@ -32,6 +32,7 @@
   width: 100%;
   background-color: #fff;
   border: 2px solid #4747ff;
+  color: #002c59;
   border-radius: 4px;
   padding: 4px 8px;
   padding-right: 32px;


### PR DESCRIPTION
iOS browsers default select inputs to having a blue font color. This is a small tweak to override that behavior so that it matches the rest of the text.

## Screenshot

Taken on an iPhone viewing a locally hosted server

![IMG_0038](https://github.com/user-attachments/assets/8b84d592-d4e2-497d-af71-386176ed817d)
