### PR TITLE
sankey percentage should be based on current round

### DIFF
--- a/static/sankey/sankey-wrapper.js
+++ b/static/sankey/sankey-wrapper.js
@@ -75,7 +75,7 @@ function makeSankey(graph, numRounds, numCandidates, numWinners, longestLabelApx
       return textForNode(d)
   }
   function getNodePercentText(d) {
-      const percentDenominator = calculatePercentDenominator(numWinners, totalVotesPerRound[0], totalVotesPerRound[d.round])
+      const percentDenominator = calculatePercentDenominator(numWinners, totalVotesPerRound[d.round], totalVotesPerRound[d.round])
       return percentToText(d.name, d.value, percentDenominator)
   }
 


### PR DESCRIPTION
Previously this was not how it worked because it seemed confusing to not gain votes but increase in percentage. However, that is now at odds with the percentages shown in the other visualizations, so let's make percentages consistent across all visualizations.

Before:
<img width="1384" height="1328" alt="image" src="https://github.com/user-attachments/assets/9c0fc080-10b7-4d3f-9397-75107daeaeb4" />


After:
<img width="1376" height="1326" alt="image" src="https://github.com/user-attachments/assets/f2c97815-f55f-443c-8180-4eba7458f9fa" />
