### PR TITLE
switch from sendgrid to generic smtp host

### DIFF
--- a/app.json
+++ b/app.json
@@ -56,12 +56,20 @@
       "required": false
     },
 
-    "SENDGRID_USERNAME": {
-      "description": "sendgrid username - required in prod to send user registration emails",
+    "SMTP_HOST": {
+      "description": "smtp host - required in prod to send user registration emails",
       "required": false
     },
-    "SENDGRID_PASSWORD": {
-      "description": "sendgrid password - required in prod to send user registration emails",
+    "SMTP_PORT": {
+      "description": "smtp port - required in prod to send user registration emails",
+      "required": false
+    },
+    "SMTP_USERNAME": {
+      "description": "smtp username - required in prod to send user registration emails",
+      "required": false
+    },
+    "SMTP_PASSWORD": {
+      "description": "smtp password - required in prod to send user registration emails",
       "required": false
     }
   },

--- a/infra/.env.template
+++ b/infra/.env.template
@@ -26,8 +26,10 @@ export OFFLINE_ADMIN='name@domain.com'
 # export AWS_SECRET_ACCESS_KEY=''
 
 # To send registration emails when OFFLINE_MODE is False:
-# export SENDGRID_USERNAME=''
-# export SENDGRID_PASSWORD=''
+# export SMTP_HOST='smtp.mailgun.org'
+# export SMTP_PORT=587
+# export SMTP_USERNAME=''
+# export SMTP_PASSWORD=''
 
 # To clear cloudflare cache when models update:
 # export CLOUDFLARE_ZONE_ID=''

--- a/rcvis/settings.py
+++ b/rcvis/settings.py
@@ -133,10 +133,10 @@ if OFFLINE_MODE:
     EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 else:
     EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-    EMAIL_HOST = 'smtp.sendgrid.net'
-    EMAIL_HOST_USER = os.environ.get('SENDGRID_USERNAME')
-    EMAIL_HOST_PASSWORD = os.environ.get('SENDGRID_PASSWORD')
-    EMAIL_PORT = 587
+    EMAIL_HOST = os.environ.get('SMTP_HOST')
+    EMAIL_HOST_USER = os.environ.get('SMTP_USERNAME')
+    EMAIL_HOST_PASSWORD = os.environ.get('SMTP_PASSWORD')
+    EMAIL_PORT = os.environ.get('SMTP_PORT')
     EMAIL_USE_TLS = True
     DEFAULT_FROM_EMAIL = 'team@rcvis.com'
 


### PR DESCRIPTION
sendgrid now charges for all plans. change to mailgun, and make it easier to switch smtp providers without code updates -- environment variables only.