### PR TITLE
deprecate disable cache: no longer compatible with tests

### DIFF
--- a/infra/.env.template
+++ b/infra/.env.template
@@ -48,6 +48,3 @@ export SQS_QUEUE_NAME='default-queue'
 # export MAILCHIMP_API_KEY=''
 # export MAILCHIMP_LIST_ID=''
 # export MAILCHIMP_DC=''
-
-# If you are updating a template, you'll need to clear the cache every time or set:
-# export DISABLE_CACHE=True

--- a/rcvis/settings.py
+++ b/rcvis/settings.py
@@ -282,20 +282,12 @@ CLOUDFLARE_AUTH_TOKEN = os.environ.get('CLOUDFLARE_AUTH_TOKEN')
 
 AWS_DEFAULT_ACL = None
 
-if os.environ.get('DISABLE_CACHE') != 'True':
-    CACHES = {
-        'default': {
-            'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
-            'LOCATION': '/tmp/django_rcvis_cache/',
-        }
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+        'LOCATION': '/tmp/django_rcvis_cache/',
     }
-else:
-    assert DEBUG
-    CACHES = {
-        'default': {
-            'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
-        }
-    }
+}
 
 REST_FRAMEWORK = {
     # Use Django's standard `django.contrib.auth` permissions,


### PR DESCRIPTION
Disabling cache causes some tests which test caching to fail. Deprecate it: it doesn't help much of the time and is not worth maintaining for the little benefit it gives.