### PR TITLE
remove guess as to why some elections have only one round

### DIFF
--- a/visualizer/descriptors/roundDescriber.py
+++ b/visualizer/descriptors/roundDescriber.py
@@ -207,14 +207,8 @@ class Describer:
         numRounds = len(summary.rounds)
 
         if self.config.excludeFinalWinnerAndEliminatedCandidate:
-            if numRounds > 1:
-                # Preliminary results + 1 round
-                return "This ranked-choice voting election does not have any winners "\
-                    "because the results are still incomplete. Votes are still being counted."
-
-            # Preliminary results, first-round-only
-            return "The results of this ranked-choice voting election are still preliminary. "\
-                   "Only voters' first choices have been counted."
+            return "This ranked-choice voting election does not have any winners "\
+                "because the results are still incomplete. Votes are still being counted."
         if len(winners) == 0:
             return "This election does not have any winners, "\
                    "perhaps because the results are still preliminary. "


### PR DESCRIPTION
It is possible for a first-round majority winner to be uploaded to RCVis. These results may have gone through tabulation, leading to a first _round_ winner, not just a first _rank_ winner. Remove the assumption that 1-round results with "exclude final winner" checked is just a first-rank non-RCV upload.