### PR TITLE
Pie chart: surplus slivers close smoothly; residual surplus no longer a labeled candidate

### DIFF
--- a/static/pie/pie-chart.es.js
+++ b/static/pie/pie-chart.es.js
@@ -1,27 +1,27 @@
-var zl = Object.defineProperty;
-var la = (e) => {
+var Ul = Object.defineProperty;
+var ha = (e) => {
   throw TypeError(e);
 };
-var Hl = (e, t, n) => t in e ? zl(e, t, { enumerable: !0, configurable: !0, writable: !0, value: n }) : e[t] = n;
-var pe = (e, t, n) => Hl(e, typeof t != "symbol" ? t + "" : t, n), es = (e, t, n) => t.has(e) || la("Cannot " + n);
-var v = (e, t, n) => (es(e, t, "read from private field"), n ? n.call(e) : t.get(e)), z = (e, t, n) => t.has(e) ? la("Cannot add the same private member more than once") : t instanceof WeakSet ? t.add(e) : t.set(e, n), q = (e, t, n, r) => (es(e, t, "write to private field"), r ? r.call(e, n) : t.set(e, n), n), be = (e, t, n) => (es(e, t, "access private method"), n);
-var Ha;
-typeof window < "u" && ((Ha = window.__svelte ?? (window.__svelte = {})).v ?? (Ha.v = /* @__PURE__ */ new Set())).add("5");
-const Yl = 1, Bl = 2, Wa = 4, Xl = 8, Wl = 16, Ul = 1, Gl = 4, Kl = 8, jl = 16, Jl = 1, Zl = 2, Ns = "[", Di = "[!", ks = "]", cr = {}, Re = Symbol(), Ua = "http://www.w3.org/1999/xhtml", os = !1;
-var Ga = Array.isArray, Ql = Array.prototype.indexOf, hr = Array.prototype.includes, Oi = Array.from, xi = Object.keys, bi = Object.defineProperty, Hn = Object.getOwnPropertyDescriptor, eu = Object.getOwnPropertyDescriptors, tu = Object.prototype, nu = Array.prototype, Ka = Object.getPrototypeOf, ua = Object.isExtensible;
-const ru = () => {
+var Gl = (e, t, n) => t in e ? Ul(e, t, { enumerable: !0, configurable: !0, writable: !0, value: n }) : e[t] = n;
+var de = (e, t, n) => Gl(e, typeof t != "symbol" ? t + "" : t, n), ss = (e, t, n) => t.has(e) || ha("Cannot " + n);
+var g = (e, t, n) => (ss(e, t, "read from private field"), n ? n.call(e) : t.get(e)), H = (e, t, n) => t.has(e) ? ha("Cannot add the same private member more than once") : t instanceof WeakSet ? t.add(e) : t.set(e, n), L = (e, t, n, r) => (ss(e, t, "write to private field"), r ? r.call(e, n) : t.set(e, n), n), we = (e, t, n) => (ss(e, t, "access private method"), n);
+var Wa;
+typeof window < "u" && ((Wa = window.__svelte ?? (window.__svelte = {})).v ?? (Wa.v = /* @__PURE__ */ new Set())).add("5");
+const Kl = 1, jl = 2, ja = 4, Jl = 8, Zl = 16, Ql = 1, eu = 4, tu = 8, nu = 16, ru = 1, iu = 2, Os = "[", Li = "[!", Is = "]", pr = {}, Ae = Symbol(), Ja = "http://www.w3.org/1999/xhtml", hs = !1;
+var Za = Array.isArray, su = Array.prototype.indexOf, vr = Array.prototype.includes, qi = Array.from, Ai = Object.keys, Ei = Object.defineProperty, Bn = Object.getOwnPropertyDescriptor, au = Object.getOwnPropertyDescriptors, ou = Object.prototype, lu = Array.prototype, Qa = Object.getPrototypeOf, da = Object.isExtensible;
+const uu = () => {
 };
-function iu(e) {
+function fu(e) {
   for (var t = 0; t < e.length; t++)
     e[t]();
 }
-function ja() {
+function eo() {
   var e, t, n = new Promise((r, i) => {
     e = r, t = i;
   });
   return { promise: n, resolve: e, reject: t };
 }
-function su(e, t) {
+function cu(e, t) {
   if (Array.isArray(e))
     return e;
   if (!(Symbol.iterator in e))
@@ -31,130 +31,130 @@ function su(e, t) {
     if (n.push(r), n.length === t) break;
   return n;
 }
-const Ce = 2, Lr = 4, Fi = 8, Ja = 1 << 24, cn = 16, Tt = 32, An = 64, Za = 128, ht = 512, Ae = 1024, Ne = 2048, Et = 4096, nt = 8192, on = 16384, wr = 32768, dr = 65536, fa = 1 << 17, Qa = 1 << 18, jn = 1 << 19, au = 1 << 20, sn = 1 << 25, Wn = 65536, ls = 1 << 21, Ms = 1 << 22, yn = 1 << 23, Or = Symbol("$state"), eo = Symbol("legacy props"), ou = Symbol(""), kn = new class extends Error {
+const Te = 2, Vr = 4, Vi = 8, to = 1 << 24, dn = 16, At = 32, Tn = 64, no = 128, pt = 512, be = 1024, Re = 2048, $t = 4096, nt = 8192, un = 16384, $r = 32768, gr = 65536, pa = 1 << 17, ro = 1 << 18, Zn = 1 << 19, hu = 1 << 20, on = 1 << 25, Gn = 65536, ds = 1 << 21, Fs = 1 << 22, xn = 1 << 23, Fr = Symbol("$state"), io = Symbol("legacy props"), du = Symbol(""), Mn = new class extends Error {
   constructor() {
     super(...arguments);
-    pe(this, "name", "StaleReactionError");
-    pe(this, "message", "The reaction that called `getAbortSignal()` was re-run or destroyed");
+    de(this, "name", "StaleReactionError");
+    de(this, "message", "The reaction that called `getAbortSignal()` was re-run or destroyed");
   }
 }();
-var Ya;
-const lu = ((Ya = globalThis.document) == null ? void 0 : /* @__PURE__ */ Ya.contentType.includes("xml")) ?? !1, Kr = 3, xr = 8;
-function uu(e) {
+var Ua;
+const pu = ((Ua = globalThis.document) == null ? void 0 : /* @__PURE__ */ Ua.contentType.includes("xml")) ?? !1, Jr = 3, Ar = 8;
+function vu(e) {
   throw new Error("https://svelte.dev/e/lifecycle_outside_component");
 }
-function fu() {
+function gu() {
   throw new Error("https://svelte.dev/e/async_derived_orphan");
 }
-function cu(e, t, n) {
+function _u(e, t, n) {
   throw new Error("https://svelte.dev/e/each_key_duplicate");
 }
-function hu(e) {
+function mu(e) {
   throw new Error("https://svelte.dev/e/effect_in_teardown");
 }
-function du() {
+function yu() {
   throw new Error("https://svelte.dev/e/effect_in_unowned_derived");
 }
-function pu(e) {
+function wu(e) {
   throw new Error("https://svelte.dev/e/effect_orphan");
 }
-function vu() {
+function xu() {
   throw new Error("https://svelte.dev/e/effect_update_depth_exceeded");
 }
-function gu() {
+function bu() {
   throw new Error("https://svelte.dev/e/hydration_failed");
 }
-function _u(e) {
+function $u(e) {
   throw new Error("https://svelte.dev/e/props_invalid_value");
 }
-function mu() {
+function Au() {
   throw new Error("https://svelte.dev/e/state_descriptors_fixed");
 }
-function yu() {
+function Eu() {
   throw new Error("https://svelte.dev/e/state_prototype_fixed");
 }
-function wu() {
+function Tu() {
   throw new Error("https://svelte.dev/e/state_unsafe_mutation");
 }
-function xu() {
+function Ru() {
   throw new Error("https://svelte.dev/e/svelte_boundary_reset_onerror");
 }
-function Ii(e) {
+function zi(e) {
   console.warn("https://svelte.dev/e/hydration_mismatch");
 }
-function bu() {
+function Su() {
   console.warn("https://svelte.dev/e/svelte_boundary_reset_noop");
 }
-let j = !1;
-function an(e) {
-  j = e;
+let Z = !1;
+function ln(e) {
+  Z = e;
 }
-let X;
-function Ie(e) {
+let W;
+function Fe(e) {
   if (e === null)
-    throw Ii(), cr;
-  return X = e;
+    throw zi(), pr;
+  return W = e;
 }
-function Li() {
-  return Ie(/* @__PURE__ */ Ht(X));
+function Hi() {
+  return Fe(/* @__PURE__ */ zt(W));
 }
 function Oe(e) {
-  if (j) {
-    if (/* @__PURE__ */ Ht(X) !== null)
-      throw Ii(), cr;
-    X = e;
+  if (Z) {
+    if (/* @__PURE__ */ zt(W) !== null)
+      throw zi(), pr;
+    W = e;
   }
 }
-function us(e = 1) {
-  if (j) {
-    for (var t = e, n = X; t--; )
+function ps(e = 1) {
+  if (Z) {
+    for (var t = e, n = W; t--; )
       n = /** @type {TemplateNode} */
-      /* @__PURE__ */ Ht(n);
-    X = n;
+      /* @__PURE__ */ zt(n);
+    W = n;
   }
 }
-function $i(e = !0) {
-  for (var t = 0, n = X; ; ) {
-    if (n.nodeType === xr) {
+function Ti(e = !0) {
+  for (var t = 0, n = W; ; ) {
+    if (n.nodeType === Ar) {
       var r = (
         /** @type {Comment} */
         n.data
       );
-      if (r === ks) {
+      if (r === Is) {
         if (t === 0) return n;
         t -= 1;
-      } else (r === Ns || r === Di || // "[1", "[2", etc. for if blocks
+      } else (r === Os || r === Li || // "[1", "[2", etc. for if blocks
       r[0] === "[" && !isNaN(Number(r.slice(1)))) && (t += 1);
     }
     var i = (
       /** @type {TemplateNode} */
-      /* @__PURE__ */ Ht(n)
+      /* @__PURE__ */ zt(n)
     );
     e && n.remove(), n = i;
   }
 }
-function to(e) {
-  if (!e || e.nodeType !== xr)
-    throw Ii(), cr;
+function so(e) {
+  if (!e || e.nodeType !== Ar)
+    throw zi(), pr;
   return (
     /** @type {Comment} */
     e.data
   );
 }
-function no(e) {
+function ao(e) {
   return e === this.v;
 }
-function $u(e, t) {
+function Cu(e, t) {
   return e != e ? t == t : e !== t || e !== null && typeof e == "object" || typeof e == "function";
 }
-function ro(e) {
-  return !$u(e, this.v);
+function oo(e) {
+  return !Cu(e, this.v);
 }
-let Au = !1, it = null;
-function pr(e) {
+let Nu = !1, it = null;
+function _r(e) {
   it = e;
 }
-function qi(e, t = !1, n) {
+function Yi(e, t = !1, n) {
   it = {
     p: it,
     i: !1,
@@ -165,7 +165,7 @@ function qi(e, t = !1, n) {
     l: null
   };
 }
-function Vi(e) {
+function Bi(e) {
   var t = (
     /** @type {ComponentContext} */
     it
@@ -173,44 +173,44 @@ function Vi(e) {
   if (n !== null) {
     t.e = null;
     for (var r of n)
-      Co(r);
+      Mo(r);
   }
   return e !== void 0 && (t.x = e), t.i = !0, it = t.p, e ?? /** @type {T} */
   {};
 }
-function io() {
+function lo() {
   return !0;
 }
-let Mn = [];
-function so() {
-  var e = Mn;
-  Mn = [], iu(e);
+let Dn = [];
+function uo() {
+  var e = Dn;
+  Dn = [], fu(e);
 }
-function wn(e) {
-  if (Mn.length === 0 && !Fr) {
-    var t = Mn;
+function bn(e) {
+  if (Dn.length === 0 && !Lr) {
+    var t = Dn;
     queueMicrotask(() => {
-      t === Mn && so();
+      t === Dn && uo();
     });
   }
-  Mn.push(e);
+  Dn.push(e);
 }
-function Eu() {
-  for (; Mn.length > 0; )
-    so();
+function ku() {
+  for (; Dn.length > 0; )
+    uo();
 }
-function ao(e) {
-  var t = J;
+function fo(e) {
+  var t = te;
   if (t === null)
-    return B.f |= yn, e;
-  if ((t.f & wr) === 0 && (t.f & Lr) === 0)
+    return X.f |= xn, e;
+  if ((t.f & $r) === 0 && (t.f & Vr) === 0)
     throw e;
-  vr(e, t);
+  mr(e, t);
 }
-function vr(e, t) {
+function mr(e, t) {
   for (; t !== null; ) {
-    if ((t.f & Za) !== 0) {
-      if ((t.f & wr) === 0)
+    if ((t.f & no) !== 0) {
+      if ((t.f & $r) === 0)
         throw e;
       try {
         t.b.error(e);
@@ -223,78 +223,78 @@ function vr(e, t) {
   }
   throw e;
 }
-const Tu = -7169;
-function ge(e, t) {
-  e.f = e.f & Tu | t;
+const Pu = -7169;
+function ve(e, t) {
+  e.f = e.f & Pu | t;
 }
-function Ps(e) {
-  (e.f & ht) !== 0 || e.deps === null ? ge(e, Ae) : ge(e, Et);
+function Ls(e) {
+  (e.f & pt) !== 0 || e.deps === null ? ve(e, be) : ve(e, $t);
 }
-function oo(e) {
+function co(e) {
   if (e !== null)
     for (const t of e)
-      (t.f & Ce) === 0 || (t.f & Wn) === 0 || (t.f ^= Wn, oo(
+      (t.f & Te) === 0 || (t.f & Gn) === 0 || (t.f ^= Gn, co(
         /** @type {Derived} */
         t.deps
       ));
 }
-function lo(e, t, n) {
-  (e.f & Ne) !== 0 ? t.add(e) : (e.f & Et) !== 0 && n.add(e), oo(e.deps), ge(e, Ae);
+function ho(e, t, n) {
+  (e.f & Re) !== 0 ? t.add(e) : (e.f & $t) !== 0 && n.add(e), co(e.deps), ve(e, be);
 }
-const ti = /* @__PURE__ */ new Set();
-let K = null, Se = null, Ue = [], zi = null, fs = !1, Fr = !1;
-var ir, sr, Fn, ar, Br, Xr, In, Qt, or, zt, cs, hs, uo;
-const Js = class Js {
+const ii = /* @__PURE__ */ new Set();
+let J = null, Ee = null, Xe = [], Xi = null, vs = !1, Lr = !1;
+var or, lr, Ln, ur, Wr, Ur, qn, tn, fr, Vt, gs, _s, po;
+const ta = class ta {
   constructor() {
-    z(this, zt);
-    pe(this, "committed", !1);
+    H(this, Vt);
+    de(this, "committed", !1);
     /**
      * The current values of any sources that are updated in this batch
      * They keys of this map are identical to `this.#previous`
      * @type {Map<Source, any>}
      */
-    pe(this, "current", /* @__PURE__ */ new Map());
+    de(this, "current", /* @__PURE__ */ new Map());
     /**
      * The values of any sources that are updated in this batch _before_ those updates took place.
      * They keys of this map are identical to `this.#current`
      * @type {Map<Source, any>}
      */
-    pe(this, "previous", /* @__PURE__ */ new Map());
+    de(this, "previous", /* @__PURE__ */ new Map());
     /**
      * When the batch is committed (and the DOM is updated), we need to remove old branches
      * and append new ones by calling the functions added inside (if/each/key/etc) blocks
      * @type {Set<() => void>}
      */
-    z(this, ir, /* @__PURE__ */ new Set());
+    H(this, or, /* @__PURE__ */ new Set());
     /**
      * If a fork is discarded, we need to destroy any effects that are no longer needed
      * @type {Set<(batch: Batch) => void>}
      */
-    z(this, sr, /* @__PURE__ */ new Set());
+    H(this, lr, /* @__PURE__ */ new Set());
     /**
      * The number of async effects that are currently in flight
      */
-    z(this, Fn, 0);
+    H(this, Ln, 0);
     /**
      * The number of async effects that are currently in flight, _not_ inside a pending boundary
      */
-    z(this, ar, 0);
+    H(this, ur, 0);
     /**
      * A deferred that resolves when the batch is committed, used with `settled()`
      * TODO replace with Promise.withResolvers once supported widely enough
      * @type {{ promise: Promise<void>, resolve: (value?: any) => void, reject: (reason: unknown) => void } | null}
      */
-    z(this, Br, null);
+    H(this, Wr, null);
     /**
      * Deferred effects (which run after async work has completed) that are DIRTY
      * @type {Set<Effect>}
      */
-    z(this, Xr, /* @__PURE__ */ new Set());
+    H(this, Ur, /* @__PURE__ */ new Set());
     /**
      * Deferred effects that are MAYBE_DIRTY
      * @type {Set<Effect>}
      */
-    z(this, In, /* @__PURE__ */ new Set());
+    H(this, qn, /* @__PURE__ */ new Set());
     /**
      * A map of branches that still exist, but will be destroyed when this batch
      * is committed — we skip over these during `process`.
@@ -302,19 +302,19 @@ const Js = class Js {
      * so they can be rescheduled if the branch survives.
      * @type {Map<Effect, { d: Effect[], m: Effect[] }>}
      */
-    z(this, Qt, /* @__PURE__ */ new Map());
-    pe(this, "is_fork", !1);
-    z(this, or, !1);
+    H(this, tn, /* @__PURE__ */ new Map());
+    de(this, "is_fork", !1);
+    H(this, fr, !1);
   }
   is_deferred() {
-    return this.is_fork || v(this, ar) > 0;
+    return this.is_fork || g(this, ur) > 0;
   }
   /**
    * Add an effect to the #skipped_branches map and reset its children
    * @param {Effect} effect
    */
   skip_effect(t) {
-    v(this, Qt).has(t) || v(this, Qt).set(t, { d: [], m: [] });
+    g(this, tn).has(t) || g(this, tn).set(t, { d: [], m: [] });
   }
   /**
    * Remove an effect from the #skipped_branches map and reschedule
@@ -322,13 +322,13 @@ const Js = class Js {
    * @param {Effect} effect
    */
   unskip_effect(t) {
-    var n = v(this, Qt).get(t);
+    var n = g(this, tn).get(t);
     if (n) {
-      v(this, Qt).delete(t);
+      g(this, tn).delete(t);
       for (var r of n.d)
-        ge(r, Ne), $t(r);
+        ve(r, Re), xt(r);
       for (r of n.m)
-        ge(r, Et), $t(r);
+        ve(r, $t), xt(r);
     }
   }
   /**
@@ -337,19 +337,19 @@ const Js = class Js {
    */
   process(t) {
     var i;
-    Ue = [], this.apply();
+    Xe = [], this.apply();
     var n = [], r = [];
     for (const s of t)
-      be(this, zt, cs).call(this, s, n, r);
+      we(this, Vt, gs).call(this, s, n, r);
     if (this.is_deferred()) {
-      be(this, zt, hs).call(this, r), be(this, zt, hs).call(this, n);
-      for (const [s, a] of v(this, Qt))
-        po(s, a);
+      we(this, Vt, _s).call(this, r), we(this, Vt, _s).call(this, n);
+      for (const [s, a] of g(this, tn))
+        mo(s, a);
     } else {
-      for (const s of v(this, ir)) s();
-      v(this, ir).clear(), v(this, Fn) === 0 && be(this, zt, uo).call(this), K = null, ca(r), ca(n), (i = v(this, Br)) == null || i.resolve();
+      for (const s of g(this, or)) s();
+      g(this, or).clear(), g(this, Ln) === 0 && we(this, Vt, po).call(this), J = null, va(r), va(n), (i = g(this, Wr)) == null || i.resolve();
     }
-    Se = null;
+    Ee = null;
   }
   /**
    * Associate a change to a given source with the current
@@ -358,84 +358,84 @@ const Js = class Js {
    * @param {any} value
    */
   capture(t, n) {
-    n !== Re && !this.previous.has(t) && this.previous.set(t, n), (t.f & yn) === 0 && (this.current.set(t, t.v), Se == null || Se.set(t, t.v));
+    n !== Ae && !this.previous.has(t) && this.previous.set(t, n), (t.f & xn) === 0 && (this.current.set(t, t.v), Ee == null || Ee.set(t, t.v));
   }
   activate() {
-    K = this, this.apply();
+    J = this, this.apply();
   }
   deactivate() {
-    K === this && (K = null, Se = null);
+    J === this && (J = null, Ee = null);
   }
   flush() {
-    if (this.activate(), Ue.length > 0) {
-      if (fo(), K !== null && K !== this)
+    if (this.activate(), Xe.length > 0) {
+      if (vo(), J !== null && J !== this)
         return;
-    } else v(this, Fn) === 0 && this.process([]);
+    } else g(this, Ln) === 0 && this.process([]);
     this.deactivate();
   }
   discard() {
-    for (const t of v(this, sr)) t(this);
-    v(this, sr).clear();
+    for (const t of g(this, lr)) t(this);
+    g(this, lr).clear();
   }
   /**
    *
    * @param {boolean} blocking
    */
   increment(t) {
-    q(this, Fn, v(this, Fn) + 1), t && q(this, ar, v(this, ar) + 1);
+    L(this, Ln, g(this, Ln) + 1), t && L(this, ur, g(this, ur) + 1);
   }
   /**
    *
    * @param {boolean} blocking
    */
   decrement(t) {
-    q(this, Fn, v(this, Fn) - 1), t && q(this, ar, v(this, ar) - 1), !v(this, or) && (q(this, or, !0), wn(() => {
-      q(this, or, !1), this.is_deferred() ? Ue.length > 0 && this.flush() : this.revive();
+    L(this, Ln, g(this, Ln) - 1), t && L(this, ur, g(this, ur) - 1), !g(this, fr) && (L(this, fr, !0), bn(() => {
+      L(this, fr, !1), this.is_deferred() ? Xe.length > 0 && this.flush() : this.revive();
     }));
   }
   revive() {
-    for (const t of v(this, Xr))
-      v(this, In).delete(t), ge(t, Ne), $t(t);
-    for (const t of v(this, In))
-      ge(t, Et), $t(t);
+    for (const t of g(this, Ur))
+      g(this, qn).delete(t), ve(t, Re), xt(t);
+    for (const t of g(this, qn))
+      ve(t, $t), xt(t);
     this.flush();
   }
   /** @param {() => void} fn */
   oncommit(t) {
-    v(this, ir).add(t);
+    g(this, or).add(t);
   }
   /** @param {(batch: Batch) => void} fn */
   ondiscard(t) {
-    v(this, sr).add(t);
+    g(this, lr).add(t);
   }
   settled() {
-    return (v(this, Br) ?? q(this, Br, ja())).promise;
+    return (g(this, Wr) ?? L(this, Wr, eo())).promise;
   }
   static ensure() {
-    if (K === null) {
-      const t = K = new Js();
-      ti.add(K), Fr || wn(() => {
-        K === t && t.flush();
+    if (J === null) {
+      const t = J = new ta();
+      ii.add(J), Lr || bn(() => {
+        J === t && t.flush();
       });
     }
-    return K;
+    return J;
   }
   apply() {
   }
 };
-ir = new WeakMap(), sr = new WeakMap(), Fn = new WeakMap(), ar = new WeakMap(), Br = new WeakMap(), Xr = new WeakMap(), In = new WeakMap(), Qt = new WeakMap(), or = new WeakMap(), zt = new WeakSet(), /**
+or = new WeakMap(), lr = new WeakMap(), Ln = new WeakMap(), ur = new WeakMap(), Wr = new WeakMap(), Ur = new WeakMap(), qn = new WeakMap(), tn = new WeakMap(), fr = new WeakMap(), Vt = new WeakSet(), /**
  * Traverse the effect tree, executing effects or stashing
  * them for later execution as appropriate
  * @param {Effect} root
  * @param {Effect[]} effects
  * @param {Effect[]} render_effects
  */
-cs = function(t, n, r) {
-  t.f ^= Ae;
+gs = function(t, n, r) {
+  t.f ^= be;
   for (var i = t.first, s = null; i !== null; ) {
-    var a = i.f, o = (a & (Tt | An)) !== 0, l = o && (a & Ae) !== 0, u = l || (a & nt) !== 0 || v(this, Qt).has(i);
+    var a = i.f, o = (a & (At | Tn)) !== 0, l = o && (a & be) !== 0, u = l || (a & nt) !== 0 || g(this, tn).has(i);
     if (!u && i.fn !== null) {
-      o ? i.f ^= Ae : s !== null && (a & (Lr | Fi | Ja)) !== 0 ? s.b.defer_effect(i) : (a & Lr) !== 0 ? n.push(i) : jr(i) && ((a & cn) !== 0 && v(this, In).add(i), _r(i));
+      o ? i.f ^= be : s !== null && (a & (Vr | Vi | to)) !== 0 ? s.b.defer_effect(i) : (a & Vr) !== 0 ? n.push(i) : Zr(i) && ((a & dn) !== 0 && g(this, qn).add(i), wr(i));
       var f = i.first;
       if (f !== null) {
         i = f;
@@ -449,15 +449,15 @@ cs = function(t, n, r) {
 }, /**
  * @param {Effect[]} effects
  */
-hs = function(t) {
+_s = function(t) {
   for (var n = 0; n < t.length; n += 1)
-    lo(t[n], v(this, Xr), v(this, In));
-}, uo = function() {
+    ho(t[n], g(this, Ur), g(this, qn));
+}, po = function() {
   var i;
-  if (ti.size > 1) {
+  if (ii.size > 1) {
     this.previous.clear();
-    var t = Se, n = !0;
-    for (const s of ti) {
+    var t = Ee, n = !0;
+    for (const s of ii) {
       if (s === this) {
         n = !1;
         continue;
@@ -475,111 +475,111 @@ hs = function(t) {
         continue;
       const o = [...s.current.keys()].filter((l) => !this.current.has(l));
       if (o.length > 0) {
-        var r = Ue;
-        Ue = [];
+        var r = Xe;
+        Xe = [];
         const l = /* @__PURE__ */ new Set(), u = /* @__PURE__ */ new Map();
         for (const f of a)
-          co(f, o, l, u);
-        if (Ue.length > 0) {
-          K = s, s.apply();
-          for (const f of Ue)
-            be(i = s, zt, cs).call(i, f, [], []);
+          go(f, o, l, u);
+        if (Xe.length > 0) {
+          J = s, s.apply();
+          for (const f of Xe)
+            we(i = s, Vt, gs).call(i, f, [], []);
           s.deactivate();
         }
-        Ue = r;
+        Xe = r;
       }
     }
-    K = null, Se = t;
+    J = null, Ee = t;
   }
-  this.committed = !0, ti.delete(this);
+  this.committed = !0, ii.delete(this);
 };
-let ln = Js;
-function ne(e) {
-  var t = Fr;
-  Fr = !0;
+let fn = ta;
+function j(e) {
+  var t = Lr;
+  Lr = !0;
   try {
     for (var n; ; ) {
-      if (Eu(), Ue.length === 0 && (K == null || K.flush(), Ue.length === 0))
-        return zi = null, /** @type {T} */
+      if (ku(), Xe.length === 0 && (J == null || J.flush(), Xe.length === 0))
+        return Xi = null, /** @type {T} */
         n;
-      fo();
+      vo();
     }
   } finally {
-    Fr = t;
+    Lr = t;
   }
 }
-function fo() {
-  fs = !0;
+function vo() {
+  vs = !0;
   var e = null;
   try {
-    for (var t = 0; Ue.length > 0; ) {
-      var n = ln.ensure();
+    for (var t = 0; Xe.length > 0; ) {
+      var n = fn.ensure();
       if (t++ > 1e3) {
         var r, i;
-        Ru();
+        Mu();
       }
-      n.process(Ue), xn.clear();
+      n.process(Xe), $n.clear();
     }
   } finally {
-    Ue = [], fs = !1, zi = null;
+    Xe = [], vs = !1, Xi = null;
   }
 }
-function Ru() {
+function Mu() {
   try {
-    vu();
+    xu();
   } catch (e) {
-    vr(e, zi);
+    mr(e, Xi);
   }
 }
-let wt = null;
-function ca(e) {
+let mt = null;
+function va(e) {
   var t = e.length;
   if (t !== 0) {
     for (var n = 0; n < t; ) {
       var r = e[n++];
-      if ((r.f & (on | nt)) === 0 && jr(r) && (wt = /* @__PURE__ */ new Set(), _r(r), r.deps === null && r.first === null && r.nodes === null && r.teardown === null && r.ac === null && Mo(r), (wt == null ? void 0 : wt.size) > 0)) {
-        xn.clear();
-        for (const i of wt) {
-          if ((i.f & (on | nt)) !== 0) continue;
+      if ((r.f & (un | nt)) === 0 && Zr(r) && (mt = /* @__PURE__ */ new Set(), wr(r), r.deps === null && r.first === null && r.nodes === null && r.teardown === null && r.ac === null && Io(r), (mt == null ? void 0 : mt.size) > 0)) {
+        $n.clear();
+        for (const i of mt) {
+          if ((i.f & (un | nt)) !== 0) continue;
           const s = [i];
           let a = i.parent;
           for (; a !== null; )
-            wt.has(a) && (wt.delete(a), s.push(a)), a = a.parent;
+            mt.has(a) && (mt.delete(a), s.push(a)), a = a.parent;
           for (let o = s.length - 1; o >= 0; o--) {
             const l = s[o];
-            (l.f & (on | nt)) === 0 && _r(l);
+            (l.f & (un | nt)) === 0 && wr(l);
           }
         }
-        wt.clear();
+        mt.clear();
       }
     }
-    wt = null;
+    mt = null;
   }
 }
-function co(e, t, n, r) {
+function go(e, t, n, r) {
   if (!n.has(e) && (n.add(e), e.reactions !== null))
     for (const i of e.reactions) {
       const s = i.f;
-      (s & Ce) !== 0 ? co(
+      (s & Te) !== 0 ? go(
         /** @type {Derived} */
         i,
         t,
         n,
         r
-      ) : (s & (Ms | cn)) !== 0 && (s & Ne) === 0 && ho(i, t, r) && (ge(i, Ne), $t(
+      ) : (s & (Fs | dn)) !== 0 && (s & Re) === 0 && _o(i, t, r) && (ve(i, Re), xt(
         /** @type {Effect} */
         i
       ));
     }
 }
-function ho(e, t, n) {
+function _o(e, t, n) {
   const r = n.get(e);
   if (r !== void 0) return r;
   if (e.deps !== null)
     for (const i of e.deps) {
-      if (hr.call(t, i))
+      if (vr.call(t, i))
         return !0;
-      if ((i.f & Ce) !== 0 && ho(
+      if ((i.f & Te) !== 0 && _o(
         /** @type {Derived} */
         i,
         t,
@@ -593,80 +593,80 @@ function ho(e, t, n) {
     }
   return n.set(e, !1), !1;
 }
-function $t(e) {
-  for (var t = zi = e; t.parent !== null; ) {
+function xt(e) {
+  for (var t = Xi = e; t.parent !== null; ) {
     t = t.parent;
     var n = t.f;
-    if (fs && t === J && (n & cn) !== 0 && (n & Qa) === 0)
+    if (vs && t === te && (n & dn) !== 0 && (n & ro) === 0)
       return;
-    if ((n & (An | Tt)) !== 0) {
-      if ((n & Ae) === 0) return;
-      t.f ^= Ae;
+    if ((n & (Tn | At)) !== 0) {
+      if ((n & be) === 0) return;
+      t.f ^= be;
     }
   }
-  Ue.push(t);
+  Xe.push(t);
 }
-function po(e, t) {
-  if (!((e.f & Tt) !== 0 && (e.f & Ae) !== 0)) {
-    (e.f & Ne) !== 0 ? t.d.push(e) : (e.f & Et) !== 0 && t.m.push(e), ge(e, Ae);
+function mo(e, t) {
+  if (!((e.f & At) !== 0 && (e.f & be) !== 0)) {
+    (e.f & Re) !== 0 ? t.d.push(e) : (e.f & $t) !== 0 && t.m.push(e), ve(e, be);
     for (var n = e.first; n !== null; )
-      po(n, t), n = n.next;
+      mo(n, t), n = n.next;
   }
 }
-function Su(e) {
-  let t = 0, n = Un(0), r;
+function Du(e) {
+  let t = 0, n = Kn(0), r;
   return () => {
-    Fs() && ($(n), Ls(() => (t === 0 && (r = Bi(() => e(() => Ir(n)))), t += 1, () => {
-      wn(() => {
-        t -= 1, t === 0 && (r == null || r(), r = void 0, Ir(n));
+    zs() && (A(n), Hs(() => (t === 0 && (r = Qr(() => e(() => qr(n)))), t += 1, () => {
+      bn(() => {
+        t -= 1, t === 0 && (r == null || r(), r = void 0, qr(n));
       });
     })));
   };
 }
-var Cu = dr | jn | Za;
-function Nu(e, t, n) {
-  new ku(e, t, n);
+var Ou = gr | Zn | no;
+function Iu(e, t, n) {
+  new Fu(e, t, n);
 }
-var et, Wr, Dt, Ln, Ot, ut, Xe, Ft, en, mn, qn, tn, lr, Vn, ur, fr, nn, Mi, me, vo, go, ds, ui, fi, ps;
-class ku {
+var et, Gr, Mt, Vn, Dt, ct, Ye, Ot, nn, wn, zn, rn, cr, Hn, hr, dr, sn, Ii, _e, yo, wo, ms, hi, di, ys;
+class Fu {
   /**
    * @param {TemplateNode} node
    * @param {BoundaryProps} props
    * @param {((anchor: Node) => void)} children
    */
   constructor(t, n, r) {
-    z(this, me);
+    H(this, _e);
     /** @type {Boundary | null} */
-    pe(this, "parent");
-    pe(this, "is_pending", !1);
+    de(this, "parent");
+    de(this, "is_pending", !1);
     /** @type {TemplateNode} */
-    z(this, et);
+    H(this, et);
     /** @type {TemplateNode | null} */
-    z(this, Wr, j ? X : null);
+    H(this, Gr, Z ? W : null);
     /** @type {BoundaryProps} */
-    z(this, Dt);
+    H(this, Mt);
     /** @type {((anchor: Node) => void)} */
-    z(this, Ln);
+    H(this, Vn);
     /** @type {Effect} */
-    z(this, Ot);
+    H(this, Dt);
     /** @type {Effect | null} */
-    z(this, ut, null);
+    H(this, ct, null);
     /** @type {Effect | null} */
-    z(this, Xe, null);
+    H(this, Ye, null);
     /** @type {Effect | null} */
-    z(this, Ft, null);
+    H(this, Ot, null);
     /** @type {DocumentFragment | null} */
-    z(this, en, null);
+    H(this, nn, null);
     /** @type {TemplateNode | null} */
-    z(this, mn, null);
-    z(this, qn, 0);
-    z(this, tn, 0);
-    z(this, lr, !1);
-    z(this, Vn, !1);
+    H(this, wn, null);
+    H(this, zn, 0);
+    H(this, rn, 0);
+    H(this, cr, !1);
+    H(this, Hn, !1);
     /** @type {Set<Effect>} */
-    z(this, ur, /* @__PURE__ */ new Set());
+    H(this, hr, /* @__PURE__ */ new Set());
     /** @type {Set<Effect>} */
-    z(this, fr, /* @__PURE__ */ new Set());
+    H(this, dr, /* @__PURE__ */ new Set());
     /**
      * A source containing the number of pending async deriveds/expressions.
      * Only created if `$effect.pending()` is used inside the boundary,
@@ -674,38 +674,38 @@ class ku {
      * calls followed by no-op flushes
      * @type {Source<number> | null}
      */
-    z(this, nn, null);
-    z(this, Mi, Su(() => (q(this, nn, Un(v(this, qn))), () => {
-      q(this, nn, null);
+    H(this, sn, null);
+    H(this, Ii, Du(() => (L(this, sn, Kn(g(this, zn))), () => {
+      L(this, sn, null);
     })));
-    q(this, et, t), q(this, Dt, n), q(this, Ln, r), this.parent = /** @type {Effect} */
-    J.b, this.is_pending = !!v(this, Dt).pending, q(this, Ot, qs(() => {
-      if (J.b = this, j) {
-        const s = v(this, Wr);
-        Li(), /** @type {Comment} */
-        s.nodeType === xr && /** @type {Comment} */
-        s.data === Di ? be(this, me, go).call(this) : (be(this, me, vo).call(this), v(this, tn) === 0 && (this.is_pending = !1));
+    L(this, et, t), L(this, Mt, n), L(this, Vn, r), this.parent = /** @type {Effect} */
+    te.b, this.is_pending = !!g(this, Mt).pending, L(this, Dt, Ys(() => {
+      if (te.b = this, Z) {
+        const s = g(this, Gr);
+        Hi(), /** @type {Comment} */
+        s.nodeType === Ar && /** @type {Comment} */
+        s.data === Li ? we(this, _e, wo).call(this) : (we(this, _e, yo).call(this), g(this, rn) === 0 && (this.is_pending = !1));
       } else {
-        var i = be(this, me, ds).call(this);
+        var i = we(this, _e, ms).call(this);
         try {
-          q(this, ut, ct(() => r(i)));
+          L(this, ct, dt(() => r(i)));
         } catch (s) {
           this.error(s);
         }
-        v(this, tn) > 0 ? be(this, me, fi).call(this) : this.is_pending = !1;
+        g(this, rn) > 0 ? we(this, _e, di).call(this) : this.is_pending = !1;
       }
       return () => {
         var s;
-        (s = v(this, mn)) == null || s.remove();
+        (s = g(this, wn)) == null || s.remove();
       };
-    }, Cu)), j && q(this, et, X);
+    }, Ou)), Z && L(this, et, W);
   }
   /**
    * Defer an effect inside a pending boundary until the boundary resolves
    * @param {Effect} effect
    */
   defer_effect(t) {
-    lo(t, v(this, ur), v(this, fr));
+    ho(t, g(this, hr), g(this, dr));
   }
   /**
    * Returns `false` if the effect exists inside a boundary whose pending snippet is shown
@@ -715,7 +715,7 @@ class ku {
     return !this.is_pending && (!this.parent || this.parent.is_rendered());
   }
   has_pending_snippet() {
-    return !!v(this, Dt).pending;
+    return !!g(this, Mt).pending;
   }
   /**
    * Update the source that powers `$effect.pending()` inside this boundary,
@@ -724,199 +724,199 @@ class ku {
    * @param {1 | -1} d
    */
   update_pending_count(t) {
-    be(this, me, ps).call(this, t), q(this, qn, v(this, qn) + t), !(!v(this, nn) || v(this, lr)) && (q(this, lr, !0), wn(() => {
-      q(this, lr, !1), v(this, nn) && gr(v(this, nn), v(this, qn));
+    we(this, _e, ys).call(this, t), L(this, zn, g(this, zn) + t), !(!g(this, sn) || g(this, cr)) && (L(this, cr, !0), bn(() => {
+      L(this, cr, !1), g(this, sn) && yr(g(this, sn), g(this, zn));
     }));
   }
   get_effect_pending() {
-    return v(this, Mi).call(this), $(
+    return g(this, Ii).call(this), A(
       /** @type {Source<number>} */
-      v(this, nn)
+      g(this, sn)
     );
   }
   /** @param {unknown} error */
   error(t) {
-    var n = v(this, Dt).onerror;
-    let r = v(this, Dt).failed;
-    if (v(this, Vn) || !n && !r)
+    var n = g(this, Mt).onerror;
+    let r = g(this, Mt).failed;
+    if (g(this, Hn) || !n && !r)
       throw t;
-    v(this, ut) && (Le(v(this, ut)), q(this, ut, null)), v(this, Xe) && (Le(v(this, Xe)), q(this, Xe, null)), v(this, Ft) && (Le(v(this, Ft)), q(this, Ft, null)), j && (Ie(
+    g(this, ct) && (Le(g(this, ct)), L(this, ct, null)), g(this, Ye) && (Le(g(this, Ye)), L(this, Ye, null)), g(this, Ot) && (Le(g(this, Ot)), L(this, Ot, null)), Z && (Fe(
       /** @type {TemplateNode} */
-      v(this, Wr)
-    ), us(), Ie($i()));
+      g(this, Gr)
+    ), ps(), Fe(Ti()));
     var i = !1, s = !1;
     const a = () => {
       if (i) {
-        bu();
+        Su();
         return;
       }
-      i = !0, s && xu(), ln.ensure(), q(this, qn, 0), v(this, Ft) !== null && Yn(v(this, Ft), () => {
-        q(this, Ft, null);
-      }), this.is_pending = this.has_pending_snippet(), q(this, ut, be(this, me, ui).call(this, () => (q(this, Vn, !1), ct(() => v(this, Ln).call(this, v(this, et)))))), v(this, tn) > 0 ? be(this, me, fi).call(this) : this.is_pending = !1;
+      i = !0, s && Ru(), fn.ensure(), L(this, zn, 0), g(this, Ot) !== null && Xn(g(this, Ot), () => {
+        L(this, Ot, null);
+      }), this.is_pending = this.has_pending_snippet(), L(this, ct, we(this, _e, hi).call(this, () => (L(this, Hn, !1), dt(() => g(this, Vn).call(this, g(this, et)))))), g(this, rn) > 0 ? we(this, _e, di).call(this) : this.is_pending = !1;
     };
-    wn(() => {
+    bn(() => {
       try {
         s = !0, n == null || n(t, a), s = !1;
       } catch (o) {
-        vr(o, v(this, Ot) && v(this, Ot).parent);
+        mr(o, g(this, Dt) && g(this, Dt).parent);
       }
-      r && q(this, Ft, be(this, me, ui).call(this, () => {
-        ln.ensure(), q(this, Vn, !0);
+      r && L(this, Ot, we(this, _e, hi).call(this, () => {
+        fn.ensure(), L(this, Hn, !0);
         try {
-          return ct(() => {
+          return dt(() => {
             r(
-              v(this, et),
+              g(this, et),
               () => t,
               () => a
             );
           });
         } catch (o) {
-          return vr(
+          return mr(
             o,
             /** @type {Effect} */
-            v(this, Ot).parent
+            g(this, Dt).parent
           ), null;
         } finally {
-          q(this, Vn, !1);
+          L(this, Hn, !1);
         }
       }));
     });
   }
 }
-et = new WeakMap(), Wr = new WeakMap(), Dt = new WeakMap(), Ln = new WeakMap(), Ot = new WeakMap(), ut = new WeakMap(), Xe = new WeakMap(), Ft = new WeakMap(), en = new WeakMap(), mn = new WeakMap(), qn = new WeakMap(), tn = new WeakMap(), lr = new WeakMap(), Vn = new WeakMap(), ur = new WeakMap(), fr = new WeakMap(), nn = new WeakMap(), Mi = new WeakMap(), me = new WeakSet(), vo = function() {
+et = new WeakMap(), Gr = new WeakMap(), Mt = new WeakMap(), Vn = new WeakMap(), Dt = new WeakMap(), ct = new WeakMap(), Ye = new WeakMap(), Ot = new WeakMap(), nn = new WeakMap(), wn = new WeakMap(), zn = new WeakMap(), rn = new WeakMap(), cr = new WeakMap(), Hn = new WeakMap(), hr = new WeakMap(), dr = new WeakMap(), sn = new WeakMap(), Ii = new WeakMap(), _e = new WeakSet(), yo = function() {
   try {
-    q(this, ut, ct(() => v(this, Ln).call(this, v(this, et))));
+    L(this, ct, dt(() => g(this, Vn).call(this, g(this, et))));
   } catch (t) {
     this.error(t);
   }
-}, go = function() {
-  const t = v(this, Dt).pending;
-  t && (q(this, Xe, ct(() => t(v(this, et)))), wn(() => {
-    var n = be(this, me, ds).call(this);
-    q(this, ut, be(this, me, ui).call(this, () => (ln.ensure(), ct(() => v(this, Ln).call(this, n))))), v(this, tn) > 0 ? be(this, me, fi).call(this) : (Yn(
+}, wo = function() {
+  const t = g(this, Mt).pending;
+  t && (L(this, Ye, dt(() => t(g(this, et)))), bn(() => {
+    var n = we(this, _e, ms).call(this);
+    L(this, ct, we(this, _e, hi).call(this, () => (fn.ensure(), dt(() => g(this, Vn).call(this, n))))), g(this, rn) > 0 ? we(this, _e, di).call(this) : (Xn(
       /** @type {Effect} */
-      v(this, Xe),
+      g(this, Ye),
       () => {
-        q(this, Xe, null);
+        L(this, Ye, null);
       }
     ), this.is_pending = !1);
   }));
-}, ds = function() {
-  var t = v(this, et);
-  return this.is_pending && (q(this, mn, rt()), v(this, et).before(v(this, mn)), t = v(this, mn)), t;
+}, ms = function() {
+  var t = g(this, et);
+  return this.is_pending && (L(this, wn, rt()), g(this, et).before(g(this, wn)), t = g(this, wn)), t;
 }, /**
  * @param {() => Effect | null} fn
  */
-ui = function(t) {
-  var n = J, r = B, i = it;
-  Vt(v(this, Ot)), pt(v(this, Ot)), pr(v(this, Ot).ctx);
+hi = function(t) {
+  var n = te, r = X, i = it;
+  qt(g(this, Dt)), gt(g(this, Dt)), _r(g(this, Dt).ctx);
   try {
     return t();
   } catch (s) {
-    return ao(s), null;
+    return fo(s), null;
   } finally {
-    Vt(n), pt(r), pr(i);
+    qt(n), gt(r), _r(i);
   }
-}, fi = function() {
+}, di = function() {
   const t = (
     /** @type {(anchor: Node) => void} */
-    v(this, Dt).pending
+    g(this, Mt).pending
   );
-  v(this, ut) !== null && (q(this, en, document.createDocumentFragment()), v(this, en).append(
+  g(this, ct) !== null && (L(this, nn, document.createDocumentFragment()), g(this, nn).append(
     /** @type {TemplateNode} */
-    v(this, mn)
-  ), Oo(v(this, ut), v(this, en))), v(this, Xe) === null && q(this, Xe, ct(() => t(v(this, et))));
+    g(this, wn)
+  ), qo(g(this, ct), g(this, nn))), g(this, Ye) === null && L(this, Ye, dt(() => t(g(this, et))));
 }, /**
  * Updates the pending count associated with the currently visible pending snippet,
  * if any, such that we can replace the snippet with content once work is done
  * @param {1 | -1} d
  */
-ps = function(t) {
+ys = function(t) {
   var n;
   if (!this.has_pending_snippet()) {
-    this.parent && be(n = this.parent, me, ps).call(n, t);
+    this.parent && we(n = this.parent, _e, ys).call(n, t);
     return;
   }
-  if (q(this, tn, v(this, tn) + t), v(this, tn) === 0) {
+  if (L(this, rn, g(this, rn) + t), g(this, rn) === 0) {
     this.is_pending = !1;
-    for (const r of v(this, ur))
-      ge(r, Ne), $t(r);
-    for (const r of v(this, fr))
-      ge(r, Et), $t(r);
-    v(this, ur).clear(), v(this, fr).clear(), v(this, Xe) && Yn(v(this, Xe), () => {
-      q(this, Xe, null);
-    }), v(this, en) && (v(this, et).before(v(this, en)), q(this, en, null));
+    for (const r of g(this, hr))
+      ve(r, Re), xt(r);
+    for (const r of g(this, dr))
+      ve(r, $t), xt(r);
+    g(this, hr).clear(), g(this, dr).clear(), g(this, Ye) && Xn(g(this, Ye), () => {
+      L(this, Ye, null);
+    }), g(this, nn) && (g(this, et).before(g(this, nn)), L(this, nn, null));
   }
 };
-function Mu(e, t, n, r) {
-  const i = Hi;
+function Lu(e, t, n, r) {
+  const i = Wi;
   var s = e.filter((h) => !h.settled);
   if (n.length === 0 && s.length === 0) {
     r(t.map(i));
     return;
   }
-  var a = K, o = (
+  var a = J, o = (
     /** @type {Effect} */
-    J
-  ), l = Pu(), u = s.length === 1 ? s[0].promise : s.length > 1 ? Promise.all(s.map((h) => h.promise)) : null;
+    te
+  ), l = qu(), u = s.length === 1 ? s[0].promise : s.length > 1 ? Promise.all(s.map((h) => h.promise)) : null;
   function f(h) {
     l();
     try {
       r(h);
     } catch (p) {
-      (o.f & on) === 0 && vr(p, o);
+      (o.f & un) === 0 && mr(p, o);
     }
-    a == null || a.deactivate(), vs();
+    a == null || a.deactivate(), ws();
   }
   if (n.length === 0) {
     u.then(() => f(t.map(i)));
     return;
   }
   function d() {
-    l(), Promise.all(n.map((h) => /* @__PURE__ */ Du(h))).then((h) => f([...t.map(i), ...h])).catch((h) => vr(h, o));
+    l(), Promise.all(n.map((h) => /* @__PURE__ */ Vu(h))).then((h) => f([...t.map(i), ...h])).catch((h) => mr(h, o));
   }
   u ? u.then(d) : d();
 }
-function Pu() {
-  var e = J, t = B, n = it, r = K;
+function qu() {
+  var e = te, t = X, n = it, r = J;
   return function(s = !0) {
-    Vt(e), pt(t), pr(n), s && (r == null || r.activate());
+    qt(e), gt(t), _r(n), s && (r == null || r.activate());
   };
 }
-function vs() {
-  Vt(null), pt(null), pr(null);
+function ws() {
+  qt(null), gt(null), _r(null);
 }
 // @__NO_SIDE_EFFECTS__
-function Hi(e) {
-  var t = Ce | Ne, n = B !== null && (B.f & Ce) !== 0 ? (
+function Wi(e) {
+  var t = Te | Re, n = X !== null && (X.f & Te) !== 0 ? (
     /** @type {Derived} */
-    B
+    X
   ) : null;
-  return J !== null && (J.f |= jn), {
+  return te !== null && (te.f |= Zn), {
     ctx: it,
     deps: null,
     effects: null,
-    equals: no,
+    equals: ao,
     f: t,
     fn: e,
     reactions: null,
     rv: 0,
     v: (
       /** @type {V} */
-      Re
+      Ae
     ),
     wv: 0,
-    parent: n ?? J,
+    parent: n ?? te,
     ac: null
   };
 }
 // @__NO_SIDE_EFFECTS__
-function Du(e, t, n) {
+function Vu(e, t, n) {
   let r = (
     /** @type {Effect | null} */
-    J
+    te
   );
-  r === null && fu();
+  r === null && gu();
   var i = (
     /** @type {Boundary} */
     r.b
@@ -924,45 +924,45 @@ function Du(e, t, n) {
     /** @type {Promise<V>} */
     /** @type {unknown} */
     void 0
-  ), a = Un(
+  ), a = Kn(
     /** @type {V} */
-    Re
-  ), o = !B, l = /* @__PURE__ */ new Map();
-  return Bu(() => {
+    Ae
+  ), o = !X, l = /* @__PURE__ */ new Map();
+  return ju(() => {
     var p;
-    var u = ja();
+    var u = eo();
     s = u.promise;
     try {
       Promise.resolve(e()).then(u.resolve, u.reject).then(() => {
-        f === K && f.committed && f.deactivate(), vs();
+        f === J && f.committed && f.deactivate(), ws();
       });
-    } catch (_) {
-      u.reject(_), vs();
+    } catch (y) {
+      u.reject(y), ws();
     }
     var f = (
       /** @type {Batch} */
-      K
+      J
     );
     if (o) {
       var d = i.is_rendered();
-      i.update_pending_count(1), f.increment(d), (p = l.get(f)) == null || p.reject(kn), l.delete(f), l.set(f, u);
+      i.update_pending_count(1), f.increment(d), (p = l.get(f)) == null || p.reject(Mn), l.delete(f), l.set(f, u);
     }
-    const h = (_, x = void 0) => {
-      if (f.activate(), x)
-        x !== kn && (a.f |= yn, gr(a, x));
+    const h = (y, E = void 0) => {
+      if (f.activate(), E)
+        E !== Mn && (a.f |= xn, yr(a, E));
       else {
-        (a.f & yn) !== 0 && (a.f ^= yn), gr(a, _);
-        for (const [y, b] of l) {
-          if (l.delete(y), y === f) break;
-          b.reject(kn);
+        (a.f & xn) !== 0 && (a.f ^= xn), yr(a, y);
+        for (const [_, x] of l) {
+          if (l.delete(_), _ === f) break;
+          x.reject(Mn);
         }
       }
       o && (i.update_pending_count(-1), f.decrement(d));
     };
-    u.promise.then(h, (_) => h(null, _ || "unknown"));
-  }), zu(() => {
+    u.promise.then(h, (y) => h(null, y || "unknown"));
+  }), Uu(() => {
     for (const u of l.values())
-      u.reject(kn);
+      u.reject(Mn);
   }), new Promise((u) => {
     function f(d) {
       function h() {
@@ -974,16 +974,16 @@ function Du(e, t, n) {
   });
 }
 // @__NO_SIDE_EFFECTS__
-function Sn(e) {
-  const t = /* @__PURE__ */ Hi(e);
-  return Fo(t), t;
+function Nn(e) {
+  const t = /* @__PURE__ */ Wi(e);
+  return Vo(t), t;
 }
 // @__NO_SIDE_EFFECTS__
-function _o(e) {
-  const t = /* @__PURE__ */ Hi(e);
-  return t.equals = ro, t;
+function xo(e) {
+  const t = /* @__PURE__ */ Wi(e);
+  return t.equals = oo, t;
 }
-function Ou(e) {
+function zu(e) {
   var t = e.effects;
   if (t !== null) {
     e.effects = null;
@@ -994,10 +994,10 @@ function Ou(e) {
       );
   }
 }
-function Fu(e) {
+function Hu(e) {
   for (var t = e.parent; t !== null; ) {
-    if ((t.f & Ce) === 0)
-      return (t.f & on) === 0 ? (
+    if ((t.f & Te) === 0)
+      return (t.f & un) === 0 ? (
         /** @type {Effect} */
         t
       ) : null;
@@ -1005,127 +1005,127 @@ function Fu(e) {
   }
   return null;
 }
-function Ds(e) {
-  var t, n = J;
-  Vt(Fu(e));
+function qs(e) {
+  var t, n = te;
+  qt(Hu(e));
   try {
-    e.f &= ~Wn, Ou(e), t = Vo(e);
+    e.f &= ~Gn, zu(e), t = Bo(e);
   } finally {
-    Vt(n);
+    qt(n);
   }
   return t;
 }
-function mo(e) {
-  var t = Ds(e);
-  if (!e.equals(t) && (e.wv = Lo(), (!(K != null && K.is_fork) || e.deps === null) && (e.v = t, e.deps === null))) {
-    ge(e, Ae);
+function bo(e) {
+  var t = qs(e);
+  if (!e.equals(t) && (e.wv = Ho(), (!(J != null && J.is_fork) || e.deps === null) && (e.v = t, e.deps === null))) {
+    ve(e, be);
     return;
   }
-  $n || (Se !== null ? (Fs() || K != null && K.is_fork) && Se.set(e, t) : Ps(e));
+  En || (Ee !== null ? (zs() || J != null && J.is_fork) && Ee.set(e, t) : Ls(e));
 }
-function Iu(e) {
+function Yu(e) {
   var t, n;
   if (e.effects !== null)
     for (const r of e.effects)
-      (r.teardown || r.ac) && ((t = r.teardown) == null || t.call(r), (n = r.ac) == null || n.abort(kn), r.teardown = ru, r.ac = null, qr(r, 0), Vs(r));
+      (r.teardown || r.ac) && ((t = r.teardown) == null || t.call(r), (n = r.ac) == null || n.abort(Mn), r.teardown = uu, r.ac = null, zr(r, 0), Bs(r));
 }
-function yo(e) {
+function $o(e) {
   if (e.effects !== null)
     for (const t of e.effects)
-      t.teardown && _r(t);
+      t.teardown && wr(t);
 }
-let gs = /* @__PURE__ */ new Set();
-const xn = /* @__PURE__ */ new Map();
-let wo = !1;
-function Un(e, t) {
+let xs = /* @__PURE__ */ new Set();
+const $n = /* @__PURE__ */ new Map();
+let Ao = !1;
+function Kn(e, t) {
   var n = {
     f: 0,
     // TODO ideally we could skip this altogether, but it causes type errors
     v: e,
     reactions: null,
-    equals: no,
+    equals: ao,
     rv: 0,
     wv: 0
   };
   return n;
 }
 // @__NO_SIDE_EFFECTS__
-function $e(e, t) {
-  const n = Un(e);
-  return Fo(n), n;
+function xe(e, t) {
+  const n = Kn(e);
+  return Vo(n), n;
 }
 // @__NO_SIDE_EFFECTS__
-function xo(e, t = !1, n = !0) {
-  const r = Un(e);
-  return t || (r.equals = ro), r;
+function Eo(e, t = !1, n = !0) {
+  const r = Kn(e);
+  return t || (r.equals = oo), r;
 }
-function ve(e, t, n = !1) {
-  B !== null && // since we are untracking the function inside `$inspect.with` we need to add this check
+function pe(e, t, n = !1) {
+  X !== null && // since we are untracking the function inside `$inspect.with` we need to add this check
   // to ensure we error if state is set inside an inspect effect
-  (!At || (B.f & fa) !== 0) && io() && (B.f & (Ce | cn | Ms | fa)) !== 0 && (dt === null || !hr.call(dt, e)) && wu();
-  let r = n ? Pn(t) : t;
-  return gr(e, r);
+  (!bt || (X.f & pa) !== 0) && lo() && (X.f & (Te | dn | Fs | pa)) !== 0 && (vt === null || !vr.call(vt, e)) && Tu();
+  let r = n ? On(t) : t;
+  return yr(e, r);
 }
-function gr(e, t) {
+function yr(e, t) {
   if (!e.equals(t)) {
     var n = e.v;
-    $n ? xn.set(e, t) : xn.set(e, n), e.v = t;
-    var r = ln.ensure();
-    if (r.capture(e, n), (e.f & Ce) !== 0) {
+    En ? $n.set(e, t) : $n.set(e, n), e.v = t;
+    var r = fn.ensure();
+    if (r.capture(e, n), (e.f & Te) !== 0) {
       const i = (
         /** @type {Derived} */
         e
       );
-      (e.f & Ne) !== 0 && Ds(i), Ps(i);
+      (e.f & Re) !== 0 && qs(i), Ls(i);
     }
-    e.wv = Lo(), bo(e, Ne), J !== null && (J.f & Ae) !== 0 && (J.f & (Tt | An)) === 0 && (lt === null ? Uu([e]) : lt.push(e)), !r.is_fork && gs.size > 0 && !wo && Lu();
+    e.wv = Ho(), To(e, Re), te !== null && (te.f & be) !== 0 && (te.f & (At | Tn)) === 0 && (ft === null ? Qu([e]) : ft.push(e)), !r.is_fork && xs.size > 0 && !Ao && Bu();
   }
   return t;
 }
-function Lu() {
-  wo = !1;
-  for (const e of gs)
-    (e.f & Ae) !== 0 && ge(e, Et), jr(e) && _r(e);
-  gs.clear();
+function Bu() {
+  Ao = !1;
+  for (const e of xs)
+    (e.f & be) !== 0 && ve(e, $t), Zr(e) && wr(e);
+  xs.clear();
 }
-function Ir(e) {
-  ve(e, e.v + 1);
+function qr(e) {
+  pe(e, e.v + 1);
 }
-function bo(e, t) {
+function To(e, t) {
   var n = e.reactions;
   if (n !== null)
     for (var r = n.length, i = 0; i < r; i++) {
-      var s = n[i], a = s.f, o = (a & Ne) === 0;
-      if (o && ge(s, t), (a & Ce) !== 0) {
+      var s = n[i], a = s.f, o = (a & Re) === 0;
+      if (o && ve(s, t), (a & Te) !== 0) {
         var l = (
           /** @type {Derived} */
           s
         );
-        Se == null || Se.delete(l), (a & Wn) === 0 && (a & ht && (s.f |= Wn), bo(l, Et));
-      } else o && ((a & cn) !== 0 && wt !== null && wt.add(
+        Ee == null || Ee.delete(l), (a & Gn) === 0 && (a & pt && (s.f |= Gn), To(l, $t));
+      } else o && ((a & dn) !== 0 && mt !== null && mt.add(
         /** @type {Effect} */
         s
-      ), $t(
+      ), xt(
         /** @type {Effect} */
         s
       ));
     }
 }
-function Pn(e) {
-  if (typeof e != "object" || e === null || Or in e)
+function On(e) {
+  if (typeof e != "object" || e === null || Fr in e)
     return e;
-  const t = Ka(e);
-  if (t !== tu && t !== nu)
+  const t = Qa(e);
+  if (t !== ou && t !== lu)
     return e;
-  var n = /* @__PURE__ */ new Map(), r = Ga(e), i = /* @__PURE__ */ $e(0), s = Bn, a = (o) => {
-    if (Bn === s)
+  var n = /* @__PURE__ */ new Map(), r = Za(e), i = /* @__PURE__ */ xe(0), s = Wn, a = (o) => {
+    if (Wn === s)
       return o();
-    var l = B, u = Bn;
-    pt(null), pa(s);
+    var l = X, u = Wn;
+    gt(null), ma(s);
     var f = o();
-    return pt(l), pa(u), f;
+    return gt(l), ma(u), f;
   };
-  return r && n.set("length", /* @__PURE__ */ $e(
+  return r && n.set("length", /* @__PURE__ */ xe(
     /** @type {any[]} */
     e.length
   )), new Proxy(
@@ -1133,35 +1133,35 @@ function Pn(e) {
     e,
     {
       defineProperty(o, l, u) {
-        (!("value" in u) || u.configurable === !1 || u.enumerable === !1 || u.writable === !1) && mu();
+        (!("value" in u) || u.configurable === !1 || u.enumerable === !1 || u.writable === !1) && Au();
         var f = n.get(l);
         return f === void 0 ? a(() => {
-          var d = /* @__PURE__ */ $e(u.value);
+          var d = /* @__PURE__ */ xe(u.value);
           return n.set(l, d), d;
-        }) : ve(f, u.value, !0), !0;
+        }) : pe(f, u.value, !0), !0;
       },
       deleteProperty(o, l) {
         var u = n.get(l);
         if (u === void 0) {
           if (l in o) {
-            const f = a(() => /* @__PURE__ */ $e(Re));
-            n.set(l, f), Ir(i);
+            const f = a(() => /* @__PURE__ */ xe(Ae));
+            n.set(l, f), qr(i);
           }
         } else
-          ve(u, Re), Ir(i);
+          pe(u, Ae), qr(i);
         return !0;
       },
       get(o, l, u) {
         var p;
-        if (l === Or)
+        if (l === Fr)
           return e;
         var f = n.get(l), d = l in o;
-        if (f === void 0 && (!d || (p = Hn(o, l)) != null && p.writable) && (f = a(() => {
-          var _ = Pn(d ? o[l] : Re), x = /* @__PURE__ */ $e(_);
-          return x;
+        if (f === void 0 && (!d || (p = Bn(o, l)) != null && p.writable) && (f = a(() => {
+          var y = On(d ? o[l] : Ae), E = /* @__PURE__ */ xe(y);
+          return E;
         }), n.set(l, f)), f !== void 0) {
-          var h = $(f);
-          return h === Re ? void 0 : h;
+          var h = A(f);
+          return h === Ae ? void 0 : h;
         }
         return Reflect.get(o, l, u);
       },
@@ -1169,10 +1169,10 @@ function Pn(e) {
         var u = Reflect.getOwnPropertyDescriptor(o, l);
         if (u && "value" in u) {
           var f = n.get(l);
-          f && (u.value = $(f));
+          f && (u.value = A(f));
         } else if (u === void 0) {
           var d = n.get(l), h = d == null ? void 0 : d.v;
-          if (d !== void 0 && h !== Re)
+          if (d !== void 0 && h !== Ae)
             return {
               enumerable: !0,
               configurable: !0,
@@ -1184,16 +1184,16 @@ function Pn(e) {
       },
       has(o, l) {
         var h;
-        if (l === Or)
+        if (l === Fr)
           return !0;
-        var u = n.get(l), f = u !== void 0 && u.v !== Re || Reflect.has(o, l);
-        if (u !== void 0 || J !== null && (!f || (h = Hn(o, l)) != null && h.writable)) {
+        var u = n.get(l), f = u !== void 0 && u.v !== Ae || Reflect.has(o, l);
+        if (u !== void 0 || te !== null && (!f || (h = Bn(o, l)) != null && h.writable)) {
           u === void 0 && (u = a(() => {
-            var p = f ? Pn(o[l]) : Re, _ = /* @__PURE__ */ $e(p);
-            return _;
+            var p = f ? On(o[l]) : Ae, y = /* @__PURE__ */ xe(p);
+            return y;
           }), n.set(l, u));
-          var d = $(u);
-          if (d === Re)
+          var d = A(u);
+          if (d === Ae)
             return !1;
         }
         return f;
@@ -1204,168 +1204,168 @@ function Pn(e) {
         if (r && l === "length")
           for (var p = u; p < /** @type {Source<number>} */
           d.v; p += 1) {
-            var _ = n.get(p + "");
-            _ !== void 0 ? ve(_, Re) : p in o && (_ = a(() => /* @__PURE__ */ $e(Re)), n.set(p + "", _));
+            var y = n.get(p + "");
+            y !== void 0 ? pe(y, Ae) : p in o && (y = a(() => /* @__PURE__ */ xe(Ae)), n.set(p + "", y));
           }
         if (d === void 0)
-          (!h || (N = Hn(o, l)) != null && N.writable) && (d = a(() => /* @__PURE__ */ $e(void 0)), ve(d, Pn(u)), n.set(l, d));
+          (!h || (N = Bn(o, l)) != null && N.writable) && (d = a(() => /* @__PURE__ */ xe(void 0)), pe(d, On(u)), n.set(l, d));
         else {
-          h = d.v !== Re;
-          var x = a(() => Pn(u));
-          ve(d, x);
+          h = d.v !== Ae;
+          var E = a(() => On(u));
+          pe(d, E);
         }
-        var y = Reflect.getOwnPropertyDescriptor(o, l);
-        if (y != null && y.set && y.set.call(f, u), !h) {
+        var _ = Reflect.getOwnPropertyDescriptor(o, l);
+        if (_ != null && _.set && _.set.call(f, u), !h) {
           if (r && typeof l == "string") {
-            var b = (
+            var x = (
               /** @type {Source<number>} */
               n.get("length")
-            ), O = Number(l);
-            Number.isInteger(O) && O >= b.v && ve(b, O + 1);
+            ), D = Number(l);
+            Number.isInteger(D) && D >= x.v && pe(x, D + 1);
           }
-          Ir(i);
+          qr(i);
         }
         return !0;
       },
       ownKeys(o) {
-        $(i);
+        A(i);
         var l = Reflect.ownKeys(o).filter((d) => {
           var h = n.get(d);
-          return h === void 0 || h.v !== Re;
+          return h === void 0 || h.v !== Ae;
         });
         for (var [u, f] of n)
-          f.v !== Re && !(u in o) && l.push(u);
+          f.v !== Ae && !(u in o) && l.push(u);
         return l;
       },
       setPrototypeOf() {
-        yu();
+        Eu();
       }
     }
   );
 }
-var ha, $o, Ao, Eo;
-function _s() {
-  if (ha === void 0) {
-    ha = window, $o = /Firefox/.test(navigator.userAgent);
+var ga, Ro, So, Co;
+function bs() {
+  if (ga === void 0) {
+    ga = window, Ro = /Firefox/.test(navigator.userAgent);
     var e = Element.prototype, t = Node.prototype, n = Text.prototype;
-    Ao = Hn(t, "firstChild").get, Eo = Hn(t, "nextSibling").get, ua(e) && (e.__click = void 0, e.__className = void 0, e.__attributes = null, e.__style = void 0, e.__e = void 0), ua(n) && (n.__t = void 0);
+    So = Bn(t, "firstChild").get, Co = Bn(t, "nextSibling").get, da(e) && (e.__click = void 0, e.__className = void 0, e.__attributes = null, e.__style = void 0, e.__e = void 0), da(n) && (n.__t = void 0);
   }
 }
 function rt(e = "") {
   return document.createTextNode(e);
 }
 // @__NO_SIDE_EFFECTS__
-function un(e) {
+function cn(e) {
   return (
     /** @type {TemplateNode | null} */
-    Ao.call(e)
+    So.call(e)
   );
 }
 // @__NO_SIDE_EFFECTS__
-function Ht(e) {
+function zt(e) {
   return (
     /** @type {TemplateNode | null} */
-    Eo.call(e)
+    Co.call(e)
   );
 }
-function Be(e, t) {
-  if (!j)
-    return /* @__PURE__ */ un(e);
-  var n = /* @__PURE__ */ un(X);
+function He(e, t) {
+  if (!Z)
+    return /* @__PURE__ */ cn(e);
+  var n = /* @__PURE__ */ cn(W);
   if (n === null)
-    n = X.appendChild(rt());
-  else if (t && n.nodeType !== Kr) {
+    n = W.appendChild(rt());
+  else if (t && n.nodeType !== Jr) {
     var r = rt();
-    return n == null || n.before(r), Ie(r), r;
+    return n == null || n.before(r), Fe(r), r;
   }
-  return t && Yi(
+  return t && Ui(
     /** @type {Text} */
     n
-  ), Ie(n), n;
+  ), Fe(n), n;
 }
-function gn(e, t = !1) {
-  if (!j) {
-    var n = /* @__PURE__ */ un(e);
-    return n instanceof Comment && n.data === "" ? /* @__PURE__ */ Ht(n) : n;
+function mn(e, t = !1) {
+  if (!Z) {
+    var n = /* @__PURE__ */ cn(e);
+    return n instanceof Comment && n.data === "" ? /* @__PURE__ */ zt(n) : n;
   }
   if (t) {
-    if ((X == null ? void 0 : X.nodeType) !== Kr) {
+    if ((W == null ? void 0 : W.nodeType) !== Jr) {
       var r = rt();
-      return X == null || X.before(r), Ie(r), r;
+      return W == null || W.before(r), Fe(r), r;
     }
-    Yi(
+    Ui(
       /** @type {Text} */
-      X
+      W
     );
   }
-  return X;
+  return W;
 }
 function Ze(e, t = 1, n = !1) {
-  let r = j ? X : e;
+  let r = Z ? W : e;
   for (var i; t--; )
     i = r, r = /** @type {TemplateNode} */
-    /* @__PURE__ */ Ht(r);
-  if (!j)
+    /* @__PURE__ */ zt(r);
+  if (!Z)
     return r;
   if (n) {
-    if ((r == null ? void 0 : r.nodeType) !== Kr) {
+    if ((r == null ? void 0 : r.nodeType) !== Jr) {
       var s = rt();
-      return r === null ? i == null || i.after(s) : r.before(s), Ie(s), s;
+      return r === null ? i == null || i.after(s) : r.before(s), Fe(s), s;
     }
-    Yi(
+    Ui(
       /** @type {Text} */
       r
     );
   }
-  return Ie(r), r;
+  return Fe(r), r;
 }
-function To(e) {
+function No(e) {
   e.textContent = "";
 }
-function Ro() {
+function ko() {
   return !1;
 }
-function Os(e, t, n) {
+function Vs(e, t, n) {
   return (
     /** @type {T extends keyof HTMLElementTagNameMap ? HTMLElementTagNameMap[T] : Element} */
-    document.createElementNS(Ua, e, void 0)
+    document.createElementNS(Ja, e, void 0)
   );
 }
-function Yi(e) {
+function Ui(e) {
   if (
     /** @type {string} */
     e.nodeValue.length < 65536
   )
     return;
   let t = e.nextSibling;
-  for (; t !== null && t.nodeType === Kr; )
+  for (; t !== null && t.nodeType === Jr; )
     t.remove(), e.nodeValue += /** @type {string} */
     t.nodeValue, t = e.nextSibling;
 }
-function So(e) {
-  var t = B, n = J;
-  pt(null), Vt(null);
+function Po(e) {
+  var t = X, n = te;
+  gt(null), qt(null);
   try {
     return e();
   } finally {
-    pt(t), Vt(n);
+    gt(t), qt(n);
   }
 }
-function qu(e) {
-  J === null && (B === null && pu(), du()), $n && hu();
+function Xu(e) {
+  te === null && (X === null && wu(), yu()), En && mu();
 }
-function Vu(e, t) {
+function Wu(e, t) {
   var n = t.last;
   n === null ? t.last = t.first = e : (n.next = e, e.prev = n, t.last = e);
 }
-function Yt(e, t, n) {
-  var r = J;
+function Ht(e, t, n) {
+  var r = te;
   r !== null && (r.f & nt) !== 0 && (e |= nt);
   var i = {
     ctx: it,
     deps: null,
     nodes: null,
-    f: e | Ne | ht,
+    f: e | Re | pt,
     first: null,
     fn: t,
     last: null,
@@ -1379,35 +1379,35 @@ function Yt(e, t, n) {
   };
   if (n)
     try {
-      _r(i);
+      wr(i);
     } catch (o) {
       throw Le(i), o;
     }
-  else t !== null && $t(i);
+  else t !== null && xt(i);
   var s = i;
   if (n && s.deps === null && s.teardown === null && s.nodes === null && s.first === s.last && // either `null`, or a singular child
-  (s.f & jn) === 0 && (s = s.first, (e & cn) !== 0 && (e & dr) !== 0 && s !== null && (s.f |= dr)), s !== null && (s.parent = r, r !== null && Vu(s, r), B !== null && (B.f & Ce) !== 0 && (e & An) === 0)) {
+  (s.f & Zn) === 0 && (s = s.first, (e & dn) !== 0 && (e & gr) !== 0 && s !== null && (s.f |= gr)), s !== null && (s.parent = r, r !== null && Wu(s, r), X !== null && (X.f & Te) !== 0 && (e & Tn) === 0)) {
     var a = (
       /** @type {Derived} */
-      B
+      X
     );
     (a.effects ?? (a.effects = [])).push(s);
   }
   return i;
 }
-function Fs() {
-  return B !== null && !At;
+function zs() {
+  return X !== null && !bt;
 }
-function zu(e) {
-  const t = Yt(Fi, null, !1);
-  return ge(t, Ae), t.teardown = e, t;
+function Uu(e) {
+  const t = Ht(Vi, null, !1);
+  return ve(t, be), t.teardown = e, t;
 }
-function Is(e) {
-  qu();
+function Ri(e) {
+  Xu();
   var t = (
     /** @type {Effect} */
-    J.f
-  ), n = !B && (t & Tt) !== 0 && (t & wr) === 0;
+    te.f
+  ), n = !X && (t & At) !== 0 && (t & $r) === 0;
   if (n) {
     var r = (
       /** @type {ComponentContext} */
@@ -1415,105 +1415,105 @@ function Is(e) {
     );
     (r.e ?? (r.e = [])).push(e);
   } else
-    return Co(e);
+    return Mo(e);
 }
-function Co(e) {
-  return Yt(Lr | au, e, !1);
+function Mo(e) {
+  return Ht(Vr | hu, e, !1);
 }
-function Hu(e) {
-  ln.ensure();
-  const t = Yt(An | jn, e, !0);
+function Gu(e) {
+  fn.ensure();
+  const t = Ht(Tn | Zn, e, !0);
   return () => {
     Le(t);
   };
 }
-function Yu(e) {
-  ln.ensure();
-  const t = Yt(An | jn, e, !0);
+function Ku(e) {
+  fn.ensure();
+  const t = Ht(Tn | Zn, e, !0);
   return (n = {}) => new Promise((r) => {
-    n.outro ? Yn(t, () => {
+    n.outro ? Xn(t, () => {
       Le(t), r(void 0);
     }) : (Le(t), r(void 0));
   });
 }
-function No(e) {
-  return Yt(Lr, e, !1);
+function Do(e) {
+  return Ht(Vr, e, !1);
 }
-function Bu(e) {
-  return Yt(Ms | jn, e, !0);
+function ju(e) {
+  return Ht(Fs | Zn, e, !0);
 }
-function Ls(e, t = 0) {
-  return Yt(Fi | t, e, !0);
+function Hs(e, t = 0) {
+  return Ht(Vi | t, e, !0);
 }
-function Zt(e, t = [], n = [], r = []) {
-  Mu(r, t, n, (i) => {
-    Yt(Fi, () => e(...i.map($)), !0);
+function en(e, t = [], n = [], r = []) {
+  Lu(r, t, n, (i) => {
+    Ht(Vi, () => e(...i.map(A)), !0);
   });
 }
-function qs(e, t = 0) {
-  var n = Yt(cn | t, e, !0);
+function Ys(e, t = 0) {
+  var n = Ht(dn | t, e, !0);
   return n;
 }
-function ct(e) {
-  return Yt(Tt | jn, e, !0);
+function dt(e) {
+  return Ht(At | Zn, e, !0);
 }
-function ko(e) {
+function Oo(e) {
   var t = e.teardown;
   if (t !== null) {
-    const n = $n, r = B;
-    da(!0), pt(null);
+    const n = En, r = X;
+    _a(!0), gt(null);
     try {
       t.call(null);
     } finally {
-      da(n), pt(r);
+      _a(n), gt(r);
     }
   }
 }
-function Vs(e, t = !1) {
+function Bs(e, t = !1) {
   var n = e.first;
   for (e.first = e.last = null; n !== null; ) {
     const i = n.ac;
-    i !== null && So(() => {
-      i.abort(kn);
+    i !== null && Po(() => {
+      i.abort(Mn);
     });
     var r = n.next;
-    (n.f & An) !== 0 ? n.parent = null : Le(n, t), n = r;
+    (n.f & Tn) !== 0 ? n.parent = null : Le(n, t), n = r;
   }
 }
-function Xu(e) {
+function Ju(e) {
   for (var t = e.first; t !== null; ) {
     var n = t.next;
-    (t.f & Tt) === 0 && Le(t), t = n;
+    (t.f & At) === 0 && Le(t), t = n;
   }
 }
 function Le(e, t = !0) {
   var n = !1;
-  (t || (e.f & Qa) !== 0) && e.nodes !== null && e.nodes.end !== null && (Wu(
+  (t || (e.f & ro) !== 0) && e.nodes !== null && e.nodes.end !== null && (Zu(
     e.nodes.start,
     /** @type {TemplateNode} */
     e.nodes.end
-  ), n = !0), Vs(e, t && !n), qr(e, 0), ge(e, on);
+  ), n = !0), Bs(e, t && !n), zr(e, 0), ve(e, un);
   var r = e.nodes && e.nodes.t;
   if (r !== null)
     for (const s of r)
       s.stop();
-  ko(e);
+  Oo(e);
   var i = e.parent;
-  i !== null && i.first !== null && Mo(e), e.next = e.prev = e.teardown = e.ctx = e.deps = e.fn = e.nodes = e.ac = null;
+  i !== null && i.first !== null && Io(e), e.next = e.prev = e.teardown = e.ctx = e.deps = e.fn = e.nodes = e.ac = null;
 }
-function Wu(e, t) {
+function Zu(e, t) {
   for (; e !== null; ) {
-    var n = e === t ? null : /* @__PURE__ */ Ht(e);
+    var n = e === t ? null : /* @__PURE__ */ zt(e);
     e.remove(), e = n;
   }
 }
-function Mo(e) {
+function Io(e) {
   var t = e.parent, n = e.prev, r = e.next;
   n !== null && (n.next = r), r !== null && (r.prev = n), t !== null && (t.first === e && (t.first = r), t.last === e && (t.last = n));
 }
-function Yn(e, t, n = !0) {
+function Xn(e, t, n = !0) {
   var r = [];
-  Po(e, r, !0);
+  Fo(e, r, !0);
   var i = () => {
     n && Le(e), t && t();
   }, s = r.length;
@@ -1524,7 +1524,7 @@ function Yn(e, t, n = !0) {
   } else
     i();
 }
-function Po(e, t, n) {
+function Fo(e, t, n) {
   if ((e.f & nt) === 0) {
     e.f ^= nt;
     var r = e.nodes && e.nodes.t;
@@ -1532,23 +1532,23 @@ function Po(e, t, n) {
       for (const o of r)
         (o.is_global || n) && t.push(o);
     for (var i = e.first; i !== null; ) {
-      var s = i.next, a = (i.f & dr) !== 0 || // If this is a branch effect without a block effect parent,
+      var s = i.next, a = (i.f & gr) !== 0 || // If this is a branch effect without a block effect parent,
       // it means the parent block effect was pruned. In that case,
       // transparency information was transferred to the branch effect.
-      (i.f & Tt) !== 0 && (e.f & cn) !== 0;
-      Po(i, t, a ? n : !1), i = s;
+      (i.f & At) !== 0 && (e.f & dn) !== 0;
+      Fo(i, t, a ? n : !1), i = s;
     }
   }
 }
-function zs(e) {
-  Do(e, !0);
+function Xs(e) {
+  Lo(e, !0);
 }
-function Do(e, t) {
+function Lo(e, t) {
   if ((e.f & nt) !== 0) {
-    e.f ^= nt, (e.f & Ae) === 0 && (ge(e, Ne), $t(e));
+    e.f ^= nt, (e.f & be) === 0 && (ve(e, Re), xt(e));
     for (var n = e.first; n !== null; ) {
-      var r = n.next, i = (n.f & dr) !== 0 || (n.f & Tt) !== 0;
-      Do(n, i ? t : !1), n = r;
+      var r = n.next, i = (n.f & gr) !== 0 || (n.f & At) !== 0;
+      Lo(n, i ? t : !1), n = r;
     }
     var s = e.nodes && e.nodes.t;
     if (s !== null)
@@ -1556,259 +1556,259 @@ function Do(e, t) {
         (a.is_global || t) && a.in();
   }
 }
-function Oo(e, t) {
+function qo(e, t) {
   if (e.nodes)
     for (var n = e.nodes.start, r = e.nodes.end; n !== null; ) {
-      var i = n === r ? null : /* @__PURE__ */ Ht(n);
+      var i = n === r ? null : /* @__PURE__ */ zt(n);
       t.append(n), n = i;
     }
 }
-let ci = !1, $n = !1;
-function da(e) {
-  $n = e;
+let pi = !1, En = !1;
+function _a(e) {
+  En = e;
 }
-let B = null, At = !1;
-function pt(e) {
-  B = e;
+let X = null, bt = !1;
+function gt(e) {
+  X = e;
 }
-let J = null;
-function Vt(e) {
-  J = e;
+let te = null;
+function qt(e) {
+  te = e;
 }
-let dt = null;
-function Fo(e) {
-  B !== null && (dt === null ? dt = [e] : dt.push(e));
+let vt = null;
+function Vo(e) {
+  X !== null && (vt === null ? vt = [e] : vt.push(e));
 }
-let Ge = null, Qe = 0, lt = null;
-function Uu(e) {
-  lt = e;
+let We = null, Qe = 0, ft = null;
+function Qu(e) {
+  ft = e;
 }
-let Io = 1, Dn = 0, Bn = Dn;
-function pa(e) {
-  Bn = e;
+let zo = 1, In = 0, Wn = In;
+function ma(e) {
+  Wn = e;
 }
-function Lo() {
-  return ++Io;
+function Ho() {
+  return ++zo;
 }
-function jr(e) {
+function Zr(e) {
   var t = e.f;
-  if ((t & Ne) !== 0)
+  if ((t & Re) !== 0)
     return !0;
-  if (t & Ce && (e.f &= ~Wn), (t & Et) !== 0) {
+  if (t & Te && (e.f &= ~Gn), (t & $t) !== 0) {
     for (var n = (
       /** @type {Value[]} */
       e.deps
     ), r = n.length, i = 0; i < r; i++) {
       var s = n[i];
-      if (jr(
+      if (Zr(
         /** @type {Derived} */
         s
-      ) && mo(
+      ) && bo(
         /** @type {Derived} */
         s
       ), s.wv > e.wv)
         return !0;
     }
-    (t & ht) !== 0 && // During time traveling we don't want to reset the status so that
+    (t & pt) !== 0 && // During time traveling we don't want to reset the status so that
     // traversal of the graph in the other batches still happens
-    Se === null && ge(e, Ae);
+    Ee === null && ve(e, be);
   }
   return !1;
 }
-function qo(e, t, n = !0) {
+function Yo(e, t, n = !0) {
   var r = e.reactions;
-  if (r !== null && !(dt !== null && hr.call(dt, e)))
+  if (r !== null && !(vt !== null && vr.call(vt, e)))
     for (var i = 0; i < r.length; i++) {
       var s = r[i];
-      (s.f & Ce) !== 0 ? qo(
+      (s.f & Te) !== 0 ? Yo(
         /** @type {Derived} */
         s,
         t,
         !1
-      ) : t === s && (n ? ge(s, Ne) : (s.f & Ae) !== 0 && ge(s, Et), $t(
+      ) : t === s && (n ? ve(s, Re) : (s.f & be) !== 0 && ve(s, $t), xt(
         /** @type {Effect} */
         s
       ));
     }
 }
-function Vo(e) {
-  var x;
-  var t = Ge, n = Qe, r = lt, i = B, s = dt, a = it, o = At, l = Bn, u = e.f;
-  Ge = /** @type {null | Value[]} */
-  null, Qe = 0, lt = null, B = (u & (Tt | An)) === 0 ? e : null, dt = null, pr(e.ctx), At = !1, Bn = ++Dn, e.ac !== null && (So(() => {
-    e.ac.abort(kn);
+function Bo(e) {
+  var E;
+  var t = We, n = Qe, r = ft, i = X, s = vt, a = it, o = bt, l = Wn, u = e.f;
+  We = /** @type {null | Value[]} */
+  null, Qe = 0, ft = null, X = (u & (At | Tn)) === 0 ? e : null, vt = null, _r(e.ctx), bt = !1, Wn = ++In, e.ac !== null && (Po(() => {
+    e.ac.abort(Mn);
   }), e.ac = null);
   try {
-    e.f |= ls;
+    e.f |= ds;
     var f = (
       /** @type {Function} */
       e.fn
     ), d = f();
-    e.f |= wr;
-    var h = e.deps, p = K == null ? void 0 : K.is_fork;
-    if (Ge !== null) {
-      var _;
-      if (p || qr(e, Qe), h !== null && Qe > 0)
-        for (h.length = Qe + Ge.length, _ = 0; _ < Ge.length; _++)
-          h[Qe + _] = Ge[_];
+    e.f |= $r;
+    var h = e.deps, p = J == null ? void 0 : J.is_fork;
+    if (We !== null) {
+      var y;
+      if (p || zr(e, Qe), h !== null && Qe > 0)
+        for (h.length = Qe + We.length, y = 0; y < We.length; y++)
+          h[Qe + y] = We[y];
       else
-        e.deps = h = Ge;
-      if (Fs() && (e.f & ht) !== 0)
-        for (_ = Qe; _ < h.length; _++)
-          ((x = h[_]).reactions ?? (x.reactions = [])).push(e);
-    } else !p && h !== null && Qe < h.length && (qr(e, Qe), h.length = Qe);
-    if (io() && lt !== null && !At && h !== null && (e.f & (Ce | Et | Ne)) === 0)
-      for (_ = 0; _ < /** @type {Source[]} */
-      lt.length; _++)
-        qo(
-          lt[_],
+        e.deps = h = We;
+      if (zs() && (e.f & pt) !== 0)
+        for (y = Qe; y < h.length; y++)
+          ((E = h[y]).reactions ?? (E.reactions = [])).push(e);
+    } else !p && h !== null && Qe < h.length && (zr(e, Qe), h.length = Qe);
+    if (lo() && ft !== null && !bt && h !== null && (e.f & (Te | $t | Re)) === 0)
+      for (y = 0; y < /** @type {Source[]} */
+      ft.length; y++)
+        Yo(
+          ft[y],
           /** @type {Effect} */
           e
         );
     if (i !== null && i !== e) {
-      if (Dn++, i.deps !== null)
-        for (let y = 0; y < n; y += 1)
-          i.deps[y].rv = Dn;
+      if (In++, i.deps !== null)
+        for (let _ = 0; _ < n; _ += 1)
+          i.deps[_].rv = In;
       if (t !== null)
-        for (const y of t)
-          y.rv = Dn;
-      lt !== null && (r === null ? r = lt : r.push(.../** @type {Source[]} */
-      lt));
+        for (const _ of t)
+          _.rv = In;
+      ft !== null && (r === null ? r = ft : r.push(.../** @type {Source[]} */
+      ft));
     }
-    return (e.f & yn) !== 0 && (e.f ^= yn), d;
-  } catch (y) {
-    return ao(y);
+    return (e.f & xn) !== 0 && (e.f ^= xn), d;
+  } catch (_) {
+    return fo(_);
   } finally {
-    e.f ^= ls, Ge = t, Qe = n, lt = r, B = i, dt = s, pr(a), At = o, Bn = l;
+    e.f ^= ds, We = t, Qe = n, ft = r, X = i, vt = s, _r(a), bt = o, Wn = l;
   }
 }
-function Gu(e, t) {
+function ef(e, t) {
   let n = t.reactions;
   if (n !== null) {
-    var r = Ql.call(n, e);
+    var r = su.call(n, e);
     if (r !== -1) {
       var i = n.length - 1;
       i === 0 ? n = t.reactions = null : (n[r] = n[i], n.pop());
     }
   }
-  if (n === null && (t.f & Ce) !== 0 && // Destroying a child effect while updating a parent effect can cause a dependency to appear
+  if (n === null && (t.f & Te) !== 0 && // Destroying a child effect while updating a parent effect can cause a dependency to appear
   // to be unused, when in fact it is used by the currently-updating parent. Checking `new_deps`
   // allows us to skip the expensive work of disconnecting and immediately reconnecting it
-  (Ge === null || !hr.call(Ge, t))) {
+  (We === null || !vr.call(We, t))) {
     var s = (
       /** @type {Derived} */
       t
     );
-    (s.f & ht) !== 0 && (s.f ^= ht, s.f &= ~Wn), Ps(s), Iu(s), qr(s, 0);
+    (s.f & pt) !== 0 && (s.f ^= pt, s.f &= ~Gn), Ls(s), Yu(s), zr(s, 0);
   }
 }
-function qr(e, t) {
+function zr(e, t) {
   var n = e.deps;
   if (n !== null)
     for (var r = t; r < n.length; r++)
-      Gu(e, n[r]);
+      ef(e, n[r]);
 }
-function _r(e) {
+function wr(e) {
   var t = e.f;
-  if ((t & on) === 0) {
-    ge(e, Ae);
-    var n = J, r = ci;
-    J = e, ci = !0;
+  if ((t & un) === 0) {
+    ve(e, be);
+    var n = te, r = pi;
+    te = e, pi = !0;
     try {
-      (t & (cn | Ja)) !== 0 ? Xu(e) : Vs(e), ko(e);
-      var i = Vo(e);
-      e.teardown = typeof i == "function" ? i : null, e.wv = Io;
+      (t & (dn | to)) !== 0 ? Ju(e) : Bs(e), Oo(e);
+      var i = Bo(e);
+      e.teardown = typeof i == "function" ? i : null, e.wv = zo;
       var s;
-      os && Au && (e.f & Ne) !== 0 && e.deps;
+      hs && Nu && (e.f & Re) !== 0 && e.deps;
     } finally {
-      ci = r, J = n;
+      pi = r, te = n;
     }
   }
 }
-function $(e) {
-  var t = e.f, n = (t & Ce) !== 0;
-  if (B !== null && !At) {
-    var r = J !== null && (J.f & on) !== 0;
-    if (!r && (dt === null || !hr.call(dt, e))) {
-      var i = B.deps;
-      if ((B.f & ls) !== 0)
-        e.rv < Dn && (e.rv = Dn, Ge === null && i !== null && i[Qe] === e ? Qe++ : Ge === null ? Ge = [e] : Ge.push(e));
+function A(e) {
+  var t = e.f, n = (t & Te) !== 0;
+  if (X !== null && !bt) {
+    var r = te !== null && (te.f & un) !== 0;
+    if (!r && (vt === null || !vr.call(vt, e))) {
+      var i = X.deps;
+      if ((X.f & ds) !== 0)
+        e.rv < In && (e.rv = In, We === null && i !== null && i[Qe] === e ? Qe++ : We === null ? We = [e] : We.push(e));
       else {
-        (B.deps ?? (B.deps = [])).push(e);
+        (X.deps ?? (X.deps = [])).push(e);
         var s = e.reactions;
-        s === null ? e.reactions = [B] : hr.call(s, B) || s.push(B);
+        s === null ? e.reactions = [X] : vr.call(s, X) || s.push(X);
       }
     }
   }
-  if ($n && xn.has(e))
-    return xn.get(e);
+  if (En && $n.has(e))
+    return $n.get(e);
   if (n) {
     var a = (
       /** @type {Derived} */
       e
     );
-    if ($n) {
+    if (En) {
       var o = a.v;
-      return ((a.f & Ae) === 0 && a.reactions !== null || Ho(a)) && (o = Ds(a)), xn.set(a, o), o;
+      return ((a.f & be) === 0 && a.reactions !== null || Wo(a)) && (o = qs(a)), $n.set(a, o), o;
     }
-    var l = (a.f & ht) === 0 && !At && B !== null && (ci || (B.f & ht) !== 0), u = (a.f & wr) === 0;
-    jr(a) && (l && (a.f |= ht), mo(a)), l && !u && (yo(a), zo(a));
+    var l = (a.f & pt) === 0 && !bt && X !== null && (pi || (X.f & pt) !== 0), u = (a.f & $r) === 0;
+    Zr(a) && (l && (a.f |= pt), bo(a)), l && !u && ($o(a), Xo(a));
   }
-  if (Se != null && Se.has(e))
-    return Se.get(e);
-  if ((e.f & yn) !== 0)
+  if (Ee != null && Ee.has(e))
+    return Ee.get(e);
+  if ((e.f & xn) !== 0)
     throw e.v;
   return e.v;
 }
-function zo(e) {
-  if (e.f |= ht, e.deps !== null)
+function Xo(e) {
+  if (e.f |= pt, e.deps !== null)
     for (const t of e.deps)
-      (t.reactions ?? (t.reactions = [])).push(e), (t.f & Ce) !== 0 && (t.f & ht) === 0 && (yo(
+      (t.reactions ?? (t.reactions = [])).push(e), (t.f & Te) !== 0 && (t.f & pt) === 0 && ($o(
         /** @type {Derived} */
         t
-      ), zo(
+      ), Xo(
         /** @type {Derived} */
         t
       ));
 }
-function Ho(e) {
-  if (e.v === Re) return !0;
+function Wo(e) {
+  if (e.v === Ae) return !0;
   if (e.deps === null) return !1;
   for (const t of e.deps)
-    if (xn.has(t) || (t.f & Ce) !== 0 && Ho(
+    if ($n.has(t) || (t.f & Te) !== 0 && Wo(
       /** @type {Derived} */
       t
     ))
       return !0;
   return !1;
 }
-function Bi(e) {
-  var t = At;
+function Qr(e) {
+  var t = bt;
   try {
-    return At = !0, e();
+    return bt = !0, e();
   } finally {
-    At = t;
+    bt = t;
   }
 }
-const Yo = /* @__PURE__ */ new Set(), ms = /* @__PURE__ */ new Set();
-function Ku(e) {
+const Uo = /* @__PURE__ */ new Set(), $s = /* @__PURE__ */ new Set();
+function tf(e) {
   for (var t = 0; t < e.length; t++)
-    Yo.add(e[t]);
-  for (var n of ms)
+    Uo.add(e[t]);
+  for (var n of $s)
     n(e);
 }
-let va = null;
-function ga(e) {
-  var y;
+let ya = null;
+function wa(e) {
+  var _;
   var t = this, n = (
     /** @type {Node} */
     t.ownerDocument
-  ), r = e.type, i = ((y = e.composedPath) == null ? void 0 : y.call(e)) || [], s = (
+  ), r = e.type, i = ((_ = e.composedPath) == null ? void 0 : _.call(e)) || [], s = (
     /** @type {null | Element} */
     i[0] || e.target
   );
-  va = e;
-  var a = 0, o = va === e && e.__root;
+  ya = e;
+  var a = 0, o = ya === e && e.__root;
   if (o) {
     var l = i.indexOf(o);
     if (l !== -1 && (t === document || t === /** @type {any} */
@@ -1823,140 +1823,140 @@ function ga(e) {
   }
   if (s = /** @type {Element} */
   i[a] || e.target, s !== t) {
-    bi(e, "currentTarget", {
+    Ei(e, "currentTarget", {
       configurable: !0,
       get() {
         return s || n;
       }
     });
-    var f = B, d = J;
-    pt(null), Vt(null);
+    var f = X, d = te;
+    gt(null), qt(null);
     try {
       for (var h, p = []; s !== null; ) {
-        var _ = s.assignedSlot || s.parentNode || /** @type {any} */
+        var y = s.assignedSlot || s.parentNode || /** @type {any} */
         s.host || null;
         try {
-          var x = s["__" + r];
-          x != null && (!/** @type {any} */
+          var E = s["__" + r];
+          E != null && (!/** @type {any} */
           s.disabled || // DOM could've been updated already by the time this is reached, so we check this as well
           // -> the target could not have been disabled because it emits the event in the first place
-          e.target === s) && x.call(s, e);
-        } catch (b) {
-          h ? p.push(b) : h = b;
+          e.target === s) && E.call(s, e);
+        } catch (x) {
+          h ? p.push(x) : h = x;
         }
-        if (e.cancelBubble || _ === t || _ === null)
+        if (e.cancelBubble || y === t || y === null)
           break;
-        s = _;
+        s = y;
       }
       if (h) {
-        for (let b of p)
+        for (let x of p)
           queueMicrotask(() => {
-            throw b;
+            throw x;
           });
         throw h;
       }
     } finally {
-      e.__root = t, delete e.currentTarget, pt(f), Vt(d);
+      e.__root = t, delete e.currentTarget, gt(f), qt(d);
     }
   }
 }
-var Ba, Xa;
-const ts = (Xa = (Ba = globalThis == null ? void 0 : globalThis.window) == null ? void 0 : Ba.trustedTypes) == null ? void 0 : /* @__PURE__ */ Xa.createPolicy(
+var Ga, Ka;
+const as = (Ka = (Ga = globalThis == null ? void 0 : globalThis.window) == null ? void 0 : Ga.trustedTypes) == null ? void 0 : /* @__PURE__ */ Ka.createPolicy(
   "svelte-trusted-html",
   {
     /** @param {string} html */
     createHTML: (e) => e
   }
 );
-function ju(e) {
+function nf(e) {
   return (
     /** @type {string} */
-    (ts == null ? void 0 : ts.createHTML(e)) ?? e
+    (as == null ? void 0 : as.createHTML(e)) ?? e
   );
 }
-function Bo(e, t = !1) {
-  var n = Os("template");
-  return e = e.replaceAll("<!>", "<!---->"), n.innerHTML = t ? ju(e) : e, n.content;
+function Go(e, t = !1) {
+  var n = Vs("template");
+  return e = e.replaceAll("<!>", "<!---->"), n.innerHTML = t ? nf(e) : e, n.content;
 }
-function bn(e, t) {
+function An(e, t) {
   var n = (
     /** @type {Effect} */
-    J
+    te
   );
   n.nodes === null && (n.nodes = { start: e, end: t, a: null, t: null });
 }
 // @__NO_SIDE_EFFECTS__
-function Bt(e, t) {
-  var n = (t & Jl) !== 0, r = (t & Zl) !== 0, i, s = !e.startsWith("<!>");
+function Yt(e, t) {
+  var n = (t & ru) !== 0, r = (t & iu) !== 0, i, s = !e.startsWith("<!>");
   return () => {
-    if (j)
-      return bn(X, null), X;
-    i === void 0 && (i = Bo(s ? e : "<!>" + e, !0), n || (i = /** @type {TemplateNode} */
-    /* @__PURE__ */ un(i)));
+    if (Z)
+      return An(W, null), W;
+    i === void 0 && (i = Go(s ? e : "<!>" + e, !0), n || (i = /** @type {TemplateNode} */
+    /* @__PURE__ */ cn(i)));
     var a = (
       /** @type {TemplateNode} */
-      r || $o ? document.importNode(i, !0) : i.cloneNode(!0)
+      r || Ro ? document.importNode(i, !0) : i.cloneNode(!0)
     );
     if (n) {
       var o = (
         /** @type {TemplateNode} */
-        /* @__PURE__ */ un(a)
+        /* @__PURE__ */ cn(a)
       ), l = (
         /** @type {TemplateNode} */
         a.lastChild
       );
-      bn(o, l);
+      An(o, l);
     } else
-      bn(a, a);
+      An(a, a);
     return a;
   };
 }
 // @__NO_SIDE_EFFECTS__
-function Ju(e, t, n = "svg") {
+function rf(e, t, n = "svg") {
   var r = !e.startsWith("<!>"), i = `<${n}>${r ? e : "<!>" + e}</${n}>`, s;
   return () => {
-    if (j)
-      return bn(X, null), X;
+    if (Z)
+      return An(W, null), W;
     if (!s) {
       var a = (
         /** @type {DocumentFragment} */
-        Bo(i, !0)
+        Go(i, !0)
       ), o = (
         /** @type {Element} */
-        /* @__PURE__ */ un(a)
+        /* @__PURE__ */ cn(a)
       );
       s = /** @type {Element} */
-      /* @__PURE__ */ un(o);
+      /* @__PURE__ */ cn(o);
     }
     var l = (
       /** @type {TemplateNode} */
       s.cloneNode(!0)
     );
-    return bn(l, l), l;
+    return An(l, l), l;
   };
 }
 // @__NO_SIDE_EFFECTS__
-function Zu(e, t) {
-  return /* @__PURE__ */ Ju(e, t, "svg");
+function sf(e, t) {
+  return /* @__PURE__ */ rf(e, t, "svg");
 }
-function _a(e = "") {
-  if (!j) {
+function xa(e = "") {
+  if (!Z) {
     var t = rt(e + "");
-    return bn(t, t), t;
+    return An(t, t), t;
   }
-  var n = X;
-  return n.nodeType !== Kr ? (n.before(n = rt()), Ie(n)) : Yi(
+  var n = W;
+  return n.nodeType !== Jr ? (n.before(n = rt()), Fe(n)) : Ui(
     /** @type {Text} */
     n
-  ), bn(n, n), n;
+  ), An(n, n), n;
 }
-function We(e, t) {
-  if (j) {
+function Be(e, t) {
+  if (Z) {
     var n = (
       /** @type {Effect & { nodes: EffectNodes }} */
-      J
+      te
     );
-    ((n.f & wr) === 0 || n.nodes.end === null) && (n.nodes.end = X), Li();
+    ((n.f & $r) === 0 || n.nodes.end === null) && (n.nodes.end = W), Hi();
     return;
   }
   e !== null && e.before(
@@ -1964,64 +1964,64 @@ function We(e, t) {
     t
   );
 }
-const Qu = ["touchstart", "touchmove"];
-function ef(e) {
-  return Qu.includes(e);
+const af = ["touchstart", "touchmove"];
+function of(e) {
+  return af.includes(e);
 }
-function _n(e, t) {
+function yn(e, t) {
   var n = t == null ? "" : typeof t == "object" ? t + "" : t;
   n !== (e.__t ?? (e.__t = e.nodeValue)) && (e.__t = n, e.nodeValue = n + "");
 }
-function Xo(e, t) {
-  return Wo(e, t);
+function Ko(e, t) {
+  return jo(e, t);
 }
-function tf(e, t) {
-  _s(), t.intro = t.intro ?? !1;
-  const n = t.target, r = j, i = X;
+function lf(e, t) {
+  bs(), t.intro = t.intro ?? !1;
+  const n = t.target, r = Z, i = W;
   try {
-    for (var s = /* @__PURE__ */ un(n); s && (s.nodeType !== xr || /** @type {Comment} */
-    s.data !== Ns); )
-      s = /* @__PURE__ */ Ht(s);
+    for (var s = /* @__PURE__ */ cn(n); s && (s.nodeType !== Ar || /** @type {Comment} */
+    s.data !== Os); )
+      s = /* @__PURE__ */ zt(s);
     if (!s)
-      throw cr;
-    an(!0), Ie(
+      throw pr;
+    ln(!0), Fe(
       /** @type {Comment} */
       s
     );
-    const a = Wo(e, { ...t, anchor: s });
-    return an(!1), /**  @type {Exports} */
+    const a = jo(e, { ...t, anchor: s });
+    return ln(!1), /**  @type {Exports} */
     a;
   } catch (a) {
     if (a instanceof Error && a.message.split(`
 `).some((o) => o.startsWith("https://svelte.dev/e/")))
       throw a;
-    return a !== cr && console.warn("Failed to hydrate: ", a), t.recover === !1 && gu(), _s(), To(n), an(!1), Xo(e, t);
+    return a !== pr && console.warn("Failed to hydrate: ", a), t.recover === !1 && bu(), bs(), No(n), ln(!1), Ko(e, t);
   } finally {
-    an(r), Ie(i);
+    ln(r), Fe(i);
   }
 }
-const ni = /* @__PURE__ */ new Map();
-function Wo(e, { target: t, anchor: n, props: r = {}, events: i, context: s, intro: a = !0 }) {
-  _s();
+const si = /* @__PURE__ */ new Map();
+function jo(e, { target: t, anchor: n, props: r = {}, events: i, context: s, intro: a = !0 }) {
+  bs();
   var o = /* @__PURE__ */ new Set(), l = (d) => {
     for (var h = 0; h < d.length; h++) {
       var p = d[h];
       if (!o.has(p)) {
         o.add(p);
-        var _ = ef(p);
-        for (const b of [t, document]) {
-          var x = ni.get(b);
-          x === void 0 && (x = /* @__PURE__ */ new Map(), ni.set(b, x));
-          var y = x.get(p);
-          y === void 0 ? (b.addEventListener(p, ga, { passive: _ }), x.set(p, 1)) : x.set(p, y + 1);
+        var y = of(p);
+        for (const x of [t, document]) {
+          var E = si.get(x);
+          E === void 0 && (E = /* @__PURE__ */ new Map(), si.set(x, E));
+          var _ = E.get(p);
+          _ === void 0 ? (x.addEventListener(p, wa, { passive: y }), E.set(p, 1)) : E.set(p, _ + 1);
         }
       }
     }
   };
-  l(Oi(Yo)), ms.add(l);
-  var u = void 0, f = Yu(() => {
+  l(qi(Uo)), $s.add(l);
+  var u = void 0, f = Ku(() => {
     var d = n ?? t.appendChild(rt());
-    return Nu(
+    return Iu(
       /** @type {TemplateNode} */
       d,
       {
@@ -2029,54 +2029,54 @@ function Wo(e, { target: t, anchor: n, props: r = {}, events: i, context: s, int
         }
       },
       (h) => {
-        qi({});
+        Yi({});
         var p = (
           /** @type {ComponentContext} */
           it
         );
-        if (s && (p.c = s), i && (r.$$events = i), j && bn(
+        if (s && (p.c = s), i && (r.$$events = i), Z && An(
           /** @type {TemplateNode} */
           h,
           null
-        ), u = e(h, r) || {}, j && (J.nodes.end = X, X === null || X.nodeType !== xr || /** @type {Comment} */
-        X.data !== ks))
-          throw Ii(), cr;
-        Vi();
+        ), u = e(h, r) || {}, Z && (te.nodes.end = W, W === null || W.nodeType !== Ar || /** @type {Comment} */
+        W.data !== Is))
+          throw zi(), pr;
+        Bi();
       }
     ), () => {
-      var x;
+      var E;
       for (var h of o)
-        for (const y of [t, document]) {
+        for (const _ of [t, document]) {
           var p = (
             /** @type {Map<string, number>} */
-            ni.get(y)
-          ), _ = (
+            si.get(_)
+          ), y = (
             /** @type {number} */
             p.get(h)
           );
-          --_ == 0 ? (y.removeEventListener(h, ga), p.delete(h), p.size === 0 && ni.delete(y)) : p.set(h, _);
+          --y == 0 ? (_.removeEventListener(h, wa), p.delete(h), p.size === 0 && si.delete(_)) : p.set(h, y);
         }
-      ms.delete(l), d !== n && ((x = d.parentNode) == null || x.removeChild(d));
+      $s.delete(l), d !== n && ((E = d.parentNode) == null || E.removeChild(d));
     };
   });
-  return ys.set(u, f), u;
+  return As.set(u, f), u;
 }
-let ys = /* @__PURE__ */ new WeakMap();
-function nf(e, t) {
-  const n = ys.get(e);
-  return n ? (ys.delete(e), n(t)) : Promise.resolve();
+let As = /* @__PURE__ */ new WeakMap();
+function uf(e, t) {
+  const n = As.get(e);
+  return n ? (As.delete(e), n(t)) : Promise.resolve();
 }
-var xt, It, tt, zn, Ur, Gr, Pi;
-class rf {
+var yt, It, tt, Yn, Kr, jr, Fi;
+class ff {
   /**
    * @param {TemplateNode} anchor
    * @param {boolean} transition
    */
   constructor(t, n = !0) {
     /** @type {TemplateNode} */
-    pe(this, "anchor");
+    de(this, "anchor");
     /** @type {Map<Batch, Key>} */
-    z(this, xt, /* @__PURE__ */ new Map());
+    H(this, yt, /* @__PURE__ */ new Map());
     /**
      * Map of keys to effects that are currently rendered in the DOM.
      * These effects are visible and actively part of the document tree.
@@ -2091,69 +2091,69 @@ class rf {
      * Can result in the entries `true->Effect` and `false->Effect`
      * @type {Map<Key, Effect>}
      */
-    z(this, It, /* @__PURE__ */ new Map());
+    H(this, It, /* @__PURE__ */ new Map());
     /**
      * Similar to #onscreen with respect to the keys, but contains branches that are not yet
      * in the DOM, because their insertion is deferred.
      * @type {Map<Key, Branch>}
      */
-    z(this, tt, /* @__PURE__ */ new Map());
+    H(this, tt, /* @__PURE__ */ new Map());
     /**
      * Keys of effects that are currently outroing
      * @type {Set<Key>}
      */
-    z(this, zn, /* @__PURE__ */ new Set());
+    H(this, Yn, /* @__PURE__ */ new Set());
     /**
      * Whether to pause (i.e. outro) on change, or destroy immediately.
      * This is necessary for `<svelte:element>`
      */
-    z(this, Ur, !0);
-    z(this, Gr, () => {
+    H(this, Kr, !0);
+    H(this, jr, () => {
       var t = (
         /** @type {Batch} */
-        K
+        J
       );
-      if (v(this, xt).has(t)) {
+      if (g(this, yt).has(t)) {
         var n = (
           /** @type {Key} */
-          v(this, xt).get(t)
-        ), r = v(this, It).get(n);
+          g(this, yt).get(t)
+        ), r = g(this, It).get(n);
         if (r)
-          zs(r), v(this, zn).delete(n);
+          Xs(r), g(this, Yn).delete(n);
         else {
-          var i = v(this, tt).get(n);
-          i && (v(this, It).set(n, i.effect), v(this, tt).delete(n), i.fragment.lastChild.remove(), this.anchor.before(i.fragment), r = i.effect);
+          var i = g(this, tt).get(n);
+          i && (g(this, It).set(n, i.effect), g(this, tt).delete(n), i.fragment.lastChild.remove(), this.anchor.before(i.fragment), r = i.effect);
         }
-        for (const [s, a] of v(this, xt)) {
-          if (v(this, xt).delete(s), s === t)
+        for (const [s, a] of g(this, yt)) {
+          if (g(this, yt).delete(s), s === t)
             break;
-          const o = v(this, tt).get(a);
-          o && (Le(o.effect), v(this, tt).delete(a));
+          const o = g(this, tt).get(a);
+          o && (Le(o.effect), g(this, tt).delete(a));
         }
-        for (const [s, a] of v(this, It)) {
-          if (s === n || v(this, zn).has(s)) continue;
+        for (const [s, a] of g(this, It)) {
+          if (s === n || g(this, Yn).has(s)) continue;
           const o = () => {
-            if (Array.from(v(this, xt).values()).includes(s)) {
+            if (Array.from(g(this, yt).values()).includes(s)) {
               var u = document.createDocumentFragment();
-              Oo(a, u), u.append(rt()), v(this, tt).set(s, { effect: a, fragment: u });
+              qo(a, u), u.append(rt()), g(this, tt).set(s, { effect: a, fragment: u });
             } else
               Le(a);
-            v(this, zn).delete(s), v(this, It).delete(s);
+            g(this, Yn).delete(s), g(this, It).delete(s);
           };
-          v(this, Ur) || !r ? (v(this, zn).add(s), Yn(a, o, !1)) : o();
+          g(this, Kr) || !r ? (g(this, Yn).add(s), Xn(a, o, !1)) : o();
         }
       }
     });
     /**
      * @param {Batch} batch
      */
-    z(this, Pi, (t) => {
-      v(this, xt).delete(t);
-      const n = Array.from(v(this, xt).values());
-      for (const [r, i] of v(this, tt))
-        n.includes(r) || (Le(i.effect), v(this, tt).delete(r));
+    H(this, Fi, (t) => {
+      g(this, yt).delete(t);
+      const n = Array.from(g(this, yt).values());
+      for (const [r, i] of g(this, tt))
+        n.includes(r) || (Le(i.effect), g(this, tt).delete(r));
     });
-    this.anchor = t, q(this, Ur, n);
+    this.anchor = t, L(this, Kr, n);
   }
   /**
    *
@@ -2163,69 +2163,69 @@ class rf {
   ensure(t, n) {
     var r = (
       /** @type {Batch} */
-      K
-    ), i = Ro();
-    if (n && !v(this, It).has(t) && !v(this, tt).has(t))
+      J
+    ), i = ko();
+    if (n && !g(this, It).has(t) && !g(this, tt).has(t))
       if (i) {
         var s = document.createDocumentFragment(), a = rt();
-        s.append(a), v(this, tt).set(t, {
-          effect: ct(() => n(a)),
+        s.append(a), g(this, tt).set(t, {
+          effect: dt(() => n(a)),
           fragment: s
         });
       } else
-        v(this, It).set(
+        g(this, It).set(
           t,
-          ct(() => n(this.anchor))
+          dt(() => n(this.anchor))
         );
-    if (v(this, xt).set(r, t), i) {
-      for (const [o, l] of v(this, It))
+    if (g(this, yt).set(r, t), i) {
+      for (const [o, l] of g(this, It))
         o === t ? r.unskip_effect(l) : r.skip_effect(l);
-      for (const [o, l] of v(this, tt))
+      for (const [o, l] of g(this, tt))
         o === t ? r.unskip_effect(l.effect) : r.skip_effect(l.effect);
-      r.oncommit(v(this, Gr)), r.ondiscard(v(this, Pi));
+      r.oncommit(g(this, jr)), r.ondiscard(g(this, Fi));
     } else
-      j && (this.anchor = X), v(this, Gr).call(this);
+      Z && (this.anchor = W), g(this, jr).call(this);
   }
 }
-xt = new WeakMap(), It = new WeakMap(), tt = new WeakMap(), zn = new WeakMap(), Ur = new WeakMap(), Gr = new WeakMap(), Pi = new WeakMap();
-function sf(e) {
-  it === null && uu(), Is(() => {
-    const t = Bi(e);
+yt = new WeakMap(), It = new WeakMap(), tt = new WeakMap(), Yn = new WeakMap(), Kr = new WeakMap(), jr = new WeakMap(), Fi = new WeakMap();
+function cf(e) {
+  it === null && vu(), Ri(() => {
+    const t = Qr(e);
     if (typeof t == "function") return (
       /** @type {() => void} */
       t
     );
   });
 }
-function tr(e, t, n = !1) {
-  j && Li();
-  var r = new rf(e), i = n ? dr : 0;
+function ir(e, t, n = !1) {
+  Z && Hi();
+  var r = new ff(e), i = n ? gr : 0;
   function s(a, o) {
-    if (j) {
-      const f = to(e);
+    if (Z) {
+      const f = so(e);
       var l;
-      if (f === Ns ? l = 0 : f === Di ? l = !1 : l = parseInt(f.substring(1)), a !== l) {
-        var u = $i();
-        Ie(u), r.anchor = u, an(!1), r.ensure(a, o), an(!0);
+      if (f === Os ? l = 0 : f === Li ? l = !1 : l = parseInt(f.substring(1)), a !== l) {
+        var u = Ti();
+        Fe(u), r.anchor = u, ln(!1), r.ensure(a, o), ln(!0);
         return;
       }
     }
     r.ensure(a, o);
   }
-  qs(() => {
+  Ys(() => {
     var a = !1;
     t((o, l = 0) => {
       a = !0, s(l, o);
     }), a || s(!1, null);
   }, i);
 }
-function hi(e, t) {
+function vi(e, t) {
   return t;
 }
-function af(e, t, n) {
+function hf(e, t, n) {
   for (var r = [], i = t.length, s, a = t.length, o = 0; o < i; o++) {
     let d = t[o];
-    Yn(
+    Xn(
       d,
       () => {
         if (s) {
@@ -2234,7 +2234,7 @@ function af(e, t, n) {
               /** @type {Set<EachOutroGroup>} */
               e.outrogroups
             );
-            ws(Oi(s.done)), h.delete(s), h.size === 0 && (e.outrogroups = null);
+            Es(qi(s.done)), h.delete(s), h.size === 0 && (e.outrogroups = null);
           }
         } else
           a -= 1;
@@ -2252,187 +2252,187 @@ function af(e, t, n) {
         /** @type {Element} */
         u.parentNode
       );
-      To(f), f.append(u), e.items.clear();
+      No(f), f.append(u), e.items.clear();
     }
-    ws(t, !l);
+    Es(t, !l);
   } else
     s = {
       pending: new Set(t),
       done: /* @__PURE__ */ new Set()
     }, (e.outrogroups ?? (e.outrogroups = /* @__PURE__ */ new Set())).add(s);
 }
-function ws(e, t = !0) {
+function Es(e, t = !0) {
   for (var n = 0; n < e.length; n++)
     Le(e[n], t);
 }
-var ma;
-function di(e, t, n, r, i, s = null) {
-  var a = e, o = /* @__PURE__ */ new Map(), l = (t & Wa) !== 0;
+var ba;
+function gi(e, t, n, r, i, s = null) {
+  var a = e, o = /* @__PURE__ */ new Map(), l = (t & ja) !== 0;
   if (l) {
     var u = (
       /** @type {Element} */
       e
     );
-    a = j ? Ie(/* @__PURE__ */ un(u)) : u.appendChild(rt());
+    a = Z ? Fe(/* @__PURE__ */ cn(u)) : u.appendChild(rt());
   }
-  j && Li();
-  var f = null, d = /* @__PURE__ */ _o(() => {
-    var b = n();
-    return Ga(b) ? b : b == null ? [] : Oi(b);
+  Z && Hi();
+  var f = null, d = /* @__PURE__ */ xo(() => {
+    var x = n();
+    return Za(x) ? x : x == null ? [] : qi(x);
   }), h, p = !0;
-  function _() {
-    y.fallback = f, of(y, h, a, t, r), f !== null && (h.length === 0 ? (f.f & sn) === 0 ? zs(f) : (f.f ^= sn, kr(f, null, a)) : Yn(f, () => {
+  function y() {
+    _.fallback = f, df(_, h, a, t, r), f !== null && (h.length === 0 ? (f.f & on) === 0 ? Xs(f) : (f.f ^= on, Mr(f, null, a)) : Xn(f, () => {
       f = null;
     }));
   }
-  var x = qs(() => {
+  var E = Ys(() => {
     h = /** @type {V[]} */
-    $(d);
-    var b = h.length;
-    let O = !1;
-    if (j) {
-      var N = to(a) === Di;
-      N !== (b === 0) && (a = $i(), Ie(a), an(!1), O = !0);
+    A(d);
+    var x = h.length;
+    let D = !1;
+    if (Z) {
+      var N = so(a) === Li;
+      N !== (x === 0) && (a = Ti(), Fe(a), ln(!1), D = !0);
     }
-    for (var M = /* @__PURE__ */ new Set(), F = (
+    for (var O = /* @__PURE__ */ new Set(), I = (
       /** @type {Batch} */
-      K
-    ), W = Ro(), I = 0; I < b; I += 1) {
-      j && X.nodeType === xr && /** @type {Comment} */
-      X.data === ks && (a = /** @type {Comment} */
-      X, O = !0, an(!1));
-      var ee = h[I], fe = r(ee, I), U = p ? null : o.get(fe);
-      U ? (U.v && gr(U.v, ee), U.i && gr(U.i, I), W && F.unskip_effect(U.e)) : (U = lf(
+      J
+    ), K = ko(), V = 0; V < x; V += 1) {
+      Z && W.nodeType === Ar && /** @type {Comment} */
+      W.data === Is && (a = /** @type {Comment} */
+      W, D = !0, ln(!1));
+      var Q = h[V], B = r(Q, V), U = p ? null : o.get(B);
+      U ? (U.v && yr(U.v, Q), U.i && yr(U.i, V), K && I.unskip_effect(U.e)) : (U = pf(
         o,
-        p ? a : ma ?? (ma = rt()),
-        ee,
-        fe,
-        I,
+        p ? a : ba ?? (ba = rt()),
+        Q,
+        B,
+        V,
         i,
         t,
         n
-      ), p || (U.e.f |= sn), o.set(fe, U)), M.add(fe);
+      ), p || (U.e.f |= on), o.set(B, U)), O.add(B);
     }
-    if (b === 0 && s && !f && (p ? f = ct(() => s(a)) : (f = ct(() => s(ma ?? (ma = rt()))), f.f |= sn)), b > M.size && cu(), j && b > 0 && Ie($i()), !p)
-      if (W) {
-        for (const [re, le] of o)
-          M.has(re) || F.skip_effect(le.e);
-        F.oncommit(_), F.ondiscard(() => {
+    if (x === 0 && s && !f && (p ? f = dt(() => s(a)) : (f = dt(() => s(ba ?? (ba = rt()))), f.f |= on)), x > O.size && _u(), Z && x > 0 && Fe(Ti()), !p)
+      if (K) {
+        for (const [fe, ie] of o)
+          O.has(fe) || I.skip_effect(ie.e);
+        I.oncommit(y), I.ondiscard(() => {
         });
       } else
-        _();
-    O && an(!0), $(d);
-  }), y = { effect: x, items: o, outrogroups: null, fallback: f };
-  p = !1, j && (a = X);
+        y();
+    D && ln(!0), A(d);
+  }), _ = { effect: E, items: o, outrogroups: null, fallback: f };
+  p = !1, Z && (a = W);
 }
-function Cr(e) {
-  for (; e !== null && (e.f & Tt) === 0; )
+function kr(e) {
+  for (; e !== null && (e.f & At) === 0; )
     e = e.next;
   return e;
 }
-function of(e, t, n, r, i) {
-  var U, re, le, D, H, te, je, qe, de;
-  var s = (r & Xl) !== 0, a = t.length, o = e.items, l = Cr(e.effect.first), u, f = null, d, h = [], p = [], _, x, y, b;
+function df(e, t, n, r, i) {
+  var U, fe, ie, M, z, Se, Ge, se, Pe;
+  var s = (r & Jl) !== 0, a = t.length, o = e.items, l = kr(e.effect.first), u, f = null, d, h = [], p = [], y, E, _, x;
   if (s)
-    for (b = 0; b < a; b += 1)
-      _ = t[b], x = i(_, b), y = /** @type {EachItem} */
-      o.get(x).e, (y.f & sn) === 0 && ((re = (U = y.nodes) == null ? void 0 : U.a) == null || re.measure(), (d ?? (d = /* @__PURE__ */ new Set())).add(y));
-  for (b = 0; b < a; b += 1) {
-    if (_ = t[b], x = i(_, b), y = /** @type {EachItem} */
-    o.get(x).e, e.outrogroups !== null)
-      for (const ce of e.outrogroups)
-        ce.pending.delete(y), ce.done.delete(y);
-    if ((y.f & sn) !== 0)
-      if (y.f ^= sn, y === l)
-        kr(y, null, n);
+    for (x = 0; x < a; x += 1)
+      y = t[x], E = i(y, x), _ = /** @type {EachItem} */
+      o.get(E).e, (_.f & on) === 0 && ((fe = (U = _.nodes) == null ? void 0 : U.a) == null || fe.measure(), (d ?? (d = /* @__PURE__ */ new Set())).add(_));
+  for (x = 0; x < a; x += 1) {
+    if (y = t[x], E = i(y, x), _ = /** @type {EachItem} */
+    o.get(E).e, e.outrogroups !== null)
+      for (const me of e.outrogroups)
+        me.pending.delete(_), me.done.delete(_);
+    if ((_.f & on) !== 0)
+      if (_.f ^= on, _ === l)
+        Mr(_, null, n);
       else {
-        var O = f ? f.next : l;
-        y === e.effect.last && (e.effect.last = y.prev), y.prev && (y.prev.next = y.next), y.next && (y.next.prev = y.prev), vn(e, f, y), vn(e, y, O), kr(y, O, n), f = y, h = [], p = [], l = Cr(f.next);
+        var D = f ? f.next : l;
+        _ === e.effect.last && (e.effect.last = _.prev), _.prev && (_.prev.next = _.next), _.next && (_.next.prev = _.prev), _n(e, f, _), _n(e, _, D), Mr(_, D, n), f = _, h = [], p = [], l = kr(f.next);
         continue;
       }
-    if ((y.f & nt) !== 0 && (zs(y), s && ((D = (le = y.nodes) == null ? void 0 : le.a) == null || D.unfix(), (d ?? (d = /* @__PURE__ */ new Set())).delete(y))), y !== l) {
-      if (u !== void 0 && u.has(y)) {
+    if ((_.f & nt) !== 0 && (Xs(_), s && ((M = (ie = _.nodes) == null ? void 0 : ie.a) == null || M.unfix(), (d ?? (d = /* @__PURE__ */ new Set())).delete(_))), _ !== l) {
+      if (u !== void 0 && u.has(_)) {
         if (h.length < p.length) {
-          var N = p[0], M;
+          var N = p[0], O;
           f = N.prev;
-          var F = h[0], W = h[h.length - 1];
-          for (M = 0; M < h.length; M += 1)
-            kr(h[M], N, n);
-          for (M = 0; M < p.length; M += 1)
-            u.delete(p[M]);
-          vn(e, F.prev, W.next), vn(e, f, F), vn(e, W, N), l = N, f = W, b -= 1, h = [], p = [];
+          var I = h[0], K = h[h.length - 1];
+          for (O = 0; O < h.length; O += 1)
+            Mr(h[O], N, n);
+          for (O = 0; O < p.length; O += 1)
+            u.delete(p[O]);
+          _n(e, I.prev, K.next), _n(e, f, I), _n(e, K, N), l = N, f = K, x -= 1, h = [], p = [];
         } else
-          u.delete(y), kr(y, l, n), vn(e, y.prev, y.next), vn(e, y, f === null ? e.effect.first : f.next), vn(e, f, y), f = y;
+          u.delete(_), Mr(_, l, n), _n(e, _.prev, _.next), _n(e, _, f === null ? e.effect.first : f.next), _n(e, f, _), f = _;
         continue;
       }
-      for (h = [], p = []; l !== null && l !== y; )
-        (u ?? (u = /* @__PURE__ */ new Set())).add(l), p.push(l), l = Cr(l.next);
+      for (h = [], p = []; l !== null && l !== _; )
+        (u ?? (u = /* @__PURE__ */ new Set())).add(l), p.push(l), l = kr(l.next);
       if (l === null)
         continue;
     }
-    (y.f & sn) === 0 && h.push(y), f = y, l = Cr(y.next);
+    (_.f & on) === 0 && h.push(_), f = _, l = kr(_.next);
   }
   if (e.outrogroups !== null) {
-    for (const ce of e.outrogroups)
-      ce.pending.size === 0 && (ws(Oi(ce.done)), (H = e.outrogroups) == null || H.delete(ce));
+    for (const me of e.outrogroups)
+      me.pending.size === 0 && (Es(qi(me.done)), (z = e.outrogroups) == null || z.delete(me));
     e.outrogroups.size === 0 && (e.outrogroups = null);
   }
   if (l !== null || u !== void 0) {
-    var I = [];
+    var V = [];
     if (u !== void 0)
-      for (y of u)
-        (y.f & nt) === 0 && I.push(y);
+      for (_ of u)
+        (_.f & nt) === 0 && V.push(_);
     for (; l !== null; )
-      (l.f & nt) === 0 && l !== e.fallback && I.push(l), l = Cr(l.next);
-    var ee = I.length;
-    if (ee > 0) {
-      var fe = (r & Wa) !== 0 && a === 0 ? n : null;
+      (l.f & nt) === 0 && l !== e.fallback && V.push(l), l = kr(l.next);
+    var Q = V.length;
+    if (Q > 0) {
+      var B = (r & ja) !== 0 && a === 0 ? n : null;
       if (s) {
-        for (b = 0; b < ee; b += 1)
-          (je = (te = I[b].nodes) == null ? void 0 : te.a) == null || je.measure();
-        for (b = 0; b < ee; b += 1)
-          (de = (qe = I[b].nodes) == null ? void 0 : qe.a) == null || de.fix();
+        for (x = 0; x < Q; x += 1)
+          (Ge = (Se = V[x].nodes) == null ? void 0 : Se.a) == null || Ge.measure();
+        for (x = 0; x < Q; x += 1)
+          (Pe = (se = V[x].nodes) == null ? void 0 : se.a) == null || Pe.fix();
       }
-      af(e, I, fe);
+      hf(e, V, B);
     }
   }
-  s && wn(() => {
-    var ce, _e;
+  s && bn(() => {
+    var me, ye;
     if (d !== void 0)
-      for (y of d)
-        (_e = (ce = y.nodes) == null ? void 0 : ce.a) == null || _e.apply();
+      for (_ of d)
+        (ye = (me = _.nodes) == null ? void 0 : me.a) == null || ye.apply();
   });
 }
-function lf(e, t, n, r, i, s, a, o) {
-  var l = (a & Yl) !== 0 ? (a & Wl) === 0 ? /* @__PURE__ */ xo(n, !1, !1) : Un(n) : null, u = (a & Bl) !== 0 ? Un(i) : null;
+function pf(e, t, n, r, i, s, a, o) {
+  var l = (a & Kl) !== 0 ? (a & Zl) === 0 ? /* @__PURE__ */ Eo(n, !1, !1) : Kn(n) : null, u = (a & jl) !== 0 ? Kn(i) : null;
   return {
     v: l,
     i: u,
-    e: ct(() => (s(t, l ?? n, u ?? i, o), () => {
+    e: dt(() => (s(t, l ?? n, u ?? i, o), () => {
       e.delete(r);
     }))
   };
 }
-function kr(e, t, n) {
+function Mr(e, t, n) {
   if (e.nodes)
-    for (var r = e.nodes.start, i = e.nodes.end, s = t && (t.f & sn) === 0 ? (
+    for (var r = e.nodes.start, i = e.nodes.end, s = t && (t.f & on) === 0 ? (
       /** @type {EffectNodes} */
       t.nodes.start
     ) : n; r !== null; ) {
       var a = (
         /** @type {TemplateNode} */
-        /* @__PURE__ */ Ht(r)
+        /* @__PURE__ */ zt(r)
       );
       if (s.before(r), r === i)
         return;
       r = a;
     }
 }
-function vn(e, t, n) {
+function _n(e, t, n) {
   t === null ? e.effect.first = n : t.next = n, n === null ? e.effect.last = t : n.prev = t;
 }
-function Hs(e, t) {
-  No(() => {
+function Ws(e, t) {
+  Do(() => {
     var n = e.getRootNode(), r = (
       /** @type {ShadowRoot} */
       n.host ? (
@@ -2445,14 +2445,14 @@ function Hs(e, t) {
       )
     );
     if (!r.querySelector("#" + t.hash)) {
-      const i = Os("style");
+      const i = Vs("style");
       i.id = t.hash, i.textContent = t.code, r.appendChild(i);
     }
   });
 }
-const ya = [...` 	
+const $a = [...` 	
 \r\f \v\uFEFF`];
-function uf(e, t, n) {
+function vf(e, t, n) {
   var r = e == null ? "" : "" + e;
   if (n) {
     for (var i in n)
@@ -2461,12 +2461,12 @@ function uf(e, t, n) {
       else if (r.length)
         for (var s = i.length, a = 0; (a = r.indexOf(i, a)) >= 0; ) {
           var o = a + s;
-          (a === 0 || ya.includes(r[a - 1])) && (o === r.length || ya.includes(r[o])) ? r = (a === 0 ? "" : r.substring(0, a)) + r.substring(o + 1) : a = o;
+          (a === 0 || $a.includes(r[a - 1])) && (o === r.length || $a.includes(r[o])) ? r = (a === 0 ? "" : r.substring(0, a)) + r.substring(o + 1) : a = o;
         }
   }
   return r === "" ? null : r;
 }
-function wa(e, t = !1) {
+function Aa(e, t = !1) {
   var n = t ? " !important;" : ";", r = "";
   for (var i in e) {
     var s = e[i];
@@ -2474,18 +2474,18 @@ function wa(e, t = !1) {
   }
   return r;
 }
-function ff(e, t) {
+function gf(e, t) {
   if (t) {
     var n = "", r, i;
-    return Array.isArray(t) ? (r = t[0], i = t[1]) : r = t, r && (n += wa(r)), i && (n += wa(i, !0)), n = n.trim(), n === "" ? null : n;
+    return Array.isArray(t) ? (r = t[0], i = t[1]) : r = t, r && (n += Aa(r)), i && (n += Aa(i, !0)), n = n.trim(), n === "" ? null : n;
   }
   return String(e);
 }
-function ri(e, t, n, r, i, s) {
+function ai(e, t, n, r, i, s) {
   var a = e.__className;
-  if (j || a !== n || a === void 0) {
-    var o = uf(n, r, s);
-    (!j || o !== e.getAttribute("class")) && (o == null ? e.removeAttribute("class") : e.className = o), e.__className = n;
+  if (Z || a !== n || a === void 0) {
+    var o = vf(n, r, s);
+    (!Z || o !== e.getAttribute("class")) && (o == null ? e.removeAttribute("class") : e.className = o), e.__className = n;
   } else if (s && i !== s)
     for (var l in s) {
       var u = !!s[l];
@@ -2493,80 +2493,80 @@ function ri(e, t, n, r, i, s) {
     }
   return s;
 }
-function ns(e, t = {}, n, r) {
+function os(e, t = {}, n, r) {
   for (var i in n) {
     var s = n[i];
     t[i] !== s && (n[i] == null ? e.style.removeProperty(i) : e.style.setProperty(i, s, r));
   }
 }
-function xa(e, t, n, r) {
+function Ea(e, t, n, r) {
   var i = e.__style;
-  if (j || i !== t) {
-    var s = ff(t, r);
-    (!j || s !== e.getAttribute("style")) && (s == null ? e.removeAttribute("style") : e.style.cssText = s), e.__style = t;
-  } else r && (Array.isArray(r) ? (ns(e, n == null ? void 0 : n[0], r[0]), ns(e, n == null ? void 0 : n[1], r[1], "important")) : ns(e, n, r));
+  if (Z || i !== t) {
+    var s = gf(t, r);
+    (!Z || s !== e.getAttribute("style")) && (s == null ? e.removeAttribute("style") : e.style.cssText = s), e.__style = t;
+  } else r && (Array.isArray(r) ? (os(e, n == null ? void 0 : n[0], r[0]), os(e, n == null ? void 0 : n[1], r[1], "important")) : os(e, n, r));
   return r;
 }
-const cf = Symbol("is custom element"), hf = Symbol("is html"), df = lu ? "link" : "LINK";
-function ba(e, t, n, r) {
-  var i = pf(e);
-  j && (i[t] = e.getAttribute(t), t === "src" || t === "srcset" || t === "href" && e.nodeName === df) || i[t] !== (i[t] = n) && (t === "loading" && (e[ou] = n), n == null ? e.removeAttribute(t) : typeof n != "string" && vf(e).includes(t) ? e[t] = n : e.setAttribute(t, n));
+const _f = Symbol("is custom element"), mf = Symbol("is html"), yf = pu ? "link" : "LINK";
+function Ta(e, t, n, r) {
+  var i = wf(e);
+  Z && (i[t] = e.getAttribute(t), t === "src" || t === "srcset" || t === "href" && e.nodeName === yf) || i[t] !== (i[t] = n) && (t === "loading" && (e[du] = n), n == null ? e.removeAttribute(t) : typeof n != "string" && xf(e).includes(t) ? e[t] = n : e.setAttribute(t, n));
 }
-function pf(e) {
+function wf(e) {
   return (
     /** @type {Record<string | symbol, unknown>} **/
     // @ts-expect-error
     e.__attributes ?? (e.__attributes = {
-      [cf]: e.nodeName.includes("-"),
-      [hf]: e.namespaceURI === Ua
+      [_f]: e.nodeName.includes("-"),
+      [mf]: e.namespaceURI === Ja
     })
   );
 }
-var $a = /* @__PURE__ */ new Map();
-function vf(e) {
-  var t = e.getAttribute("is") || e.nodeName, n = $a.get(t);
+var Ra = /* @__PURE__ */ new Map();
+function xf(e) {
+  var t = e.getAttribute("is") || e.nodeName, n = Ra.get(t);
   if (n) return n;
-  $a.set(t, n = []);
+  Ra.set(t, n = []);
   for (var r, i = e, s = Element.prototype; s !== i; ) {
-    r = eu(i);
+    r = au(i);
     for (var a in r)
       r[a].set && n.push(a);
-    i = Ka(i);
+    i = Qa(i);
   }
   return n;
 }
-function Aa(e, t) {
-  return e === t || (e == null ? void 0 : e[Or]) === t;
+function Sa(e, t) {
+  return e === t || (e == null ? void 0 : e[Fr]) === t;
 }
-function pi(e = {}, t, n, r) {
-  return No(() => {
+function _i(e = {}, t, n, r) {
+  return Do(() => {
     var i, s;
-    return Ls(() => {
-      i = s, s = [], Bi(() => {
-        e !== n(...s) && (t(e, ...s), i && Aa(n(...i), e) && t(null, ...i));
+    return Hs(() => {
+      i = s, s = [], Qr(() => {
+        e !== n(...s) && (t(e, ...s), i && Sa(n(...i), e) && t(null, ...i));
       });
     }), () => {
-      wn(() => {
-        s && Aa(n(...s), e) && t(null, ...s);
+      bn(() => {
+        s && Sa(n(...s), e) && t(null, ...s);
       });
     };
   }), e;
 }
-let ii = !1;
-function gf(e) {
-  var t = ii;
+let oi = !1;
+function bf(e) {
+  var t = oi;
   try {
-    return ii = !1, [e(), ii];
+    return oi = !1, [e(), oi];
   } finally {
-    ii = t;
+    oi = t;
   }
 }
-function ie(e, t, n, r) {
-  var O;
-  var i = (n & Kl) !== 0, s = (n & jl) !== 0, a = (
+function ee(e, t, n, r) {
+  var D;
+  var i = (n & tu) !== 0, s = (n & nu) !== 0, a = (
     /** @type {V} */
     r
-  ), o = !0, l = () => (o && (o = !1, a = s ? Bi(
+  ), o = !0, l = () => (o && (o = !1, a = s ? Qr(
     /** @type {() => V} */
     r
   ) : (
@@ -2574,15 +2574,15 @@ function ie(e, t, n, r) {
     r
   )), a), u;
   if (i) {
-    var f = Or in e || eo in e;
-    u = ((O = Hn(e, t)) == null ? void 0 : O.set) ?? (f && t in e ? (N) => e[t] = N : void 0);
+    var f = Fr in e || io in e;
+    u = ((D = Bn(e, t)) == null ? void 0 : D.set) ?? (f && t in e ? (N) => e[t] = N : void 0);
   }
   var d, h = !1;
-  i ? [d, h] = gf(() => (
+  i ? [d, h] = bf(() => (
     /** @type {V} */
     e[t]
   )) : d = /** @type {V} */
-  e[t], d === void 0 && r !== void 0 && (d = l(), u && (_u(), u(d)));
+  e[t], d === void 0 && r !== void 0 && (d = l(), u && ($u(), u(d)));
   var p;
   if (p = () => {
     var N = (
@@ -2590,39 +2590,39 @@ function ie(e, t, n, r) {
       e[t]
     );
     return N === void 0 ? l() : (o = !0, N);
-  }, (n & Gl) === 0)
+  }, (n & eu) === 0)
     return p;
   if (u) {
-    var _ = e.$$legacy;
+    var y = e.$$legacy;
     return (
       /** @type {() => V} */
-      (function(N, M) {
-        return arguments.length > 0 ? ((!M || _ || h) && u(M ? p() : N), N) : p();
+      (function(N, O) {
+        return arguments.length > 0 ? ((!O || y || h) && u(O ? p() : N), N) : p();
       })
     );
   }
-  var x = !1, y = ((n & Ul) !== 0 ? Hi : _o)(() => (x = !1, p()));
-  i && $(y);
-  var b = (
+  var E = !1, _ = ((n & Ql) !== 0 ? Wi : xo)(() => (E = !1, p()));
+  i && A(_);
+  var x = (
     /** @type {Effect} */
-    J
+    te
   );
   return (
     /** @type {() => V} */
-    (function(N, M) {
+    (function(N, O) {
       if (arguments.length > 0) {
-        const F = M ? $(y) : i ? Pn(N) : N;
-        return ve(y, F), x = !0, a !== void 0 && (a = F), N;
+        const I = O ? A(_) : i ? On(N) : N;
+        return pe(_, I), E = !0, a !== void 0 && (a = I), N;
       }
-      return $n && x || (b.f & on) !== 0 ? y.v : $(y);
+      return En && E || (x.f & un) !== 0 ? _.v : A(_);
     })
   );
 }
-function _f(e) {
-  return new mf(e);
+function $f(e) {
+  return new Af(e);
 }
-var rn, ft;
-class mf {
+var an, ht;
+class Af {
   /**
    * @param {ComponentConstructorOptions & {
    *  component: any;
@@ -2630,57 +2630,57 @@ class mf {
    */
   constructor(t) {
     /** @type {any} */
-    z(this, rn);
+    H(this, an);
     /** @type {Record<string, any>} */
-    z(this, ft);
+    H(this, ht);
     var s;
     var n = /* @__PURE__ */ new Map(), r = (a, o) => {
-      var l = /* @__PURE__ */ xo(o, !1, !1);
+      var l = /* @__PURE__ */ Eo(o, !1, !1);
       return n.set(a, l), l;
     };
     const i = new Proxy(
       { ...t.props || {}, $$events: {} },
       {
         get(a, o) {
-          return $(n.get(o) ?? r(o, Reflect.get(a, o)));
+          return A(n.get(o) ?? r(o, Reflect.get(a, o)));
         },
         has(a, o) {
-          return o === eo ? !0 : ($(n.get(o) ?? r(o, Reflect.get(a, o))), Reflect.has(a, o));
+          return o === io ? !0 : (A(n.get(o) ?? r(o, Reflect.get(a, o))), Reflect.has(a, o));
         },
         set(a, o, l) {
-          return ve(n.get(o) ?? r(o, l), l), Reflect.set(a, o, l);
+          return pe(n.get(o) ?? r(o, l), l), Reflect.set(a, o, l);
         }
       }
     );
-    q(this, ft, (t.hydrate ? tf : Xo)(t.component, {
+    L(this, ht, (t.hydrate ? lf : Ko)(t.component, {
       target: t.target,
       anchor: t.anchor,
       props: i,
       context: t.context,
       intro: t.intro ?? !1,
       recover: t.recover
-    })), (!((s = t == null ? void 0 : t.props) != null && s.$$host) || t.sync === !1) && ne(), q(this, rn, i.$$events);
-    for (const a of Object.keys(v(this, ft)))
-      a === "$set" || a === "$destroy" || a === "$on" || bi(this, a, {
+    })), (!((s = t == null ? void 0 : t.props) != null && s.$$host) || t.sync === !1) && j(), L(this, an, i.$$events);
+    for (const a of Object.keys(g(this, ht)))
+      a === "$set" || a === "$destroy" || a === "$on" || Ei(this, a, {
         get() {
-          return v(this, ft)[a];
+          return g(this, ht)[a];
         },
         /** @param {any} value */
         set(o) {
-          v(this, ft)[a] = o;
+          g(this, ht)[a] = o;
         },
         enumerable: !0
       });
-    v(this, ft).$set = /** @param {Record<string, any>} next */
+    g(this, ht).$set = /** @param {Record<string, any>} next */
     (a) => {
       Object.assign(i, a);
-    }, v(this, ft).$destroy = () => {
-      nf(v(this, ft));
+    }, g(this, ht).$destroy = () => {
+      uf(g(this, ht));
     };
   }
   /** @param {Record<string, any>} props */
   $set(t) {
-    v(this, ft).$set(t);
+    g(this, ht).$set(t);
   }
   /**
    * @param {string} event
@@ -2688,22 +2688,22 @@ class mf {
    * @returns {any}
    */
   $on(t, n) {
-    v(this, rn)[t] = v(this, rn)[t] || [];
+    g(this, an)[t] = g(this, an)[t] || [];
     const r = (...i) => n.call(this, ...i);
-    return v(this, rn)[t].push(r), () => {
-      v(this, rn)[t] = v(this, rn)[t].filter(
+    return g(this, an)[t].push(r), () => {
+      g(this, an)[t] = g(this, an)[t].filter(
         /** @param {any} fn */
         (i) => i !== r
       );
     };
   }
   $destroy() {
-    v(this, ft).$destroy();
+    g(this, ht).$destroy();
   }
 }
-rn = new WeakMap(), ft = new WeakMap();
-let Uo;
-typeof HTMLElement == "function" && (Uo = class extends HTMLElement {
+an = new WeakMap(), ht = new WeakMap();
+let Jo;
+typeof HTMLElement == "function" && (Jo = class extends HTMLElement {
   /**
    * @param {*} $$componentCtor
    * @param {*} $$slots
@@ -2712,27 +2712,27 @@ typeof HTMLElement == "function" && (Uo = class extends HTMLElement {
   constructor(t, n, r) {
     super();
     /** The Svelte component constructor */
-    pe(this, "$$ctor");
+    de(this, "$$ctor");
     /** Slots */
-    pe(this, "$$s");
+    de(this, "$$s");
     /** @type {any} The Svelte component instance */
-    pe(this, "$$c");
+    de(this, "$$c");
     /** Whether or not the custom element is connected */
-    pe(this, "$$cn", !1);
+    de(this, "$$cn", !1);
     /** @type {Record<string, any>} Component props data */
-    pe(this, "$$d", {});
+    de(this, "$$d", {});
     /** `true` if currently in the process of reflecting component props back to attributes */
-    pe(this, "$$r", !1);
+    de(this, "$$r", !1);
     /** @type {Record<string, CustomElementPropDefinition>} Props definition (name, reflected, type etc) */
-    pe(this, "$$p_d", {});
+    de(this, "$$p_d", {});
     /** @type {Record<string, EventListenerOrEventListenerObject[]>} Event listeners */
-    pe(this, "$$l", {});
+    de(this, "$$l", {});
     /** @type {Map<EventListenerOrEventListenerObject, Function>} Event listener unsubscribe functions */
-    pe(this, "$$l_u", /* @__PURE__ */ new Map());
+    de(this, "$$l_u", /* @__PURE__ */ new Map());
     /** @type {any} The managed render effect for reflecting attributes */
-    pe(this, "$$me");
+    de(this, "$$me");
     /** @type {ShadowRoot | null} The ShadowRoot of the custom element */
-    pe(this, "$$shadowRoot", null);
+    de(this, "$$shadowRoot", null);
     this.$$ctor = t, this.$$s = n, r && (this.$$shadowRoot = this.attachShadow(r));
   }
   /**
@@ -2762,23 +2762,23 @@ typeof HTMLElement == "function" && (Uo = class extends HTMLElement {
     if (this.$$cn = !0, !this.$$c) {
       let n = function(s) {
         return (a) => {
-          const o = Os("slot");
-          s !== "default" && (o.name = s), We(a, o);
+          const o = Vs("slot");
+          s !== "default" && (o.name = s), Be(a, o);
         };
       };
       var t = n;
       if (await Promise.resolve(), !this.$$cn || this.$$c)
         return;
-      const r = {}, i = yf(this);
+      const r = {}, i = Ef(this);
       for (const s of this.$$s)
         s in i && (s === "default" && !this.$$d.children ? (this.$$d.children = n(s), r.default = !0) : r[s] = n(s));
       for (const s of this.attributes) {
         const a = this.$$g_p(s.name);
-        a in this.$$d || (this.$$d[a] = vi(a, s.value, this.$$p_d, "toProp"));
+        a in this.$$d || (this.$$d[a] = mi(a, s.value, this.$$p_d, "toProp"));
       }
       for (const s in this.$$p_d)
         !(s in this.$$d) && this[s] !== void 0 && (this.$$d[s] = this[s], delete this[s]);
-      this.$$c = _f({
+      this.$$c = $f({
         component: this.$$ctor,
         target: this.$$shadowRoot || this,
         props: {
@@ -2786,14 +2786,14 @@ typeof HTMLElement == "function" && (Uo = class extends HTMLElement {
           $$slots: r,
           $$host: this
         }
-      }), this.$$me = Hu(() => {
-        Ls(() => {
+      }), this.$$me = Gu(() => {
+        Hs(() => {
           var s;
           this.$$r = !0;
-          for (const a of xi(this.$$c)) {
+          for (const a of Ai(this.$$c)) {
             if (!((s = this.$$p_d[a]) != null && s.reflect)) continue;
             this.$$d[a] = this.$$c[a];
-            const o = vi(
+            const o = mi(
               a,
               this.$$d[a],
               this.$$p_d,
@@ -2821,7 +2821,7 @@ typeof HTMLElement == "function" && (Uo = class extends HTMLElement {
    */
   attributeChangedCallback(t, n, r) {
     var i;
-    this.$$r || (t = this.$$g_p(t), this.$$d[t] = vi(t, r, this.$$p_d, "toProp"), (i = this.$$c) == null || i.$set({ [t]: this.$$d[t] }));
+    this.$$r || (t = this.$$g_p(t), this.$$d[t] = mi(t, r, this.$$p_d, "toProp"), (i = this.$$c) == null || i.$set({ [t]: this.$$d[t] }));
   }
   disconnectedCallback() {
     this.$$cn = !1, Promise.resolve().then(() => {
@@ -2832,12 +2832,12 @@ typeof HTMLElement == "function" && (Uo = class extends HTMLElement {
    * @param {string} attribute_name
    */
   $$g_p(t) {
-    return xi(this.$$p_d).find(
+    return Ai(this.$$p_d).find(
       (n) => this.$$p_d[n].attribute === t || !this.$$p_d[n].attribute && n.toLowerCase() === t
     ) || t;
   }
 });
-function vi(e, t, n, r) {
+function mi(e, t, n, r) {
   var s;
   const i = (s = n[e]) == null ? void 0 : s.type;
   if (t = i === "Boolean" && typeof t != "boolean" ? t != null : t, !r || !n[e])
@@ -2868,7 +2868,7 @@ function vi(e, t, n, r) {
         return t;
     }
 }
-function yf(e) {
+function Ef(e) {
   const t = {};
   return e.childNodes.forEach((n) => {
     t[
@@ -2877,34 +2877,34 @@ function yf(e) {
     ] = !0;
   }), t;
 }
-function Ys(e, t, n, r, i, s) {
-  let a = class extends Uo {
+function Us(e, t, n, r, i, s) {
+  let a = class extends Jo {
     constructor() {
       super(e, n, i), this.$$p_d = t;
     }
     static get observedAttributes() {
-      return xi(t).map(
+      return Ai(t).map(
         (o) => (t[o].attribute || o).toLowerCase()
       );
     }
   };
-  return xi(t).forEach((o) => {
-    bi(a.prototype, o, {
+  return Ai(t).forEach((o) => {
+    Ei(a.prototype, o, {
       get() {
         return this.$$c && o in this.$$c ? this.$$c[o] : this.$$d[o];
       },
       set(l) {
         var d;
-        l = vi(o, l, t), this.$$d[o] = l;
+        l = mi(o, l, t), this.$$d[o] = l;
         var u = this.$$c;
         if (u) {
-          var f = (d = Hn(u, o)) == null ? void 0 : d.get;
+          var f = (d = Bn(u, o)) == null ? void 0 : d.get;
           f ? u[o] = l : u.$set({ [o]: l });
         }
       }
     });
   }), r.forEach((o) => {
-    bi(a.prototype, o, {
+    Ei(a.prototype, o, {
       get() {
         var l;
         return (l = this.$$c) == null ? void 0 : l[o];
@@ -2913,43 +2913,43 @@ function Ys(e, t, n, r, i, s) {
   }), e.element = /** @type {any} */
   a, a;
 }
-var wf = { value: () => {
+var Tf = { value: () => {
 } };
-function Go() {
+function Zo() {
   for (var e = 0, t = arguments.length, n = {}, r; e < t; ++e) {
     if (!(r = arguments[e] + "") || r in n || /[\s.]/.test(r)) throw new Error("illegal type: " + r);
     n[r] = [];
   }
-  return new gi(n);
+  return new yi(n);
 }
-function gi(e) {
+function yi(e) {
   this._ = e;
 }
-function xf(e, t) {
+function Rf(e, t) {
   return e.trim().split(/^|\s+/).map(function(n) {
     var r = "", i = n.indexOf(".");
     if (i >= 0 && (r = n.slice(i + 1), n = n.slice(0, i)), n && !t.hasOwnProperty(n)) throw new Error("unknown type: " + n);
     return { type: n, name: r };
   });
 }
-gi.prototype = Go.prototype = {
-  constructor: gi,
+yi.prototype = Zo.prototype = {
+  constructor: yi,
   on: function(e, t) {
-    var n = this._, r = xf(e + "", n), i, s = -1, a = r.length;
+    var n = this._, r = Rf(e + "", n), i, s = -1, a = r.length;
     if (arguments.length < 2) {
-      for (; ++s < a; ) if ((i = (e = r[s]).type) && (i = bf(n[i], e.name))) return i;
+      for (; ++s < a; ) if ((i = (e = r[s]).type) && (i = Sf(n[i], e.name))) return i;
       return;
     }
     if (t != null && typeof t != "function") throw new Error("invalid callback: " + t);
     for (; ++s < a; )
-      if (i = (e = r[s]).type) n[i] = Ea(n[i], e.name, t);
-      else if (t == null) for (i in n) n[i] = Ea(n[i], e.name, null);
+      if (i = (e = r[s]).type) n[i] = Ca(n[i], e.name, t);
+      else if (t == null) for (i in n) n[i] = Ca(n[i], e.name, null);
     return this;
   },
   copy: function() {
     var e = {}, t = this._;
     for (var n in t) e[n] = t[n].slice();
-    return new gi(e);
+    return new yi(e);
   },
   call: function(e, t) {
     if ((i = arguments.length - 2) > 0) for (var n = new Array(i), r = 0, i, s; r < i; ++r) n[r] = arguments[r + 2];
@@ -2961,135 +2961,135 @@ gi.prototype = Go.prototype = {
     for (var r = this._[e], i = 0, s = r.length; i < s; ++i) r[i].value.apply(t, n);
   }
 };
-function bf(e, t) {
+function Sf(e, t) {
   for (var n = 0, r = e.length, i; n < r; ++n)
     if ((i = e[n]).name === t)
       return i.value;
 }
-function Ea(e, t, n) {
+function Ca(e, t, n) {
   for (var r = 0, i = e.length; r < i; ++r)
     if (e[r].name === t) {
-      e[r] = wf, e = e.slice(0, r).concat(e.slice(r + 1));
+      e[r] = Tf, e = e.slice(0, r).concat(e.slice(r + 1));
       break;
     }
   return n != null && e.push({ name: t, value: n }), e;
 }
-var xs = "http://www.w3.org/1999/xhtml";
-const Ta = {
+var Ts = "http://www.w3.org/1999/xhtml";
+const Na = {
   svg: "http://www.w3.org/2000/svg",
-  xhtml: xs,
+  xhtml: Ts,
   xlink: "http://www.w3.org/1999/xlink",
   xml: "http://www.w3.org/XML/1998/namespace",
   xmlns: "http://www.w3.org/2000/xmlns/"
 };
-function Xi(e) {
+function Gi(e) {
   var t = e += "", n = t.indexOf(":");
-  return n >= 0 && (t = e.slice(0, n)) !== "xmlns" && (e = e.slice(n + 1)), Ta.hasOwnProperty(t) ? { space: Ta[t], local: e } : e;
+  return n >= 0 && (t = e.slice(0, n)) !== "xmlns" && (e = e.slice(n + 1)), Na.hasOwnProperty(t) ? { space: Na[t], local: e } : e;
 }
-function $f(e) {
+function Cf(e) {
   return function() {
     var t = this.ownerDocument, n = this.namespaceURI;
-    return n === xs && t.documentElement.namespaceURI === xs ? t.createElement(e) : t.createElementNS(n, e);
+    return n === Ts && t.documentElement.namespaceURI === Ts ? t.createElement(e) : t.createElementNS(n, e);
   };
 }
-function Af(e) {
+function Nf(e) {
   return function() {
     return this.ownerDocument.createElementNS(e.space, e.local);
   };
 }
-function Ko(e) {
-  var t = Xi(e);
-  return (t.local ? Af : $f)(t);
+function Qo(e) {
+  var t = Gi(e);
+  return (t.local ? Nf : Cf)(t);
 }
-function Ef() {
+function kf() {
 }
-function Bs(e) {
-  return e == null ? Ef : function() {
+function Gs(e) {
+  return e == null ? kf : function() {
     return this.querySelector(e);
   };
 }
-function Tf(e) {
-  typeof e != "function" && (e = Bs(e));
+function Pf(e) {
+  typeof e != "function" && (e = Gs(e));
   for (var t = this._groups, n = t.length, r = new Array(n), i = 0; i < n; ++i)
     for (var s = t[i], a = s.length, o = r[i] = new Array(a), l, u, f = 0; f < a; ++f)
       (l = s[f]) && (u = e.call(l, l.__data__, f, s)) && ("__data__" in l && (u.__data__ = l.__data__), o[f] = u);
   return new st(r, this._parents);
 }
-function Rf(e) {
+function Mf(e) {
   return e == null ? [] : Array.isArray(e) ? e : Array.from(e);
 }
-function Sf() {
+function Df() {
   return [];
 }
-function jo(e) {
-  return e == null ? Sf : function() {
+function el(e) {
+  return e == null ? Df : function() {
     return this.querySelectorAll(e);
   };
 }
-function Cf(e) {
+function Of(e) {
   return function() {
-    return Rf(e.apply(this, arguments));
+    return Mf(e.apply(this, arguments));
   };
 }
-function Nf(e) {
-  typeof e == "function" ? e = Cf(e) : e = jo(e);
+function If(e) {
+  typeof e == "function" ? e = Of(e) : e = el(e);
   for (var t = this._groups, n = t.length, r = [], i = [], s = 0; s < n; ++s)
     for (var a = t[s], o = a.length, l, u = 0; u < o; ++u)
       (l = a[u]) && (r.push(e.call(l, l.__data__, u, a)), i.push(l));
   return new st(r, i);
 }
-function Jo(e) {
+function tl(e) {
   return function() {
     return this.matches(e);
   };
 }
-function Zo(e) {
+function nl(e) {
   return function(t) {
     return t.matches(e);
   };
 }
-var kf = Array.prototype.find;
-function Mf(e) {
+var Ff = Array.prototype.find;
+function Lf(e) {
   return function() {
-    return kf.call(this.children, e);
+    return Ff.call(this.children, e);
   };
 }
-function Pf() {
+function qf() {
   return this.firstElementChild;
 }
-function Df(e) {
-  return this.select(e == null ? Pf : Mf(typeof e == "function" ? e : Zo(e)));
+function Vf(e) {
+  return this.select(e == null ? qf : Lf(typeof e == "function" ? e : nl(e)));
 }
-var Of = Array.prototype.filter;
-function Ff() {
+var zf = Array.prototype.filter;
+function Hf() {
   return Array.from(this.children);
 }
-function If(e) {
+function Yf(e) {
   return function() {
-    return Of.call(this.children, e);
+    return zf.call(this.children, e);
   };
 }
-function Lf(e) {
-  return this.selectAll(e == null ? Ff : If(typeof e == "function" ? e : Zo(e)));
+function Bf(e) {
+  return this.selectAll(e == null ? Hf : Yf(typeof e == "function" ? e : nl(e)));
 }
-function qf(e) {
-  typeof e != "function" && (e = Jo(e));
+function Xf(e) {
+  typeof e != "function" && (e = tl(e));
   for (var t = this._groups, n = t.length, r = new Array(n), i = 0; i < n; ++i)
     for (var s = t[i], a = s.length, o = r[i] = [], l, u = 0; u < a; ++u)
       (l = s[u]) && e.call(l, l.__data__, u, s) && o.push(l);
   return new st(r, this._parents);
 }
-function Qo(e) {
+function rl(e) {
   return new Array(e.length);
 }
-function Vf() {
-  return new st(this._enter || this._groups.map(Qo), this._parents);
+function Wf() {
+  return new st(this._enter || this._groups.map(rl), this._parents);
 }
-function Ai(e, t) {
+function Si(e, t) {
   this.ownerDocument = e.ownerDocument, this.namespaceURI = e.namespaceURI, this._next = null, this._parent = e, this.__data__ = t;
 }
-Ai.prototype = {
-  constructor: Ai,
+Si.prototype = {
+  constructor: Si,
   appendChild: function(e) {
     return this._parent.insertBefore(e, this._next);
   },
@@ -3103,70 +3103,70 @@ Ai.prototype = {
     return this._parent.querySelectorAll(e);
   }
 };
-function zf(e) {
+function Uf(e) {
   return function() {
     return e;
   };
 }
-function Hf(e, t, n, r, i, s) {
+function Gf(e, t, n, r, i, s) {
   for (var a = 0, o, l = t.length, u = s.length; a < u; ++a)
-    (o = t[a]) ? (o.__data__ = s[a], r[a] = o) : n[a] = new Ai(e, s[a]);
+    (o = t[a]) ? (o.__data__ = s[a], r[a] = o) : n[a] = new Si(e, s[a]);
   for (; a < l; ++a)
     (o = t[a]) && (i[a] = o);
 }
-function Yf(e, t, n, r, i, s, a) {
+function Kf(e, t, n, r, i, s, a) {
   var o, l, u = /* @__PURE__ */ new Map(), f = t.length, d = s.length, h = new Array(f), p;
   for (o = 0; o < f; ++o)
     (l = t[o]) && (h[o] = p = a.call(l, l.__data__, o, t) + "", u.has(p) ? i[o] = l : u.set(p, l));
   for (o = 0; o < d; ++o)
-    p = a.call(e, s[o], o, s) + "", (l = u.get(p)) ? (r[o] = l, l.__data__ = s[o], u.delete(p)) : n[o] = new Ai(e, s[o]);
+    p = a.call(e, s[o], o, s) + "", (l = u.get(p)) ? (r[o] = l, l.__data__ = s[o], u.delete(p)) : n[o] = new Si(e, s[o]);
   for (o = 0; o < f; ++o)
     (l = t[o]) && u.get(h[o]) === l && (i[o] = l);
 }
-function Bf(e) {
+function jf(e) {
   return e.__data__;
 }
-function Xf(e, t) {
-  if (!arguments.length) return Array.from(this, Bf);
-  var n = t ? Yf : Hf, r = this._parents, i = this._groups;
-  typeof e != "function" && (e = zf(e));
+function Jf(e, t) {
+  if (!arguments.length) return Array.from(this, jf);
+  var n = t ? Kf : Gf, r = this._parents, i = this._groups;
+  typeof e != "function" && (e = Uf(e));
   for (var s = i.length, a = new Array(s), o = new Array(s), l = new Array(s), u = 0; u < s; ++u) {
-    var f = r[u], d = i[u], h = d.length, p = Wf(e.call(f, f && f.__data__, u, r)), _ = p.length, x = o[u] = new Array(_), y = a[u] = new Array(_), b = l[u] = new Array(h);
-    n(f, d, x, y, b, p, t);
-    for (var O = 0, N = 0, M, F; O < _; ++O)
-      if (M = x[O]) {
-        for (O >= N && (N = O + 1); !(F = y[N]) && ++N < _; ) ;
-        M._next = F || null;
+    var f = r[u], d = i[u], h = d.length, p = Zf(e.call(f, f && f.__data__, u, r)), y = p.length, E = o[u] = new Array(y), _ = a[u] = new Array(y), x = l[u] = new Array(h);
+    n(f, d, E, _, x, p, t);
+    for (var D = 0, N = 0, O, I; D < y; ++D)
+      if (O = E[D]) {
+        for (D >= N && (N = D + 1); !(I = _[N]) && ++N < y; ) ;
+        O._next = I || null;
       }
   }
   return a = new st(a, r), a._enter = o, a._exit = l, a;
 }
-function Wf(e) {
+function Zf(e) {
   return typeof e == "object" && "length" in e ? e : Array.from(e);
 }
-function Uf() {
-  return new st(this._exit || this._groups.map(Qo), this._parents);
+function Qf() {
+  return new st(this._exit || this._groups.map(rl), this._parents);
 }
-function Gf(e, t, n) {
+function ec(e, t, n) {
   var r = this.enter(), i = this, s = this.exit();
   return typeof e == "function" ? (r = e(r), r && (r = r.selection())) : r = r.append(e + ""), t != null && (i = t(i), i && (i = i.selection())), n == null ? s.remove() : n(s), r && i ? r.merge(i).order() : i;
 }
-function Kf(e) {
+function tc(e) {
   for (var t = e.selection ? e.selection() : e, n = this._groups, r = t._groups, i = n.length, s = r.length, a = Math.min(i, s), o = new Array(i), l = 0; l < a; ++l)
-    for (var u = n[l], f = r[l], d = u.length, h = o[l] = new Array(d), p, _ = 0; _ < d; ++_)
-      (p = u[_] || f[_]) && (h[_] = p);
+    for (var u = n[l], f = r[l], d = u.length, h = o[l] = new Array(d), p, y = 0; y < d; ++y)
+      (p = u[y] || f[y]) && (h[y] = p);
   for (; l < i; ++l)
     o[l] = n[l];
   return new st(o, this._parents);
 }
-function jf() {
+function nc() {
   for (var e = this._groups, t = -1, n = e.length; ++t < n; )
     for (var r = e[t], i = r.length - 1, s = r[i], a; --i >= 0; )
       (a = r[i]) && (s && a.compareDocumentPosition(s) ^ 4 && s.parentNode.insertBefore(a, s), s = a);
   return this;
 }
-function Jf(e) {
-  e || (e = Zf);
+function rc(e) {
+  e || (e = ic);
   function t(d, h) {
     return d && h ? e(d.__data__, h.__data__) : !d - !h;
   }
@@ -3177,17 +3177,17 @@ function Jf(e) {
   }
   return new st(i, this._parents).order();
 }
-function Zf(e, t) {
+function ic(e, t) {
   return e < t ? -1 : e > t ? 1 : e >= t ? 0 : NaN;
 }
-function Qf() {
+function sc() {
   var e = arguments[0];
   return arguments[0] = this, e.apply(null, arguments), this;
 }
-function ec() {
+function ac() {
   return Array.from(this);
 }
-function tc() {
+function oc() {
   for (var e = this._groups, t = 0, n = e.length; t < n; ++t)
     for (var r = e[t], i = 0, s = r.length; i < s; ++i) {
       var a = r[i];
@@ -3195,114 +3195,114 @@ function tc() {
     }
   return null;
 }
-function nc() {
+function lc() {
   let e = 0;
   for (const t of this) ++e;
   return e;
 }
-function rc() {
+function uc() {
   return !this.node();
 }
-function ic(e) {
+function fc(e) {
   for (var t = this._groups, n = 0, r = t.length; n < r; ++n)
     for (var i = t[n], s = 0, a = i.length, o; s < a; ++s)
       (o = i[s]) && e.call(o, o.__data__, s, i);
   return this;
 }
-function sc(e) {
+function cc(e) {
   return function() {
     this.removeAttribute(e);
   };
 }
-function ac(e) {
+function hc(e) {
   return function() {
     this.removeAttributeNS(e.space, e.local);
   };
 }
-function oc(e, t) {
+function dc(e, t) {
   return function() {
     this.setAttribute(e, t);
   };
 }
-function lc(e, t) {
+function pc(e, t) {
   return function() {
     this.setAttributeNS(e.space, e.local, t);
   };
 }
-function uc(e, t) {
+function vc(e, t) {
   return function() {
     var n = t.apply(this, arguments);
     n == null ? this.removeAttribute(e) : this.setAttribute(e, n);
   };
 }
-function fc(e, t) {
+function gc(e, t) {
   return function() {
     var n = t.apply(this, arguments);
     n == null ? this.removeAttributeNS(e.space, e.local) : this.setAttributeNS(e.space, e.local, n);
   };
 }
-function cc(e, t) {
-  var n = Xi(e);
+function _c(e, t) {
+  var n = Gi(e);
   if (arguments.length < 2) {
     var r = this.node();
     return n.local ? r.getAttributeNS(n.space, n.local) : r.getAttribute(n);
   }
-  return this.each((t == null ? n.local ? ac : sc : typeof t == "function" ? n.local ? fc : uc : n.local ? lc : oc)(n, t));
+  return this.each((t == null ? n.local ? hc : cc : typeof t == "function" ? n.local ? gc : vc : n.local ? pc : dc)(n, t));
 }
-function el(e) {
+function il(e) {
   return e.ownerDocument && e.ownerDocument.defaultView || e.document && e || e.defaultView;
 }
-function hc(e) {
+function mc(e) {
   return function() {
     this.style.removeProperty(e);
   };
 }
-function dc(e, t, n) {
+function yc(e, t, n) {
   return function() {
     this.style.setProperty(e, t, n);
   };
 }
-function pc(e, t, n) {
+function wc(e, t, n) {
   return function() {
     var r = t.apply(this, arguments);
     r == null ? this.style.removeProperty(e) : this.style.setProperty(e, r, n);
   };
 }
-function vc(e, t, n) {
-  return arguments.length > 1 ? this.each((t == null ? hc : typeof t == "function" ? pc : dc)(e, t, n ?? "")) : mr(this.node(), e);
+function xc(e, t, n) {
+  return arguments.length > 1 ? this.each((t == null ? mc : typeof t == "function" ? wc : yc)(e, t, n ?? "")) : xr(this.node(), e);
 }
-function mr(e, t) {
-  return e.style.getPropertyValue(t) || el(e).getComputedStyle(e, null).getPropertyValue(t);
+function xr(e, t) {
+  return e.style.getPropertyValue(t) || il(e).getComputedStyle(e, null).getPropertyValue(t);
 }
-function gc(e) {
+function bc(e) {
   return function() {
     delete this[e];
   };
 }
-function _c(e, t) {
+function $c(e, t) {
   return function() {
     this[e] = t;
   };
 }
-function mc(e, t) {
+function Ac(e, t) {
   return function() {
     var n = t.apply(this, arguments);
     n == null ? delete this[e] : this[e] = n;
   };
 }
-function yc(e, t) {
-  return arguments.length > 1 ? this.each((t == null ? gc : typeof t == "function" ? mc : _c)(e, t)) : this.node()[e];
+function Ec(e, t) {
+  return arguments.length > 1 ? this.each((t == null ? bc : typeof t == "function" ? Ac : $c)(e, t)) : this.node()[e];
 }
-function tl(e) {
+function sl(e) {
   return e.trim().split(/^|\s+/);
 }
-function Xs(e) {
-  return e.classList || new nl(e);
+function Ks(e) {
+  return e.classList || new al(e);
 }
-function nl(e) {
-  this._node = e, this._names = tl(e.getAttribute("class") || "");
+function al(e) {
+  this._node = e, this._names = sl(e.getAttribute("class") || "");
 }
-nl.prototype = {
+al.prototype = {
   add: function(e) {
     var t = this._names.indexOf(e);
     t < 0 && (this._names.push(e), this._node.setAttribute("class", this._names.join(" ")));
@@ -3315,129 +3315,129 @@ nl.prototype = {
     return this._names.indexOf(e) >= 0;
   }
 };
-function rl(e, t) {
-  for (var n = Xs(e), r = -1, i = t.length; ++r < i; ) n.add(t[r]);
+function ol(e, t) {
+  for (var n = Ks(e), r = -1, i = t.length; ++r < i; ) n.add(t[r]);
 }
-function il(e, t) {
-  for (var n = Xs(e), r = -1, i = t.length; ++r < i; ) n.remove(t[r]);
+function ll(e, t) {
+  for (var n = Ks(e), r = -1, i = t.length; ++r < i; ) n.remove(t[r]);
 }
-function wc(e) {
+function Tc(e) {
   return function() {
-    rl(this, e);
+    ol(this, e);
   };
 }
-function xc(e) {
+function Rc(e) {
   return function() {
-    il(this, e);
+    ll(this, e);
   };
 }
-function bc(e, t) {
+function Sc(e, t) {
   return function() {
-    (t.apply(this, arguments) ? rl : il)(this, e);
+    (t.apply(this, arguments) ? ol : ll)(this, e);
   };
 }
-function $c(e, t) {
-  var n = tl(e + "");
+function Cc(e, t) {
+  var n = sl(e + "");
   if (arguments.length < 2) {
-    for (var r = Xs(this.node()), i = -1, s = n.length; ++i < s; ) if (!r.contains(n[i])) return !1;
+    for (var r = Ks(this.node()), i = -1, s = n.length; ++i < s; ) if (!r.contains(n[i])) return !1;
     return !0;
   }
-  return this.each((typeof t == "function" ? bc : t ? wc : xc)(n, t));
+  return this.each((typeof t == "function" ? Sc : t ? Tc : Rc)(n, t));
 }
-function Ac() {
+function Nc() {
   this.textContent = "";
 }
-function Ec(e) {
+function kc(e) {
   return function() {
     this.textContent = e;
   };
 }
-function Tc(e) {
+function Pc(e) {
   return function() {
     var t = e.apply(this, arguments);
     this.textContent = t ?? "";
   };
 }
-function Rc(e) {
-  return arguments.length ? this.each(e == null ? Ac : (typeof e == "function" ? Tc : Ec)(e)) : this.node().textContent;
+function Mc(e) {
+  return arguments.length ? this.each(e == null ? Nc : (typeof e == "function" ? Pc : kc)(e)) : this.node().textContent;
 }
-function Sc() {
+function Dc() {
   this.innerHTML = "";
 }
-function Cc(e) {
+function Oc(e) {
   return function() {
     this.innerHTML = e;
   };
 }
-function Nc(e) {
+function Ic(e) {
   return function() {
     var t = e.apply(this, arguments);
     this.innerHTML = t ?? "";
   };
 }
-function kc(e) {
-  return arguments.length ? this.each(e == null ? Sc : (typeof e == "function" ? Nc : Cc)(e)) : this.node().innerHTML;
+function Fc(e) {
+  return arguments.length ? this.each(e == null ? Dc : (typeof e == "function" ? Ic : Oc)(e)) : this.node().innerHTML;
 }
-function Mc() {
+function Lc() {
   this.nextSibling && this.parentNode.appendChild(this);
 }
-function Pc() {
-  return this.each(Mc);
+function qc() {
+  return this.each(Lc);
 }
-function Dc() {
+function Vc() {
   this.previousSibling && this.parentNode.insertBefore(this, this.parentNode.firstChild);
 }
-function Oc() {
-  return this.each(Dc);
+function zc() {
+  return this.each(Vc);
 }
-function Fc(e) {
-  var t = typeof e == "function" ? e : Ko(e);
+function Hc(e) {
+  var t = typeof e == "function" ? e : Qo(e);
   return this.select(function() {
     return this.appendChild(t.apply(this, arguments));
   });
 }
-function Ic() {
+function Yc() {
   return null;
 }
-function Lc(e, t) {
-  var n = typeof e == "function" ? e : Ko(e), r = t == null ? Ic : typeof t == "function" ? t : Bs(t);
+function Bc(e, t) {
+  var n = typeof e == "function" ? e : Qo(e), r = t == null ? Yc : typeof t == "function" ? t : Gs(t);
   return this.select(function() {
     return this.insertBefore(n.apply(this, arguments), r.apply(this, arguments) || null);
   });
 }
-function qc() {
+function Xc() {
   var e = this.parentNode;
   e && e.removeChild(this);
 }
-function Vc() {
-  return this.each(qc);
+function Wc() {
+  return this.each(Xc);
 }
-function zc() {
+function Uc() {
   var e = this.cloneNode(!1), t = this.parentNode;
   return t ? t.insertBefore(e, this.nextSibling) : e;
 }
-function Hc() {
+function Gc() {
   var e = this.cloneNode(!0), t = this.parentNode;
   return t ? t.insertBefore(e, this.nextSibling) : e;
 }
-function Yc(e) {
-  return this.select(e ? Hc : zc);
+function Kc(e) {
+  return this.select(e ? Gc : Uc);
 }
-function Bc(e) {
+function jc(e) {
   return arguments.length ? this.property("__data__", e) : this.node().__data__;
 }
-function Xc(e) {
+function Jc(e) {
   return function(t) {
     e.call(this, t, this.__data__);
   };
 }
-function Wc(e) {
+function Zc(e) {
   return e.trim().split(/^|\s+/).map(function(t) {
     var n = "", r = t.indexOf(".");
     return r >= 0 && (n = t.slice(r + 1), t = t.slice(0, r)), { type: t, name: n };
   });
 }
-function Uc(e) {
+function Qc(e) {
   return function() {
     var t = this.__on;
     if (t) {
@@ -3447,9 +3447,9 @@ function Uc(e) {
     }
   };
 }
-function Gc(e, t, n) {
+function eh(e, t, n) {
   return function() {
-    var r = this.__on, i, s = Xc(t);
+    var r = this.__on, i, s = Jc(t);
     if (r) {
       for (var a = 0, o = r.length; a < o; ++a)
         if ((i = r[a]).type === e.type && i.name === e.name) {
@@ -3460,8 +3460,8 @@ function Gc(e, t, n) {
     this.addEventListener(e.type, s, n), i = { type: e.type, name: e.name, value: t, listener: s, options: n }, r ? r.push(i) : this.__on = [i];
   };
 }
-function Kc(e, t, n) {
-  var r = Wc(e + ""), i, s = r.length, a;
+function th(e, t, n) {
+  var r = Zc(e + ""), i, s = r.length, a;
   if (arguments.length < 2) {
     var o = this.node().__on;
     if (o) {
@@ -3472,93 +3472,93 @@ function Kc(e, t, n) {
     }
     return;
   }
-  for (o = t ? Gc : Uc, i = 0; i < s; ++i) this.each(o(r[i], t, n));
+  for (o = t ? eh : Qc, i = 0; i < s; ++i) this.each(o(r[i], t, n));
   return this;
 }
-function sl(e, t, n) {
-  var r = el(e), i = r.CustomEvent;
+function ul(e, t, n) {
+  var r = il(e), i = r.CustomEvent;
   typeof i == "function" ? i = new i(t, n) : (i = r.document.createEvent("Event"), n ? (i.initEvent(t, n.bubbles, n.cancelable), i.detail = n.detail) : i.initEvent(t, !1, !1)), e.dispatchEvent(i);
 }
-function jc(e, t) {
+function nh(e, t) {
   return function() {
-    return sl(this, e, t);
+    return ul(this, e, t);
   };
 }
-function Jc(e, t) {
+function rh(e, t) {
   return function() {
-    return sl(this, e, t.apply(this, arguments));
+    return ul(this, e, t.apply(this, arguments));
   };
 }
-function Zc(e, t) {
-  return this.each((typeof t == "function" ? Jc : jc)(e, t));
+function ih(e, t) {
+  return this.each((typeof t == "function" ? rh : nh)(e, t));
 }
-function* Qc() {
+function* sh() {
   for (var e = this._groups, t = 0, n = e.length; t < n; ++t)
     for (var r = e[t], i = 0, s = r.length, a; i < s; ++i)
       (a = r[i]) && (yield a);
 }
-var al = [null];
+var fl = [null];
 function st(e, t) {
   this._groups = e, this._parents = t;
 }
-function br() {
-  return new st([[document.documentElement]], al);
+function Er() {
+  return new st([[document.documentElement]], fl);
 }
-function eh() {
+function ah() {
   return this;
 }
-st.prototype = br.prototype = {
+st.prototype = Er.prototype = {
   constructor: st,
-  select: Tf,
-  selectAll: Nf,
-  selectChild: Df,
-  selectChildren: Lf,
-  filter: qf,
-  data: Xf,
-  enter: Vf,
-  exit: Uf,
-  join: Gf,
-  merge: Kf,
-  selection: eh,
-  order: jf,
-  sort: Jf,
-  call: Qf,
-  nodes: ec,
-  node: tc,
-  size: nc,
-  empty: rc,
-  each: ic,
-  attr: cc,
-  style: vc,
-  property: yc,
-  classed: $c,
-  text: Rc,
-  html: kc,
-  raise: Pc,
-  lower: Oc,
-  append: Fc,
-  insert: Lc,
-  remove: Vc,
-  clone: Yc,
-  datum: Bc,
-  on: Kc,
-  dispatch: Zc,
-  [Symbol.iterator]: Qc
+  select: Pf,
+  selectAll: If,
+  selectChild: Vf,
+  selectChildren: Bf,
+  filter: Xf,
+  data: Jf,
+  enter: Wf,
+  exit: Qf,
+  join: ec,
+  merge: tc,
+  selection: ah,
+  order: nc,
+  sort: rc,
+  call: sc,
+  nodes: ac,
+  node: oc,
+  size: lc,
+  empty: uc,
+  each: fc,
+  attr: _c,
+  style: xc,
+  property: Ec,
+  classed: Cc,
+  text: Mc,
+  html: Fc,
+  raise: qc,
+  lower: zc,
+  append: Hc,
+  insert: Bc,
+  remove: Wc,
+  clone: Kc,
+  datum: jc,
+  on: th,
+  dispatch: ih,
+  [Symbol.iterator]: sh
 };
-function he(e) {
-  return typeof e == "string" ? new st([[document.querySelector(e)]], [document.documentElement]) : new st([[e]], al);
+function ue(e) {
+  return typeof e == "string" ? new st([[document.querySelector(e)]], [document.documentElement]) : new st([[e]], fl);
 }
-function Ws(e, t, n) {
+function js(e, t, n) {
   e.prototype = t.prototype = n, n.constructor = e;
 }
-function ol(e, t) {
+function cl(e, t) {
   var n = Object.create(e.prototype);
   for (var r in t) n[r] = t[r];
   return n;
 }
-function Jr() {
+function ei() {
 }
-var Vr = 0.7, Ei = 1 / Vr, rr = "\\s*([+-]?\\d+)\\s*", zr = "\\s*([+-]?(?:\\d*\\.)?\\d+(?:[eE][+-]?\\d+)?)\\s*", qt = "\\s*([+-]?(?:\\d*\\.)?\\d+(?:[eE][+-]?\\d+)?)%\\s*", th = /^#([0-9a-f]{3,8})$/, nh = new RegExp(`^rgb\\(${rr},${rr},${rr}\\)$`), rh = new RegExp(`^rgb\\(${qt},${qt},${qt}\\)$`), ih = new RegExp(`^rgba\\(${rr},${rr},${rr},${zr}\\)$`), sh = new RegExp(`^rgba\\(${qt},${qt},${qt},${zr}\\)$`), ah = new RegExp(`^hsl\\(${zr},${qt},${qt}\\)$`), oh = new RegExp(`^hsla\\(${zr},${qt},${qt},${zr}\\)$`), Ra = {
+var Hr = 0.7, Ci = 1 / Hr, ar = "\\s*([+-]?\\d+)\\s*", Yr = "\\s*([+-]?(?:\\d*\\.)?\\d+(?:[eE][+-]?\\d+)?)\\s*", Lt = "\\s*([+-]?(?:\\d*\\.)?\\d+(?:[eE][+-]?\\d+)?)%\\s*", oh = /^#([0-9a-f]{3,8})$/, lh = new RegExp(`^rgb\\(${ar},${ar},${ar}\\)$`), uh = new RegExp(`^rgb\\(${Lt},${Lt},${Lt}\\)$`), fh = new RegExp(`^rgba\\(${ar},${ar},${ar},${Yr}\\)$`), ch = new RegExp(`^rgba\\(${Lt},${Lt},${Lt},${Yr}\\)$`), hh = new RegExp(`^hsl\\(${Yr},${Lt},${Lt}\\)$`), dh = new RegExp(`^hsla\\(${Yr},${Lt},${Lt},${Yr}\\)$`), ka = {
   aliceblue: 15792383,
   antiquewhite: 16444375,
   aqua: 65535,
@@ -3708,178 +3708,178 @@ var Vr = 0.7, Ei = 1 / Vr, rr = "\\s*([+-]?\\d+)\\s*", zr = "\\s*([+-]?(?:\\d*\\
   yellow: 16776960,
   yellowgreen: 10145074
 };
-Ws(Jr, Gn, {
+js(ei, jn, {
   copy(e) {
     return Object.assign(new this.constructor(), this, e);
   },
   displayable() {
     return this.rgb().displayable();
   },
-  hex: Sa,
+  hex: Pa,
   // Deprecated! Use color.formatHex.
-  formatHex: Sa,
-  formatHex8: lh,
-  formatHsl: uh,
-  formatRgb: Ca,
-  toString: Ca
+  formatHex: Pa,
+  formatHex8: ph,
+  formatHsl: vh,
+  formatRgb: Ma,
+  toString: Ma
 });
-function Sa() {
+function Pa() {
   return this.rgb().formatHex();
 }
-function lh() {
+function ph() {
   return this.rgb().formatHex8();
 }
-function uh() {
-  return ll(this).formatHsl();
+function vh() {
+  return hl(this).formatHsl();
 }
-function Ca() {
+function Ma() {
   return this.rgb().formatRgb();
 }
-function Gn(e) {
+function jn(e) {
   var t, n;
-  return e = (e + "").trim().toLowerCase(), (t = th.exec(e)) ? (n = t[1].length, t = parseInt(t[1], 16), n === 6 ? Na(t) : n === 3 ? new Ke(t >> 8 & 15 | t >> 4 & 240, t >> 4 & 15 | t & 240, (t & 15) << 4 | t & 15, 1) : n === 8 ? si(t >> 24 & 255, t >> 16 & 255, t >> 8 & 255, (t & 255) / 255) : n === 4 ? si(t >> 12 & 15 | t >> 8 & 240, t >> 8 & 15 | t >> 4 & 240, t >> 4 & 15 | t & 240, ((t & 15) << 4 | t & 15) / 255) : null) : (t = nh.exec(e)) ? new Ke(t[1], t[2], t[3], 1) : (t = rh.exec(e)) ? new Ke(t[1] * 255 / 100, t[2] * 255 / 100, t[3] * 255 / 100, 1) : (t = ih.exec(e)) ? si(t[1], t[2], t[3], t[4]) : (t = sh.exec(e)) ? si(t[1] * 255 / 100, t[2] * 255 / 100, t[3] * 255 / 100, t[4]) : (t = ah.exec(e)) ? Pa(t[1], t[2] / 100, t[3] / 100, 1) : (t = oh.exec(e)) ? Pa(t[1], t[2] / 100, t[3] / 100, t[4]) : Ra.hasOwnProperty(e) ? Na(Ra[e]) : e === "transparent" ? new Ke(NaN, NaN, NaN, 0) : null;
+  return e = (e + "").trim().toLowerCase(), (t = oh.exec(e)) ? (n = t[1].length, t = parseInt(t[1], 16), n === 6 ? Da(t) : n === 3 ? new Ue(t >> 8 & 15 | t >> 4 & 240, t >> 4 & 15 | t & 240, (t & 15) << 4 | t & 15, 1) : n === 8 ? li(t >> 24 & 255, t >> 16 & 255, t >> 8 & 255, (t & 255) / 255) : n === 4 ? li(t >> 12 & 15 | t >> 8 & 240, t >> 8 & 15 | t >> 4 & 240, t >> 4 & 15 | t & 240, ((t & 15) << 4 | t & 15) / 255) : null) : (t = lh.exec(e)) ? new Ue(t[1], t[2], t[3], 1) : (t = uh.exec(e)) ? new Ue(t[1] * 255 / 100, t[2] * 255 / 100, t[3] * 255 / 100, 1) : (t = fh.exec(e)) ? li(t[1], t[2], t[3], t[4]) : (t = ch.exec(e)) ? li(t[1] * 255 / 100, t[2] * 255 / 100, t[3] * 255 / 100, t[4]) : (t = hh.exec(e)) ? Fa(t[1], t[2] / 100, t[3] / 100, 1) : (t = dh.exec(e)) ? Fa(t[1], t[2] / 100, t[3] / 100, t[4]) : ka.hasOwnProperty(e) ? Da(ka[e]) : e === "transparent" ? new Ue(NaN, NaN, NaN, 0) : null;
 }
-function Na(e) {
-  return new Ke(e >> 16 & 255, e >> 8 & 255, e & 255, 1);
+function Da(e) {
+  return new Ue(e >> 16 & 255, e >> 8 & 255, e & 255, 1);
 }
-function si(e, t, n, r) {
-  return r <= 0 && (e = t = n = NaN), new Ke(e, t, n, r);
+function li(e, t, n, r) {
+  return r <= 0 && (e = t = n = NaN), new Ue(e, t, n, r);
 }
-function fh(e) {
-  return e instanceof Jr || (e = Gn(e)), e ? (e = e.rgb(), new Ke(e.r, e.g, e.b, e.opacity)) : new Ke();
+function gh(e) {
+  return e instanceof ei || (e = jn(e)), e ? (e = e.rgb(), new Ue(e.r, e.g, e.b, e.opacity)) : new Ue();
 }
-function bs(e, t, n, r) {
-  return arguments.length === 1 ? fh(e) : new Ke(e, t, n, r ?? 1);
+function Rs(e, t, n, r) {
+  return arguments.length === 1 ? gh(e) : new Ue(e, t, n, r ?? 1);
 }
-function Ke(e, t, n, r) {
+function Ue(e, t, n, r) {
   this.r = +e, this.g = +t, this.b = +n, this.opacity = +r;
 }
-Ws(Ke, bs, ol(Jr, {
+js(Ue, Rs, cl(ei, {
   brighter(e) {
-    return e = e == null ? Ei : Math.pow(Ei, e), new Ke(this.r * e, this.g * e, this.b * e, this.opacity);
+    return e = e == null ? Ci : Math.pow(Ci, e), new Ue(this.r * e, this.g * e, this.b * e, this.opacity);
   },
   darker(e) {
-    return e = e == null ? Vr : Math.pow(Vr, e), new Ke(this.r * e, this.g * e, this.b * e, this.opacity);
+    return e = e == null ? Hr : Math.pow(Hr, e), new Ue(this.r * e, this.g * e, this.b * e, this.opacity);
   },
   rgb() {
     return this;
   },
   clamp() {
-    return new Ke(Xn(this.r), Xn(this.g), Xn(this.b), Ti(this.opacity));
+    return new Ue(Un(this.r), Un(this.g), Un(this.b), Ni(this.opacity));
   },
   displayable() {
     return -0.5 <= this.r && this.r < 255.5 && -0.5 <= this.g && this.g < 255.5 && -0.5 <= this.b && this.b < 255.5 && 0 <= this.opacity && this.opacity <= 1;
   },
-  hex: ka,
+  hex: Oa,
   // Deprecated! Use color.formatHex.
-  formatHex: ka,
-  formatHex8: ch,
-  formatRgb: Ma,
-  toString: Ma
+  formatHex: Oa,
+  formatHex8: _h,
+  formatRgb: Ia,
+  toString: Ia
 }));
-function ka() {
-  return `#${On(this.r)}${On(this.g)}${On(this.b)}`;
+function Oa() {
+  return `#${Fn(this.r)}${Fn(this.g)}${Fn(this.b)}`;
 }
-function ch() {
-  return `#${On(this.r)}${On(this.g)}${On(this.b)}${On((isNaN(this.opacity) ? 1 : this.opacity) * 255)}`;
+function _h() {
+  return `#${Fn(this.r)}${Fn(this.g)}${Fn(this.b)}${Fn((isNaN(this.opacity) ? 1 : this.opacity) * 255)}`;
 }
-function Ma() {
-  const e = Ti(this.opacity);
-  return `${e === 1 ? "rgb(" : "rgba("}${Xn(this.r)}, ${Xn(this.g)}, ${Xn(this.b)}${e === 1 ? ")" : `, ${e})`}`;
+function Ia() {
+  const e = Ni(this.opacity);
+  return `${e === 1 ? "rgb(" : "rgba("}${Un(this.r)}, ${Un(this.g)}, ${Un(this.b)}${e === 1 ? ")" : `, ${e})`}`;
 }
-function Ti(e) {
+function Ni(e) {
   return isNaN(e) ? 1 : Math.max(0, Math.min(1, e));
 }
-function Xn(e) {
+function Un(e) {
   return Math.max(0, Math.min(255, Math.round(e) || 0));
 }
-function On(e) {
-  return e = Xn(e), (e < 16 ? "0" : "") + e.toString(16);
+function Fn(e) {
+  return e = Un(e), (e < 16 ? "0" : "") + e.toString(16);
 }
-function Pa(e, t, n, r) {
-  return r <= 0 ? e = t = n = NaN : n <= 0 || n >= 1 ? e = t = NaN : t <= 0 && (e = NaN), new bt(e, t, n, r);
+function Fa(e, t, n, r) {
+  return r <= 0 ? e = t = n = NaN : n <= 0 || n >= 1 ? e = t = NaN : t <= 0 && (e = NaN), new wt(e, t, n, r);
 }
-function ll(e) {
-  if (e instanceof bt) return new bt(e.h, e.s, e.l, e.opacity);
-  if (e instanceof Jr || (e = Gn(e)), !e) return new bt();
-  if (e instanceof bt) return e;
+function hl(e) {
+  if (e instanceof wt) return new wt(e.h, e.s, e.l, e.opacity);
+  if (e instanceof ei || (e = jn(e)), !e) return new wt();
+  if (e instanceof wt) return e;
   e = e.rgb();
   var t = e.r / 255, n = e.g / 255, r = e.b / 255, i = Math.min(t, n, r), s = Math.max(t, n, r), a = NaN, o = s - i, l = (s + i) / 2;
-  return o ? (t === s ? a = (n - r) / o + (n < r) * 6 : n === s ? a = (r - t) / o + 2 : a = (t - n) / o + 4, o /= l < 0.5 ? s + i : 2 - s - i, a *= 60) : o = l > 0 && l < 1 ? 0 : a, new bt(a, o, l, e.opacity);
+  return o ? (t === s ? a = (n - r) / o + (n < r) * 6 : n === s ? a = (r - t) / o + 2 : a = (t - n) / o + 4, o /= l < 0.5 ? s + i : 2 - s - i, a *= 60) : o = l > 0 && l < 1 ? 0 : a, new wt(a, o, l, e.opacity);
 }
-function hh(e, t, n, r) {
-  return arguments.length === 1 ? ll(e) : new bt(e, t, n, r ?? 1);
+function mh(e, t, n, r) {
+  return arguments.length === 1 ? hl(e) : new wt(e, t, n, r ?? 1);
 }
-function bt(e, t, n, r) {
+function wt(e, t, n, r) {
   this.h = +e, this.s = +t, this.l = +n, this.opacity = +r;
 }
-Ws(bt, hh, ol(Jr, {
+js(wt, mh, cl(ei, {
   brighter(e) {
-    return e = e == null ? Ei : Math.pow(Ei, e), new bt(this.h, this.s, this.l * e, this.opacity);
+    return e = e == null ? Ci : Math.pow(Ci, e), new wt(this.h, this.s, this.l * e, this.opacity);
   },
   darker(e) {
-    return e = e == null ? Vr : Math.pow(Vr, e), new bt(this.h, this.s, this.l * e, this.opacity);
+    return e = e == null ? Hr : Math.pow(Hr, e), new wt(this.h, this.s, this.l * e, this.opacity);
   },
   rgb() {
     var e = this.h % 360 + (this.h < 0) * 360, t = isNaN(e) || isNaN(this.s) ? 0 : this.s, n = this.l, r = n + (n < 0.5 ? n : 1 - n) * t, i = 2 * n - r;
-    return new Ke(
-      rs(e >= 240 ? e - 240 : e + 120, i, r),
-      rs(e, i, r),
-      rs(e < 120 ? e + 240 : e - 120, i, r),
+    return new Ue(
+      ls(e >= 240 ? e - 240 : e + 120, i, r),
+      ls(e, i, r),
+      ls(e < 120 ? e + 240 : e - 120, i, r),
       this.opacity
     );
   },
   clamp() {
-    return new bt(Da(this.h), ai(this.s), ai(this.l), Ti(this.opacity));
+    return new wt(La(this.h), ui(this.s), ui(this.l), Ni(this.opacity));
   },
   displayable() {
     return (0 <= this.s && this.s <= 1 || isNaN(this.s)) && 0 <= this.l && this.l <= 1 && 0 <= this.opacity && this.opacity <= 1;
   },
   formatHsl() {
-    const e = Ti(this.opacity);
-    return `${e === 1 ? "hsl(" : "hsla("}${Da(this.h)}, ${ai(this.s) * 100}%, ${ai(this.l) * 100}%${e === 1 ? ")" : `, ${e})`}`;
+    const e = Ni(this.opacity);
+    return `${e === 1 ? "hsl(" : "hsla("}${La(this.h)}, ${ui(this.s) * 100}%, ${ui(this.l) * 100}%${e === 1 ? ")" : `, ${e})`}`;
   }
 }));
-function Da(e) {
+function La(e) {
   return e = (e || 0) % 360, e < 0 ? e + 360 : e;
 }
-function ai(e) {
+function ui(e) {
   return Math.max(0, Math.min(1, e || 0));
 }
-function rs(e, t, n) {
+function ls(e, t, n) {
   return (e < 60 ? t + (n - t) * e / 60 : e < 180 ? n : e < 240 ? t + (n - t) * (240 - e) / 60 : t) * 255;
 }
-const Us = (e) => () => e;
-function dh(e, t) {
+const Js = (e) => () => e;
+function yh(e, t) {
   return function(n) {
     return e + n * t;
   };
 }
-function ph(e, t, n) {
+function wh(e, t, n) {
   return e = Math.pow(e, n), t = Math.pow(t, n) - e, n = 1 / n, function(r) {
     return Math.pow(e + r * t, n);
   };
 }
-function vh(e) {
-  return (e = +e) == 1 ? ul : function(t, n) {
-    return n - t ? ph(t, n, e) : Us(isNaN(t) ? n : t);
+function xh(e) {
+  return (e = +e) == 1 ? dl : function(t, n) {
+    return n - t ? wh(t, n, e) : Js(isNaN(t) ? n : t);
   };
 }
-function ul(e, t) {
+function dl(e, t) {
   var n = t - e;
-  return n ? dh(e, n) : Us(isNaN(e) ? t : e);
+  return n ? yh(e, n) : Js(isNaN(e) ? t : e);
 }
-const Ri = (function e(t) {
-  var n = vh(t);
+const ki = (function e(t) {
+  var n = xh(t);
   function r(i, s) {
-    var a = n((i = bs(i)).r, (s = bs(s)).r), o = n(i.g, s.g), l = n(i.b, s.b), u = ul(i.opacity, s.opacity);
+    var a = n((i = Rs(i)).r, (s = Rs(s)).r), o = n(i.g, s.g), l = n(i.b, s.b), u = dl(i.opacity, s.opacity);
     return function(f) {
       return i.r = a(f), i.g = o(f), i.b = l(f), i.opacity = u(f), i + "";
     };
   }
   return r.gamma = e, r;
 })(1);
-function gh(e, t) {
+function bh(e, t) {
   t || (t = []);
   var n = e ? Math.min(t.length, e.length) : 0, r = t.slice(), i;
   return function(s) {
@@ -3887,64 +3887,64 @@ function gh(e, t) {
     return r;
   };
 }
-function _h(e) {
+function $h(e) {
   return ArrayBuffer.isView(e) && !(e instanceof DataView);
 }
-function mh(e, t) {
+function Ah(e, t) {
   var n = t ? t.length : 0, r = e ? Math.min(n, e.length) : 0, i = new Array(r), s = new Array(n), a;
-  for (a = 0; a < r; ++a) i[a] = Jt(e[a], t[a]);
+  for (a = 0; a < r; ++a) i[a] = Qt(e[a], t[a]);
   for (; a < n; ++a) s[a] = t[a];
   return function(o) {
     for (a = 0; a < r; ++a) s[a] = i[a](o);
     return s;
   };
 }
-function yh(e, t) {
+function Eh(e, t) {
   var n = /* @__PURE__ */ new Date();
   return e = +e, t = +t, function(r) {
     return n.setTime(e * (1 - r) + t * r), n;
   };
 }
-function Lt(e, t) {
+function Ft(e, t) {
   return e = +e, t = +t, function(n) {
     return e * (1 - n) + t * n;
   };
 }
-function wh(e, t) {
+function Th(e, t) {
   var n = {}, r = {}, i;
   (e === null || typeof e != "object") && (e = {}), (t === null || typeof t != "object") && (t = {});
   for (i in t)
-    i in e ? n[i] = Jt(e[i], t[i]) : r[i] = t[i];
+    i in e ? n[i] = Qt(e[i], t[i]) : r[i] = t[i];
   return function(s) {
     for (i in n) r[i] = n[i](s);
     return r;
   };
 }
-var $s = /[-+]?(?:\d+\.?\d*|\.?\d+)(?:[eE][-+]?\d+)?/g, is = new RegExp($s.source, "g");
-function xh(e) {
+var Ss = /[-+]?(?:\d+\.?\d*|\.?\d+)(?:[eE][-+]?\d+)?/g, us = new RegExp(Ss.source, "g");
+function Rh(e) {
   return function() {
     return e;
   };
 }
-function bh(e) {
+function Sh(e) {
   return function(t) {
     return e(t) + "";
   };
 }
-function fl(e, t) {
-  var n = $s.lastIndex = is.lastIndex = 0, r, i, s, a = -1, o = [], l = [];
-  for (e = e + "", t = t + ""; (r = $s.exec(e)) && (i = is.exec(t)); )
-    (s = i.index) > n && (s = t.slice(n, s), o[a] ? o[a] += s : o[++a] = s), (r = r[0]) === (i = i[0]) ? o[a] ? o[a] += i : o[++a] = i : (o[++a] = null, l.push({ i: a, x: Lt(r, i) })), n = is.lastIndex;
-  return n < t.length && (s = t.slice(n), o[a] ? o[a] += s : o[++a] = s), o.length < 2 ? l[0] ? bh(l[0].x) : xh(t) : (t = l.length, function(u) {
+function pl(e, t) {
+  var n = Ss.lastIndex = us.lastIndex = 0, r, i, s, a = -1, o = [], l = [];
+  for (e = e + "", t = t + ""; (r = Ss.exec(e)) && (i = us.exec(t)); )
+    (s = i.index) > n && (s = t.slice(n, s), o[a] ? o[a] += s : o[++a] = s), (r = r[0]) === (i = i[0]) ? o[a] ? o[a] += i : o[++a] = i : (o[++a] = null, l.push({ i: a, x: Ft(r, i) })), n = us.lastIndex;
+  return n < t.length && (s = t.slice(n), o[a] ? o[a] += s : o[++a] = s), o.length < 2 ? l[0] ? Sh(l[0].x) : Rh(t) : (t = l.length, function(u) {
     for (var f = 0, d; f < t; ++f) o[(d = l[f]).i] = d.x(u);
     return o.join("");
   });
 }
-function Jt(e, t) {
+function Qt(e, t) {
   var n = typeof t, r;
-  return t == null || n === "boolean" ? Us(t) : (n === "number" ? Lt : n === "string" ? (r = Gn(t)) ? (t = r, Ri) : fl : t instanceof Gn ? Ri : t instanceof Date ? yh : _h(t) ? gh : Array.isArray(t) ? mh : typeof t.valueOf != "function" && typeof t.toString != "function" || isNaN(t) ? wh : Lt)(e, t);
+  return t == null || n === "boolean" ? Js(t) : (n === "number" ? Ft : n === "string" ? (r = jn(t)) ? (t = r, ki) : pl : t instanceof jn ? ki : t instanceof Date ? Eh : $h(t) ? bh : Array.isArray(t) ? Ah : typeof t.valueOf != "function" && typeof t.toString != "function" || isNaN(t) ? Th : Ft)(e, t);
 }
-var Oa = 180 / Math.PI, As = {
+var qa = 180 / Math.PI, Cs = {
   translateX: 0,
   translateY: 0,
   rotate: 0,
@@ -3952,187 +3952,187 @@ var Oa = 180 / Math.PI, As = {
   scaleX: 1,
   scaleY: 1
 };
-function cl(e, t, n, r, i, s) {
+function vl(e, t, n, r, i, s) {
   var a, o, l;
   return (a = Math.sqrt(e * e + t * t)) && (e /= a, t /= a), (l = e * n + t * r) && (n -= e * l, r -= t * l), (o = Math.sqrt(n * n + r * r)) && (n /= o, r /= o, l /= o), e * r < t * n && (e = -e, t = -t, l = -l, a = -a), {
     translateX: i,
     translateY: s,
-    rotate: Math.atan2(t, e) * Oa,
-    skewX: Math.atan(l) * Oa,
+    rotate: Math.atan2(t, e) * qa,
+    skewX: Math.atan(l) * qa,
     scaleX: a,
     scaleY: o
   };
 }
-var oi;
-function $h(e) {
+var fi;
+function Ch(e) {
   const t = new (typeof DOMMatrix == "function" ? DOMMatrix : WebKitCSSMatrix)(e + "");
-  return t.isIdentity ? As : cl(t.a, t.b, t.c, t.d, t.e, t.f);
+  return t.isIdentity ? Cs : vl(t.a, t.b, t.c, t.d, t.e, t.f);
 }
-function Ah(e) {
-  return e == null || (oi || (oi = document.createElementNS("http://www.w3.org/2000/svg", "g")), oi.setAttribute("transform", e), !(e = oi.transform.baseVal.consolidate())) ? As : (e = e.matrix, cl(e.a, e.b, e.c, e.d, e.e, e.f));
+function Nh(e) {
+  return e == null || (fi || (fi = document.createElementNS("http://www.w3.org/2000/svg", "g")), fi.setAttribute("transform", e), !(e = fi.transform.baseVal.consolidate())) ? Cs : (e = e.matrix, vl(e.a, e.b, e.c, e.d, e.e, e.f));
 }
-function hl(e, t, n, r) {
+function gl(e, t, n, r) {
   function i(u) {
     return u.length ? u.pop() + " " : "";
   }
-  function s(u, f, d, h, p, _) {
+  function s(u, f, d, h, p, y) {
     if (u !== d || f !== h) {
-      var x = p.push("translate(", null, t, null, n);
-      _.push({ i: x - 4, x: Lt(u, d) }, { i: x - 2, x: Lt(f, h) });
+      var E = p.push("translate(", null, t, null, n);
+      y.push({ i: E - 4, x: Ft(u, d) }, { i: E - 2, x: Ft(f, h) });
     } else (d || h) && p.push("translate(" + d + t + h + n);
   }
   function a(u, f, d, h) {
-    u !== f ? (u - f > 180 ? f += 360 : f - u > 180 && (u += 360), h.push({ i: d.push(i(d) + "rotate(", null, r) - 2, x: Lt(u, f) })) : f && d.push(i(d) + "rotate(" + f + r);
+    u !== f ? (u - f > 180 ? f += 360 : f - u > 180 && (u += 360), h.push({ i: d.push(i(d) + "rotate(", null, r) - 2, x: Ft(u, f) })) : f && d.push(i(d) + "rotate(" + f + r);
   }
   function o(u, f, d, h) {
-    u !== f ? h.push({ i: d.push(i(d) + "skewX(", null, r) - 2, x: Lt(u, f) }) : f && d.push(i(d) + "skewX(" + f + r);
+    u !== f ? h.push({ i: d.push(i(d) + "skewX(", null, r) - 2, x: Ft(u, f) }) : f && d.push(i(d) + "skewX(" + f + r);
   }
-  function l(u, f, d, h, p, _) {
+  function l(u, f, d, h, p, y) {
     if (u !== d || f !== h) {
-      var x = p.push(i(p) + "scale(", null, ",", null, ")");
-      _.push({ i: x - 4, x: Lt(u, d) }, { i: x - 2, x: Lt(f, h) });
+      var E = p.push(i(p) + "scale(", null, ",", null, ")");
+      y.push({ i: E - 4, x: Ft(u, d) }, { i: E - 2, x: Ft(f, h) });
     } else (d !== 1 || h !== 1) && p.push(i(p) + "scale(" + d + "," + h + ")");
   }
   return function(u, f) {
     var d = [], h = [];
     return u = e(u), f = e(f), s(u.translateX, u.translateY, f.translateX, f.translateY, d, h), a(u.rotate, f.rotate, d, h), o(u.skewX, f.skewX, d, h), l(u.scaleX, u.scaleY, f.scaleX, f.scaleY, d, h), u = f = null, function(p) {
-      for (var _ = -1, x = h.length, y; ++_ < x; ) d[(y = h[_]).i] = y.x(p);
+      for (var y = -1, E = h.length, _; ++y < E; ) d[(_ = h[y]).i] = _.x(p);
       return d.join("");
     };
   };
 }
-var Eh = hl($h, "px, ", "px)", "deg)"), Th = hl(Ah, ", ", ")", ")"), yr = 0, Mr = 0, Nr = 0, dl = 1e3, Si, Pr, Ci = 0, Kn = 0, Wi = 0, Hr = typeof performance == "object" && performance.now ? performance : Date, pl = typeof window == "object" && window.requestAnimationFrame ? window.requestAnimationFrame.bind(window) : function(e) {
+var kh = gl(Ch, "px, ", "px)", "deg)"), Ph = gl(Nh, ", ", ")", ")"), br = 0, Dr = 0, Pr = 0, _l = 1e3, Pi, Or, Mi = 0, Jn = 0, Ki = 0, Br = typeof performance == "object" && performance.now ? performance : Date, ml = typeof window == "object" && window.requestAnimationFrame ? window.requestAnimationFrame.bind(window) : function(e) {
   setTimeout(e, 17);
 };
-function Gs() {
-  return Kn || (pl(Rh), Kn = Hr.now() + Wi);
+function Zs() {
+  return Jn || (ml(Mh), Jn = Br.now() + Ki);
 }
-function Rh() {
-  Kn = 0;
+function Mh() {
+  Jn = 0;
 }
-function Ni() {
+function Di() {
   this._call = this._time = this._next = null;
 }
-Ni.prototype = vl.prototype = {
-  constructor: Ni,
+Di.prototype = yl.prototype = {
+  constructor: Di,
   restart: function(e, t, n) {
     if (typeof e != "function") throw new TypeError("callback is not a function");
-    n = (n == null ? Gs() : +n) + (t == null ? 0 : +t), !this._next && Pr !== this && (Pr ? Pr._next = this : Si = this, Pr = this), this._call = e, this._time = n, Es();
+    n = (n == null ? Zs() : +n) + (t == null ? 0 : +t), !this._next && Or !== this && (Or ? Or._next = this : Pi = this, Or = this), this._call = e, this._time = n, Ns();
   },
   stop: function() {
-    this._call && (this._call = null, this._time = 1 / 0, Es());
+    this._call && (this._call = null, this._time = 1 / 0, Ns());
   }
 };
-function vl(e, t, n) {
-  var r = new Ni();
+function yl(e, t, n) {
+  var r = new Di();
   return r.restart(e, t, n), r;
 }
-function Sh() {
-  Gs(), ++yr;
-  for (var e = Si, t; e; )
-    (t = Kn - e._time) >= 0 && e._call.call(void 0, t), e = e._next;
-  --yr;
+function Dh() {
+  Zs(), ++br;
+  for (var e = Pi, t; e; )
+    (t = Jn - e._time) >= 0 && e._call.call(void 0, t), e = e._next;
+  --br;
 }
-function Fa() {
-  Kn = (Ci = Hr.now()) + Wi, yr = Mr = 0;
+function Va() {
+  Jn = (Mi = Br.now()) + Ki, br = Dr = 0;
   try {
-    Sh();
+    Dh();
   } finally {
-    yr = 0, Nh(), Kn = 0;
+    br = 0, Ih(), Jn = 0;
   }
 }
-function Ch() {
-  var e = Hr.now(), t = e - Ci;
-  t > dl && (Wi -= t, Ci = e);
+function Oh() {
+  var e = Br.now(), t = e - Mi;
+  t > _l && (Ki -= t, Mi = e);
 }
-function Nh() {
-  for (var e, t = Si, n, r = 1 / 0; t; )
-    t._call ? (r > t._time && (r = t._time), e = t, t = t._next) : (n = t._next, t._next = null, t = e ? e._next = n : Si = n);
-  Pr = e, Es(r);
+function Ih() {
+  for (var e, t = Pi, n, r = 1 / 0; t; )
+    t._call ? (r > t._time && (r = t._time), e = t, t = t._next) : (n = t._next, t._next = null, t = e ? e._next = n : Pi = n);
+  Or = e, Ns(r);
 }
-function Es(e) {
-  if (!yr) {
-    Mr && (Mr = clearTimeout(Mr));
-    var t = e - Kn;
-    t > 24 ? (e < 1 / 0 && (Mr = setTimeout(Fa, e - Hr.now() - Wi)), Nr && (Nr = clearInterval(Nr))) : (Nr || (Ci = Hr.now(), Nr = setInterval(Ch, dl)), yr = 1, pl(Fa));
+function Ns(e) {
+  if (!br) {
+    Dr && (Dr = clearTimeout(Dr));
+    var t = e - Jn;
+    t > 24 ? (e < 1 / 0 && (Dr = setTimeout(Va, e - Br.now() - Ki)), Pr && (Pr = clearInterval(Pr))) : (Pr || (Mi = Br.now(), Pr = setInterval(Oh, _l)), br = 1, ml(Va));
   }
 }
-function Ia(e, t, n) {
-  var r = new Ni();
+function za(e, t, n) {
+  var r = new Di();
   return t = t == null ? 0 : +t, r.restart((i) => {
     r.stop(), e(i + t);
   }, t, n), r;
 }
-var kh = Go("start", "end", "cancel", "interrupt"), Mh = [], gl = 0, La = 1, Ts = 2, _i = 3, qa = 4, Rs = 5, mi = 6;
-function Ui(e, t, n, r, i, s) {
+var Fh = Zo("start", "end", "cancel", "interrupt"), Lh = [], wl = 0, Ha = 1, ks = 2, wi = 3, Ya = 4, Ps = 5, xi = 6;
+function ji(e, t, n, r, i, s) {
   var a = e.__transition;
   if (!a) e.__transition = {};
   else if (n in a) return;
-  Ph(e, n, {
+  qh(e, n, {
     name: t,
     index: r,
     // For context during callback.
     group: i,
     // For context during callback.
-    on: kh,
-    tween: Mh,
+    on: Fh,
+    tween: Lh,
     time: s.time,
     delay: s.delay,
     duration: s.duration,
     ease: s.ease,
     timer: null,
-    state: gl
+    state: wl
   });
 }
-function Ks(e, t) {
-  var n = Rt(e, t);
-  if (n.state > gl) throw new Error("too late; already scheduled");
+function Qs(e, t) {
+  var n = Et(e, t);
+  if (n.state > wl) throw new Error("too late; already scheduled");
   return n;
 }
-function Xt(e, t) {
-  var n = Rt(e, t);
-  if (n.state > _i) throw new Error("too late; already running");
+function Bt(e, t) {
+  var n = Et(e, t);
+  if (n.state > wi) throw new Error("too late; already running");
   return n;
 }
-function Rt(e, t) {
+function Et(e, t) {
   var n = e.__transition;
   if (!n || !(n = n[t])) throw new Error("transition not found");
   return n;
 }
-function Ph(e, t, n) {
+function qh(e, t, n) {
   var r = e.__transition, i;
-  r[t] = n, n.timer = vl(s, 0, n.time);
+  r[t] = n, n.timer = yl(s, 0, n.time);
   function s(u) {
-    n.state = La, n.timer.restart(a, n.delay, n.time), n.delay <= u && a(u - n.delay);
+    n.state = Ha, n.timer.restart(a, n.delay, n.time), n.delay <= u && a(u - n.delay);
   }
   function a(u) {
     var f, d, h, p;
-    if (n.state !== La) return l();
+    if (n.state !== Ha) return l();
     for (f in r)
       if (p = r[f], p.name === n.name) {
-        if (p.state === _i) return Ia(a);
-        p.state === qa ? (p.state = mi, p.timer.stop(), p.on.call("interrupt", e, e.__data__, p.index, p.group), delete r[f]) : +f < t && (p.state = mi, p.timer.stop(), p.on.call("cancel", e, e.__data__, p.index, p.group), delete r[f]);
+        if (p.state === wi) return za(a);
+        p.state === Ya ? (p.state = xi, p.timer.stop(), p.on.call("interrupt", e, e.__data__, p.index, p.group), delete r[f]) : +f < t && (p.state = xi, p.timer.stop(), p.on.call("cancel", e, e.__data__, p.index, p.group), delete r[f]);
       }
-    if (Ia(function() {
-      n.state === _i && (n.state = qa, n.timer.restart(o, n.delay, n.time), o(u));
-    }), n.state = Ts, n.on.call("start", e, e.__data__, n.index, n.group), n.state === Ts) {
-      for (n.state = _i, i = new Array(h = n.tween.length), f = 0, d = -1; f < h; ++f)
+    if (za(function() {
+      n.state === wi && (n.state = Ya, n.timer.restart(o, n.delay, n.time), o(u));
+    }), n.state = ks, n.on.call("start", e, e.__data__, n.index, n.group), n.state === ks) {
+      for (n.state = wi, i = new Array(h = n.tween.length), f = 0, d = -1; f < h; ++f)
         (p = n.tween[f].value.call(e, e.__data__, n.index, n.group)) && (i[++d] = p);
       i.length = d + 1;
     }
   }
   function o(u) {
-    for (var f = u < n.duration ? n.ease.call(null, u / n.duration) : (n.timer.restart(l), n.state = Rs, 1), d = -1, h = i.length; ++d < h; )
+    for (var f = u < n.duration ? n.ease.call(null, u / n.duration) : (n.timer.restart(l), n.state = Ps, 1), d = -1, h = i.length; ++d < h; )
       i[d].call(e, f);
-    n.state === Rs && (n.on.call("end", e, e.__data__, n.index, n.group), l());
+    n.state === Ps && (n.on.call("end", e, e.__data__, n.index, n.group), l());
   }
   function l() {
-    n.state = mi, n.timer.stop(), delete r[t];
+    n.state = xi, n.timer.stop(), delete r[t];
     for (var u in r) return;
     delete e.__transition;
   }
 }
-function Dh(e, t) {
+function Vh(e, t) {
   var n = e.__transition, r, i, s = !0, a;
   if (n) {
     t = t == null ? null : t + "";
@@ -4141,20 +4141,20 @@ function Dh(e, t) {
         s = !1;
         continue;
       }
-      i = r.state > Ts && r.state < Rs, r.state = mi, r.timer.stop(), r.on.call(i ? "interrupt" : "cancel", e, e.__data__, r.index, r.group), delete n[a];
+      i = r.state > ks && r.state < Ps, r.state = xi, r.timer.stop(), r.on.call(i ? "interrupt" : "cancel", e, e.__data__, r.index, r.group), delete n[a];
     }
     s && delete e.__transition;
   }
 }
-function Oh(e) {
+function zh(e) {
   return this.each(function() {
-    Dh(this, e);
+    Vh(this, e);
   });
 }
-function Fh(e, t) {
+function Hh(e, t) {
   var n, r;
   return function() {
-    var i = Xt(this, e), s = i.tween;
+    var i = Bt(this, e), s = i.tween;
     if (s !== n) {
       r = n = s;
       for (var a = 0, o = r.length; a < o; ++a)
@@ -4166,11 +4166,11 @@ function Fh(e, t) {
     i.tween = r;
   };
 }
-function Ih(e, t, n) {
+function Yh(e, t, n) {
   var r, i;
   if (typeof n != "function") throw new Error();
   return function() {
-    var s = Xt(this, e), a = s.tween;
+    var s = Bt(this, e), a = s.tween;
     if (a !== r) {
       i = (r = a).slice();
       for (var o = { name: t, value: n }, l = 0, u = i.length; l < u; ++l)
@@ -4183,417 +4183,417 @@ function Ih(e, t, n) {
     s.tween = i;
   };
 }
-function Lh(e, t) {
+function Bh(e, t) {
   var n = this._id;
   if (e += "", arguments.length < 2) {
-    for (var r = Rt(this.node(), n).tween, i = 0, s = r.length, a; i < s; ++i)
+    for (var r = Et(this.node(), n).tween, i = 0, s = r.length, a; i < s; ++i)
       if ((a = r[i]).name === e)
         return a.value;
     return null;
   }
-  return this.each((t == null ? Fh : Ih)(n, e, t));
+  return this.each((t == null ? Hh : Yh)(n, e, t));
 }
-function js(e, t, n) {
+function ea(e, t, n) {
   var r = e._id;
   return e.each(function() {
-    var i = Xt(this, r);
+    var i = Bt(this, r);
     (i.value || (i.value = {}))[t] = n.apply(this, arguments);
   }), function(i) {
-    return Rt(i, r).value[t];
+    return Et(i, r).value[t];
   };
 }
-function _l(e, t) {
+function xl(e, t) {
   var n;
-  return (typeof t == "number" ? Lt : t instanceof Gn ? Ri : (n = Gn(t)) ? (t = n, Ri) : fl)(e, t);
+  return (typeof t == "number" ? Ft : t instanceof jn ? ki : (n = jn(t)) ? (t = n, ki) : pl)(e, t);
 }
-function qh(e) {
+function Xh(e) {
   return function() {
     this.removeAttribute(e);
   };
 }
-function Vh(e) {
+function Wh(e) {
   return function() {
     this.removeAttributeNS(e.space, e.local);
   };
 }
-function zh(e, t, n) {
+function Uh(e, t, n) {
   var r, i = n + "", s;
   return function() {
     var a = this.getAttribute(e);
     return a === i ? null : a === r ? s : s = t(r = a, n);
   };
 }
-function Hh(e, t, n) {
+function Gh(e, t, n) {
   var r, i = n + "", s;
   return function() {
     var a = this.getAttributeNS(e.space, e.local);
     return a === i ? null : a === r ? s : s = t(r = a, n);
   };
 }
-function Yh(e, t, n) {
+function Kh(e, t, n) {
   var r, i, s;
   return function() {
     var a, o = n(this), l;
     return o == null ? void this.removeAttribute(e) : (a = this.getAttribute(e), l = o + "", a === l ? null : a === r && l === i ? s : (i = l, s = t(r = a, o)));
   };
 }
-function Bh(e, t, n) {
+function jh(e, t, n) {
   var r, i, s;
   return function() {
     var a, o = n(this), l;
     return o == null ? void this.removeAttributeNS(e.space, e.local) : (a = this.getAttributeNS(e.space, e.local), l = o + "", a === l ? null : a === r && l === i ? s : (i = l, s = t(r = a, o)));
   };
 }
-function Xh(e, t) {
-  var n = Xi(e), r = n === "transform" ? Th : _l;
-  return this.attrTween(e, typeof t == "function" ? (n.local ? Bh : Yh)(n, r, js(this, "attr." + e, t)) : t == null ? (n.local ? Vh : qh)(n) : (n.local ? Hh : zh)(n, r, t));
+function Jh(e, t) {
+  var n = Gi(e), r = n === "transform" ? Ph : xl;
+  return this.attrTween(e, typeof t == "function" ? (n.local ? jh : Kh)(n, r, ea(this, "attr." + e, t)) : t == null ? (n.local ? Wh : Xh)(n) : (n.local ? Gh : Uh)(n, r, t));
 }
-function Wh(e, t) {
+function Zh(e, t) {
   return function(n) {
     this.setAttribute(e, t.call(this, n));
   };
 }
-function Uh(e, t) {
+function Qh(e, t) {
   return function(n) {
     this.setAttributeNS(e.space, e.local, t.call(this, n));
   };
 }
-function Gh(e, t) {
+function ed(e, t) {
   var n, r;
   function i() {
     var s = t.apply(this, arguments);
-    return s !== r && (n = (r = s) && Uh(e, s)), n;
+    return s !== r && (n = (r = s) && Qh(e, s)), n;
   }
   return i._value = t, i;
 }
-function Kh(e, t) {
+function td(e, t) {
   var n, r;
   function i() {
     var s = t.apply(this, arguments);
-    return s !== r && (n = (r = s) && Wh(e, s)), n;
+    return s !== r && (n = (r = s) && Zh(e, s)), n;
   }
   return i._value = t, i;
 }
-function jh(e, t) {
+function nd(e, t) {
   var n = "attr." + e;
   if (arguments.length < 2) return (n = this.tween(n)) && n._value;
   if (t == null) return this.tween(n, null);
   if (typeof t != "function") throw new Error();
-  var r = Xi(e);
-  return this.tween(n, (r.local ? Gh : Kh)(r, t));
-}
-function Jh(e, t) {
-  return function() {
-    Ks(this, e).delay = +t.apply(this, arguments);
-  };
-}
-function Zh(e, t) {
-  return t = +t, function() {
-    Ks(this, e).delay = t;
-  };
-}
-function Qh(e) {
-  var t = this._id;
-  return arguments.length ? this.each((typeof e == "function" ? Jh : Zh)(t, e)) : Rt(this.node(), t).delay;
-}
-function ed(e, t) {
-  return function() {
-    Xt(this, e).duration = +t.apply(this, arguments);
-  };
-}
-function td(e, t) {
-  return t = +t, function() {
-    Xt(this, e).duration = t;
-  };
-}
-function nd(e) {
-  var t = this._id;
-  return arguments.length ? this.each((typeof e == "function" ? ed : td)(t, e)) : Rt(this.node(), t).duration;
+  var r = Gi(e);
+  return this.tween(n, (r.local ? ed : td)(r, t));
 }
 function rd(e, t) {
-  if (typeof t != "function") throw new Error();
   return function() {
-    Xt(this, e).ease = t;
+    Qs(this, e).delay = +t.apply(this, arguments);
   };
 }
-function id(e) {
-  var t = this._id;
-  return arguments.length ? this.each(rd(t, e)) : Rt(this.node(), t).ease;
+function id(e, t) {
+  return t = +t, function() {
+    Qs(this, e).delay = t;
+  };
 }
-function sd(e, t) {
+function sd(e) {
+  var t = this._id;
+  return arguments.length ? this.each((typeof e == "function" ? rd : id)(t, e)) : Et(this.node(), t).delay;
+}
+function ad(e, t) {
+  return function() {
+    Bt(this, e).duration = +t.apply(this, arguments);
+  };
+}
+function od(e, t) {
+  return t = +t, function() {
+    Bt(this, e).duration = t;
+  };
+}
+function ld(e) {
+  var t = this._id;
+  return arguments.length ? this.each((typeof e == "function" ? ad : od)(t, e)) : Et(this.node(), t).duration;
+}
+function ud(e, t) {
+  if (typeof t != "function") throw new Error();
+  return function() {
+    Bt(this, e).ease = t;
+  };
+}
+function fd(e) {
+  var t = this._id;
+  return arguments.length ? this.each(ud(t, e)) : Et(this.node(), t).ease;
+}
+function cd(e, t) {
   return function() {
     var n = t.apply(this, arguments);
     if (typeof n != "function") throw new Error();
-    Xt(this, e).ease = n;
+    Bt(this, e).ease = n;
   };
 }
-function ad(e) {
+function hd(e) {
   if (typeof e != "function") throw new Error();
-  return this.each(sd(this._id, e));
+  return this.each(cd(this._id, e));
 }
-function od(e) {
-  typeof e != "function" && (e = Jo(e));
+function dd(e) {
+  typeof e != "function" && (e = tl(e));
   for (var t = this._groups, n = t.length, r = new Array(n), i = 0; i < n; ++i)
     for (var s = t[i], a = s.length, o = r[i] = [], l, u = 0; u < a; ++u)
       (l = s[u]) && e.call(l, l.__data__, u, s) && o.push(l);
-  return new fn(r, this._parents, this._name, this._id);
+  return new hn(r, this._parents, this._name, this._id);
 }
-function ld(e) {
+function pd(e) {
   if (e._id !== this._id) throw new Error();
   for (var t = this._groups, n = e._groups, r = t.length, i = n.length, s = Math.min(r, i), a = new Array(r), o = 0; o < s; ++o)
     for (var l = t[o], u = n[o], f = l.length, d = a[o] = new Array(f), h, p = 0; p < f; ++p)
       (h = l[p] || u[p]) && (d[p] = h);
   for (; o < r; ++o)
     a[o] = t[o];
-  return new fn(a, this._parents, this._name, this._id);
+  return new hn(a, this._parents, this._name, this._id);
 }
-function ud(e) {
+function vd(e) {
   return (e + "").trim().split(/^|\s+/).every(function(t) {
     var n = t.indexOf(".");
     return n >= 0 && (t = t.slice(0, n)), !t || t === "start";
   });
 }
-function fd(e, t, n) {
-  var r, i, s = ud(t) ? Ks : Xt;
+function gd(e, t, n) {
+  var r, i, s = vd(t) ? Qs : Bt;
   return function() {
     var a = s(this, e), o = a.on;
     o !== r && (i = (r = o).copy()).on(t, n), a.on = i;
   };
 }
-function cd(e, t) {
+function _d(e, t) {
   var n = this._id;
-  return arguments.length < 2 ? Rt(this.node(), n).on.on(e) : this.each(fd(n, e, t));
+  return arguments.length < 2 ? Et(this.node(), n).on.on(e) : this.each(gd(n, e, t));
 }
-function hd(e) {
+function md(e) {
   return function() {
     var t = this.parentNode;
     for (var n in this.__transition) if (+n !== e) return;
     t && t.removeChild(this);
   };
 }
-function dd() {
-  return this.on("end.remove", hd(this._id));
+function yd() {
+  return this.on("end.remove", md(this._id));
 }
-function pd(e) {
+function wd(e) {
   var t = this._name, n = this._id;
-  typeof e != "function" && (e = Bs(e));
+  typeof e != "function" && (e = Gs(e));
   for (var r = this._groups, i = r.length, s = new Array(i), a = 0; a < i; ++a)
     for (var o = r[a], l = o.length, u = s[a] = new Array(l), f, d, h = 0; h < l; ++h)
-      (f = o[h]) && (d = e.call(f, f.__data__, h, o)) && ("__data__" in f && (d.__data__ = f.__data__), u[h] = d, Ui(u[h], t, n, h, u, Rt(f, n)));
-  return new fn(s, this._parents, t, n);
+      (f = o[h]) && (d = e.call(f, f.__data__, h, o)) && ("__data__" in f && (d.__data__ = f.__data__), u[h] = d, ji(u[h], t, n, h, u, Et(f, n)));
+  return new hn(s, this._parents, t, n);
 }
-function vd(e) {
+function xd(e) {
   var t = this._name, n = this._id;
-  typeof e != "function" && (e = jo(e));
+  typeof e != "function" && (e = el(e));
   for (var r = this._groups, i = r.length, s = [], a = [], o = 0; o < i; ++o)
     for (var l = r[o], u = l.length, f, d = 0; d < u; ++d)
       if (f = l[d]) {
-        for (var h = e.call(f, f.__data__, d, l), p, _ = Rt(f, n), x = 0, y = h.length; x < y; ++x)
-          (p = h[x]) && Ui(p, t, n, x, h, _);
+        for (var h = e.call(f, f.__data__, d, l), p, y = Et(f, n), E = 0, _ = h.length; E < _; ++E)
+          (p = h[E]) && ji(p, t, n, E, h, y);
         s.push(h), a.push(f);
       }
-  return new fn(s, a, t, n);
+  return new hn(s, a, t, n);
 }
-var gd = br.prototype.constructor;
-function _d() {
-  return new gd(this._groups, this._parents);
+var bd = Er.prototype.constructor;
+function $d() {
+  return new bd(this._groups, this._parents);
 }
-function md(e, t) {
+function Ad(e, t) {
   var n, r, i;
   return function() {
-    var s = mr(this, e), a = (this.style.removeProperty(e), mr(this, e));
+    var s = xr(this, e), a = (this.style.removeProperty(e), xr(this, e));
     return s === a ? null : s === n && a === r ? i : i = t(n = s, r = a);
   };
 }
-function ml(e) {
+function bl(e) {
   return function() {
     this.style.removeProperty(e);
   };
 }
-function yd(e, t, n) {
+function Ed(e, t, n) {
   var r, i = n + "", s;
   return function() {
-    var a = mr(this, e);
+    var a = xr(this, e);
     return a === i ? null : a === r ? s : s = t(r = a, n);
   };
 }
-function wd(e, t, n) {
+function Td(e, t, n) {
   var r, i, s;
   return function() {
-    var a = mr(this, e), o = n(this), l = o + "";
-    return o == null && (l = o = (this.style.removeProperty(e), mr(this, e))), a === l ? null : a === r && l === i ? s : (i = l, s = t(r = a, o));
+    var a = xr(this, e), o = n(this), l = o + "";
+    return o == null && (l = o = (this.style.removeProperty(e), xr(this, e))), a === l ? null : a === r && l === i ? s : (i = l, s = t(r = a, o));
   };
 }
-function xd(e, t) {
+function Rd(e, t) {
   var n, r, i, s = "style." + t, a = "end." + s, o;
   return function() {
-    var l = Xt(this, e), u = l.on, f = l.value[s] == null ? o || (o = ml(t)) : void 0;
+    var l = Bt(this, e), u = l.on, f = l.value[s] == null ? o || (o = bl(t)) : void 0;
     (u !== n || i !== f) && (r = (n = u).copy()).on(a, i = f), l.on = r;
   };
 }
-function bd(e, t, n) {
-  var r = (e += "") == "transform" ? Eh : _l;
-  return t == null ? this.styleTween(e, md(e, r)).on("end.style." + e, ml(e)) : typeof t == "function" ? this.styleTween(e, wd(e, r, js(this, "style." + e, t))).each(xd(this._id, e)) : this.styleTween(e, yd(e, r, t), n).on("end.style." + e, null);
+function Sd(e, t, n) {
+  var r = (e += "") == "transform" ? kh : xl;
+  return t == null ? this.styleTween(e, Ad(e, r)).on("end.style." + e, bl(e)) : typeof t == "function" ? this.styleTween(e, Td(e, r, ea(this, "style." + e, t))).each(Rd(this._id, e)) : this.styleTween(e, Ed(e, r, t), n).on("end.style." + e, null);
 }
-function $d(e, t, n) {
+function Cd(e, t, n) {
   return function(r) {
     this.style.setProperty(e, t.call(this, r), n);
   };
 }
-function Ad(e, t, n) {
+function Nd(e, t, n) {
   var r, i;
   function s() {
     var a = t.apply(this, arguments);
-    return a !== i && (r = (i = a) && $d(e, a, n)), r;
+    return a !== i && (r = (i = a) && Cd(e, a, n)), r;
   }
   return s._value = t, s;
 }
-function Ed(e, t, n) {
+function kd(e, t, n) {
   var r = "style." + (e += "");
   if (arguments.length < 2) return (r = this.tween(r)) && r._value;
   if (t == null) return this.tween(r, null);
   if (typeof t != "function") throw new Error();
-  return this.tween(r, Ad(e, t, n ?? ""));
+  return this.tween(r, Nd(e, t, n ?? ""));
 }
-function Td(e) {
+function Pd(e) {
   return function() {
     this.textContent = e;
   };
 }
-function Rd(e) {
+function Md(e) {
   return function() {
     var t = e(this);
     this.textContent = t ?? "";
   };
 }
-function Sd(e) {
-  return this.tween("text", typeof e == "function" ? Rd(js(this, "text", e)) : Td(e == null ? "" : e + ""));
+function Dd(e) {
+  return this.tween("text", typeof e == "function" ? Md(ea(this, "text", e)) : Pd(e == null ? "" : e + ""));
 }
-function Cd(e) {
+function Od(e) {
   return function(t) {
     this.textContent = e.call(this, t);
   };
 }
-function Nd(e) {
+function Id(e) {
   var t, n;
   function r() {
     var i = e.apply(this, arguments);
-    return i !== n && (t = (n = i) && Cd(i)), t;
+    return i !== n && (t = (n = i) && Od(i)), t;
   }
   return r._value = e, r;
 }
-function kd(e) {
+function Fd(e) {
   var t = "text";
   if (arguments.length < 1) return (t = this.tween(t)) && t._value;
   if (e == null) return this.tween(t, null);
   if (typeof e != "function") throw new Error();
-  return this.tween(t, Nd(e));
+  return this.tween(t, Id(e));
 }
-function Md() {
-  for (var e = this._name, t = this._id, n = yl(), r = this._groups, i = r.length, s = 0; s < i; ++s)
+function Ld() {
+  for (var e = this._name, t = this._id, n = $l(), r = this._groups, i = r.length, s = 0; s < i; ++s)
     for (var a = r[s], o = a.length, l, u = 0; u < o; ++u)
       if (l = a[u]) {
-        var f = Rt(l, t);
-        Ui(l, e, n, u, a, {
+        var f = Et(l, t);
+        ji(l, e, n, u, a, {
           time: f.time + f.delay + f.duration,
           delay: 0,
           duration: f.duration,
           ease: f.ease
         });
       }
-  return new fn(r, this._parents, e, n);
+  return new hn(r, this._parents, e, n);
 }
-function Pd() {
+function qd() {
   var e, t, n = this, r = n._id, i = n.size();
   return new Promise(function(s, a) {
     var o = { value: a }, l = { value: function() {
       --i === 0 && s();
     } };
     n.each(function() {
-      var u = Xt(this, r), f = u.on;
+      var u = Bt(this, r), f = u.on;
       f !== e && (t = (e = f).copy(), t._.cancel.push(o), t._.interrupt.push(o), t._.end.push(l)), u.on = t;
     }), i === 0 && s();
   });
 }
-var Dd = 0;
-function fn(e, t, n, r) {
+var Vd = 0;
+function hn(e, t, n, r) {
   this._groups = e, this._parents = t, this._name = n, this._id = r;
 }
-function yi(e) {
-  return br().transition(e);
+function bi(e) {
+  return Er().transition(e);
 }
-function yl() {
-  return ++Dd;
+function $l() {
+  return ++Vd;
 }
-var jt = br.prototype;
-fn.prototype = yi.prototype = {
-  constructor: fn,
-  select: pd,
-  selectAll: vd,
-  selectChild: jt.selectChild,
-  selectChildren: jt.selectChildren,
-  filter: od,
-  merge: ld,
-  selection: _d,
-  transition: Md,
-  call: jt.call,
-  nodes: jt.nodes,
-  node: jt.node,
-  size: jt.size,
-  empty: jt.empty,
-  each: jt.each,
-  on: cd,
-  attr: Xh,
-  attrTween: jh,
-  style: bd,
-  styleTween: Ed,
-  text: Sd,
-  textTween: kd,
-  remove: dd,
-  tween: Lh,
-  delay: Qh,
-  duration: nd,
-  ease: id,
-  easeVarying: ad,
-  end: Pd,
-  [Symbol.iterator]: jt[Symbol.iterator]
+var Zt = Er.prototype;
+hn.prototype = bi.prototype = {
+  constructor: hn,
+  select: wd,
+  selectAll: xd,
+  selectChild: Zt.selectChild,
+  selectChildren: Zt.selectChildren,
+  filter: dd,
+  merge: pd,
+  selection: $d,
+  transition: Ld,
+  call: Zt.call,
+  nodes: Zt.nodes,
+  node: Zt.node,
+  size: Zt.size,
+  empty: Zt.empty,
+  each: Zt.each,
+  on: _d,
+  attr: Jh,
+  attrTween: nd,
+  style: Sd,
+  styleTween: kd,
+  text: Dd,
+  textTween: Fd,
+  remove: yd,
+  tween: Bh,
+  delay: sd,
+  duration: ld,
+  ease: fd,
+  easeVarying: hd,
+  end: qd,
+  [Symbol.iterator]: Zt[Symbol.iterator]
 };
-function Od(e) {
+function zd(e) {
   return ((e *= 2) <= 1 ? e * e * e : (e -= 2) * e * e + 2) / 2;
 }
-var Fd = {
+var Hd = {
   time: null,
   // Set on use.
   delay: 0,
   duration: 250,
-  ease: Od
+  ease: zd
 };
-function Id(e, t) {
+function Yd(e, t) {
   for (var n; !(n = e.__transition) || !(n = n[t]); )
     if (!(e = e.parentNode))
       throw new Error(`transition ${t} not found`);
   return n;
 }
-function Ld(e) {
+function Bd(e) {
   var t, n;
-  e instanceof fn ? (t = e._id, e = e._name) : (t = yl(), (n = Fd).time = Gs(), e = e == null ? null : e + "");
+  e instanceof hn ? (t = e._id, e = e._name) : (t = $l(), (n = Hd).time = Zs(), e = e == null ? null : e + "");
   for (var r = this._groups, i = r.length, s = 0; s < i; ++s)
     for (var a = r[s], o = a.length, l, u = 0; u < o; ++u)
-      (l = a[u]) && Ui(l, e, t, u, a, n || Id(l, t));
-  return new fn(r, this._parents, e, t);
+      (l = a[u]) && ji(l, e, t, u, a, n || Yd(l, t));
+  return new hn(r, this._parents, e, t);
 }
-br.prototype.interrupt = Oh;
-br.prototype.transition = Ld;
-const Ss = Math.PI, Cs = 2 * Ss, Nn = 1e-6, qd = Cs - Nn;
-function wl(e) {
+Er.prototype.interrupt = zh;
+Er.prototype.transition = Bd;
+const Ms = Math.PI, Ds = 2 * Ms, Pn = 1e-6, Xd = Ds - Pn;
+function Al(e) {
   this._ += e[0];
   for (let t = 1, n = e.length; t < n; ++t)
     this._ += arguments[t] + e[t];
 }
-function Vd(e) {
+function Wd(e) {
   let t = Math.floor(e);
   if (!(t >= 0)) throw new Error(`invalid digits: ${e}`);
-  if (t > 15) return wl;
+  if (t > 15) return Al;
   const n = 10 ** t;
   return function(r) {
     this._ += r[0];
@@ -4601,10 +4601,10 @@ function Vd(e) {
       this._ += Math.round(arguments[i] * n) / n + r[i];
   };
 }
-class zd {
+class Ud {
   constructor(t) {
     this._x0 = this._y0 = // start of current subpath
-    this._x1 = this._y1 = null, this._ = "", this._append = t == null ? wl : Vd(t);
+    this._x1 = this._y1 = null, this._ = "", this._append = t == null ? Al : Wd(t);
   }
   moveTo(t, n) {
     this._append`M${this._x0 = this._x1 = +t},${this._y0 = this._y1 = +n}`;
@@ -4626,17 +4626,17 @@ class zd {
     let a = this._x1, o = this._y1, l = r - t, u = i - n, f = a - t, d = o - n, h = f * f + d * d;
     if (this._x1 === null)
       this._append`M${this._x1 = t},${this._y1 = n}`;
-    else if (h > Nn) if (!(Math.abs(d * l - u * f) > Nn) || !s)
+    else if (h > Pn) if (!(Math.abs(d * l - u * f) > Pn) || !s)
       this._append`L${this._x1 = t},${this._y1 = n}`;
     else {
-      let p = r - a, _ = i - o, x = l * l + u * u, y = p * p + _ * _, b = Math.sqrt(x), O = Math.sqrt(h), N = s * Math.tan((Ss - Math.acos((x + h - y) / (2 * b * O))) / 2), M = N / O, F = N / b;
-      Math.abs(M - 1) > Nn && this._append`L${t + M * f},${n + M * d}`, this._append`A${s},${s},0,0,${+(d * p > f * _)},${this._x1 = t + F * l},${this._y1 = n + F * u}`;
+      let p = r - a, y = i - o, E = l * l + u * u, _ = p * p + y * y, x = Math.sqrt(E), D = Math.sqrt(h), N = s * Math.tan((Ms - Math.acos((E + h - _) / (2 * x * D))) / 2), O = N / D, I = N / x;
+      Math.abs(O - 1) > Pn && this._append`L${t + O * f},${n + O * d}`, this._append`A${s},${s},0,0,${+(d * p > f * y)},${this._x1 = t + I * l},${this._y1 = n + I * u}`;
     }
   }
   arc(t, n, r, i, s, a) {
     if (t = +t, n = +n, r = +r, a = !!a, r < 0) throw new Error(`negative radius: ${r}`);
     let o = r * Math.cos(i), l = r * Math.sin(i), u = t + o, f = n + l, d = 1 ^ a, h = a ? i - s : s - i;
-    this._x1 === null ? this._append`M${u},${f}` : (Math.abs(this._x1 - u) > Nn || Math.abs(this._y1 - f) > Nn) && this._append`L${u},${f}`, r && (h < 0 && (h = h % Cs + Cs), h > qd ? this._append`A${r},${r},0,1,${d},${t - o},${n - l}A${r},${r},0,1,${d},${this._x1 = u},${this._y1 = f}` : h > Nn && this._append`A${r},${r},0,${+(h >= Ss)},${d},${this._x1 = t + r * Math.cos(s)},${this._y1 = n + r * Math.sin(s)}`);
+    this._x1 === null ? this._append`M${u},${f}` : (Math.abs(this._x1 - u) > Pn || Math.abs(this._y1 - f) > Pn) && this._append`L${u},${f}`, r && (h < 0 && (h = h % Ds + Ds), h > Xd ? this._append`A${r},${r},0,1,${d},${t - o},${n - l}A${r},${r},0,1,${d},${this._x1 = u},${this._y1 = f}` : h > Pn && this._append`A${r},${r},0,${+(h >= Ms)},${d},${this._x1 = t + r * Math.cos(s)},${this._y1 = n + r * Math.sin(s)}`);
   }
   rect(t, n, r, i) {
     this._append`M${this._x0 = this._x1 = +t},${this._y0 = this._y1 = +n}h${r = +r}v${+i}h${-r}Z`;
@@ -4645,24 +4645,24 @@ class zd {
     return this._;
   }
 }
-function Hd(e) {
+function Gd(e) {
   for (var t = e.length / 6 | 0, n = new Array(t), r = 0; r < t; ) n[r] = "#" + e.slice(r * 6, ++r * 6);
   return n;
 }
-const Yd = Hd("1f77b4ff7f0e2ca02cd627289467bd8c564be377c27f7f7fbcbd2217becf");
-function Fe(e) {
+const Kd = Gd("1f77b4ff7f0e2ca02cd627289467bd8c564be377c27f7f7fbcbd2217becf");
+function Ie(e) {
   return function() {
     return e;
   };
 }
-const Va = Math.abs, Me = Math.atan2, Cn = Math.cos, Bd = Math.max, ss = Math.min, Pt = Math.sin, nr = Math.sqrt, Ye = 1e-12, Yr = Math.PI, ki = Yr / 2, wi = 2 * Yr;
-function Xd(e) {
-  return e > 1 ? 0 : e < -1 ? Yr : Math.acos(e);
+const Ba = Math.abs, ke = Math.atan2, kn = Math.cos, jd = Math.max, fs = Math.min, Pt = Math.sin, sr = Math.sqrt, ze = 1e-12, Xr = Math.PI, Oi = Xr / 2, $i = 2 * Xr;
+function Jd(e) {
+  return e > 1 ? 0 : e < -1 ? Xr : Math.acos(e);
 }
-function za(e) {
-  return e >= 1 ? ki : e <= -1 ? -ki : Math.asin(e);
+function Xa(e) {
+  return e >= 1 ? Oi : e <= -1 ? -Oi : Math.asin(e);
 }
-function Wd(e) {
+function Zd(e) {
   let t = 3;
   return e.digits = function(n) {
     if (!arguments.length) return t;
@@ -4674,141 +4674,141 @@ function Wd(e) {
       t = r;
     }
     return e;
-  }, () => new zd(t);
+  }, () => new Ud(t);
 }
-function Ud(e) {
+function Qd(e) {
   return e.innerRadius;
 }
-function Gd(e) {
+function ep(e) {
   return e.outerRadius;
 }
-function Kd(e) {
+function tp(e) {
   return e.startAngle;
 }
-function jd(e) {
+function np(e) {
   return e.endAngle;
 }
-function Jd(e) {
+function rp(e) {
   return e && e.padAngle;
 }
-function Zd(e, t, n, r, i, s, a, o) {
+function ip(e, t, n, r, i, s, a, o) {
   var l = n - e, u = r - t, f = a - i, d = o - s, h = d * l - f * u;
-  if (!(h * h < Ye))
+  if (!(h * h < ze))
     return h = (f * (t - s) - d * (e - i)) / h, [e + h * l, t + h * u];
 }
-function li(e, t, n, r, i, s, a) {
-  var o = e - n, l = t - r, u = (a ? s : -s) / nr(o * o + l * l), f = u * l, d = -u * o, h = e + f, p = t + d, _ = n + f, x = r + d, y = (h + _) / 2, b = (p + x) / 2, O = _ - h, N = x - p, M = O * O + N * N, F = i - s, W = h * x - _ * p, I = (N < 0 ? -1 : 1) * nr(Bd(0, F * F * M - W * W)), ee = (W * N - O * I) / M, fe = (-W * O - N * I) / M, U = (W * N + O * I) / M, re = (-W * O + N * I) / M, le = ee - y, D = fe - b, H = U - y, te = re - b;
-  return le * le + D * D > H * H + te * te && (ee = U, fe = re), {
-    cx: ee,
-    cy: fe,
+function ci(e, t, n, r, i, s, a) {
+  var o = e - n, l = t - r, u = (a ? s : -s) / sr(o * o + l * l), f = u * l, d = -u * o, h = e + f, p = t + d, y = n + f, E = r + d, _ = (h + y) / 2, x = (p + E) / 2, D = y - h, N = E - p, O = D * D + N * N, I = i - s, K = h * E - y * p, V = (N < 0 ? -1 : 1) * sr(jd(0, I * I * O - K * K)), Q = (K * N - D * V) / O, B = (-K * D - N * V) / O, U = (K * N + D * V) / O, fe = (-K * D + N * V) / O, ie = Q - _, M = B - x, z = U - _, Se = fe - x;
+  return ie * ie + M * M > z * z + Se * Se && (Q = U, B = fe), {
+    cx: Q,
+    cy: B,
     x01: -f,
     y01: -d,
-    x11: ee * (i / F - 1),
-    y11: fe * (i / F - 1)
+    x11: Q * (i / I - 1),
+    y11: B * (i / I - 1)
   };
 }
-function yt() {
-  var e = Ud, t = Gd, n = Fe(0), r = null, i = Kd, s = jd, a = Jd, o = null, l = Wd(u);
+function _t() {
+  var e = Qd, t = ep, n = Ie(0), r = null, i = tp, s = np, a = rp, o = null, l = Zd(u);
   function u() {
-    var f, d, h = +e.apply(this, arguments), p = +t.apply(this, arguments), _ = i.apply(this, arguments) - ki, x = s.apply(this, arguments) - ki, y = Va(x - _), b = x > _;
-    if (o || (o = f = l()), p < h && (d = p, p = h, h = d), !(p > Ye)) o.moveTo(0, 0);
-    else if (y > wi - Ye)
-      o.moveTo(p * Cn(_), p * Pt(_)), o.arc(0, 0, p, _, x, !b), h > Ye && (o.moveTo(h * Cn(x), h * Pt(x)), o.arc(0, 0, h, x, _, b));
+    var f, d, h = +e.apply(this, arguments), p = +t.apply(this, arguments), y = i.apply(this, arguments) - Oi, E = s.apply(this, arguments) - Oi, _ = Ba(E - y), x = E > y;
+    if (o || (o = f = l()), p < h && (d = p, p = h, h = d), !(p > ze)) o.moveTo(0, 0);
+    else if (_ > $i - ze)
+      o.moveTo(p * kn(y), p * Pt(y)), o.arc(0, 0, p, y, E, !x), h > ze && (o.moveTo(h * kn(E), h * Pt(E)), o.arc(0, 0, h, E, y, x));
     else {
-      var O = _, N = x, M = _, F = x, W = y, I = y, ee = a.apply(this, arguments) / 2, fe = ee > Ye && (r ? +r.apply(this, arguments) : nr(h * h + p * p)), U = ss(Va(p - h) / 2, +n.apply(this, arguments)), re = U, le = U, D, H;
-      if (fe > Ye) {
-        var te = za(fe / h * Pt(ee)), je = za(fe / p * Pt(ee));
-        (W -= te * 2) > Ye ? (te *= b ? 1 : -1, M += te, F -= te) : (W = 0, M = F = (_ + x) / 2), (I -= je * 2) > Ye ? (je *= b ? 1 : -1, O += je, N -= je) : (I = 0, O = N = (_ + x) / 2);
+      var D = y, N = E, O = y, I = E, K = _, V = _, Q = a.apply(this, arguments) / 2, B = Q > ze && (r ? +r.apply(this, arguments) : sr(h * h + p * p)), U = fs(Ba(p - h) / 2, +n.apply(this, arguments)), fe = U, ie = U, M, z;
+      if (B > ze) {
+        var Se = Xa(B / h * Pt(Q)), Ge = Xa(B / p * Pt(Q));
+        (K -= Se * 2) > ze ? (Se *= x ? 1 : -1, O += Se, I -= Se) : (K = 0, O = I = (y + E) / 2), (V -= Ge * 2) > ze ? (Ge *= x ? 1 : -1, D += Ge, N -= Ge) : (V = 0, D = N = (y + E) / 2);
       }
-      var qe = p * Cn(O), de = p * Pt(O), ce = h * Cn(F), _e = h * Pt(F);
-      if (U > Ye) {
-        var at = p * Cn(N), G = p * Pt(N), Pe = h * Cn(M), St = h * Pt(M), Z;
-        if (y < Yr)
-          if (Z = Zd(qe, de, Pe, St, at, G, ce, _e)) {
-            var hn = qe - Z[0], Ct = de - Z[1], dn = at - Z[0], Wt = G - Z[1], vt = 1 / Pt(Xd((hn * dn + Ct * Wt) / (nr(hn * hn + Ct * Ct) * nr(dn * dn + Wt * Wt))) / 2), En = nr(Z[0] * Z[0] + Z[1] * Z[1]);
-            re = ss(U, (h - En) / (vt - 1)), le = ss(U, (p - En) / (vt + 1));
+      var se = p * kn(D), Pe = p * Pt(D), me = h * kn(I), ye = h * Pt(I);
+      if (U > ze) {
+        var at = p * kn(N), Ce = p * Pt(N), Tt = h * kn(O), Rt = h * Pt(O), Y;
+        if (_ < Xr)
+          if (Y = ip(se, Pe, Tt, Rt, at, Ce, me, ye)) {
+            var Me = se - Y[0], Xt = Pe - Y[1], ae = at - Y[0], Wt = Ce - Y[1], Rn = 1 / Pt(Jd((Me * ae + Xt * Wt) / (sr(Me * Me + Xt * Xt) * sr(ae * ae + Wt * Wt))) / 2), Ut = sr(Y[0] * Y[0] + Y[1] * Y[1]);
+            fe = fs(U, (h - Ut) / (Rn - 1)), ie = fs(U, (p - Ut) / (Rn + 1));
           } else
-            re = le = 0;
+            fe = ie = 0;
       }
-      I > Ye ? le > Ye ? (D = li(Pe, St, qe, de, p, le, b), H = li(at, G, ce, _e, p, le, b), o.moveTo(D.cx + D.x01, D.cy + D.y01), le < U ? o.arc(D.cx, D.cy, le, Me(D.y01, D.x01), Me(H.y01, H.x01), !b) : (o.arc(D.cx, D.cy, le, Me(D.y01, D.x01), Me(D.y11, D.x11), !b), o.arc(0, 0, p, Me(D.cy + D.y11, D.cx + D.x11), Me(H.cy + H.y11, H.cx + H.x11), !b), o.arc(H.cx, H.cy, le, Me(H.y11, H.x11), Me(H.y01, H.x01), !b))) : (o.moveTo(qe, de), o.arc(0, 0, p, O, N, !b)) : o.moveTo(qe, de), !(h > Ye) || !(W > Ye) ? o.lineTo(ce, _e) : re > Ye ? (D = li(ce, _e, at, G, h, -re, b), H = li(qe, de, Pe, St, h, -re, b), o.lineTo(D.cx + D.x01, D.cy + D.y01), re < U ? o.arc(D.cx, D.cy, re, Me(D.y01, D.x01), Me(H.y01, H.x01), !b) : (o.arc(D.cx, D.cy, re, Me(D.y01, D.x01), Me(D.y11, D.x11), !b), o.arc(0, 0, h, Me(D.cy + D.y11, D.cx + D.x11), Me(H.cy + H.y11, H.cx + H.x11), b), o.arc(H.cx, H.cy, re, Me(H.y11, H.x11), Me(H.y01, H.x01), !b))) : o.arc(0, 0, h, F, M, b);
+      V > ze ? ie > ze ? (M = ci(Tt, Rt, se, Pe, p, ie, x), z = ci(at, Ce, me, ye, p, ie, x), o.moveTo(M.cx + M.x01, M.cy + M.y01), ie < U ? o.arc(M.cx, M.cy, ie, ke(M.y01, M.x01), ke(z.y01, z.x01), !x) : (o.arc(M.cx, M.cy, ie, ke(M.y01, M.x01), ke(M.y11, M.x11), !x), o.arc(0, 0, p, ke(M.cy + M.y11, M.cx + M.x11), ke(z.cy + z.y11, z.cx + z.x11), !x), o.arc(z.cx, z.cy, ie, ke(z.y11, z.x11), ke(z.y01, z.x01), !x))) : (o.moveTo(se, Pe), o.arc(0, 0, p, D, N, !x)) : o.moveTo(se, Pe), !(h > ze) || !(K > ze) ? o.lineTo(me, ye) : fe > ze ? (M = ci(me, ye, at, Ce, h, -fe, x), z = ci(se, Pe, Tt, Rt, h, -fe, x), o.lineTo(M.cx + M.x01, M.cy + M.y01), fe < U ? o.arc(M.cx, M.cy, fe, ke(M.y01, M.x01), ke(z.y01, z.x01), !x) : (o.arc(M.cx, M.cy, fe, ke(M.y01, M.x01), ke(M.y11, M.x11), !x), o.arc(0, 0, h, ke(M.cy + M.y11, M.cx + M.x11), ke(z.cy + z.y11, z.cx + z.x11), x), o.arc(z.cx, z.cy, fe, ke(z.y11, z.x11), ke(z.y01, z.x01), !x))) : o.arc(0, 0, h, I, O, x);
     }
     if (o.closePath(), f) return o = null, f + "" || null;
   }
   return u.centroid = function() {
-    var f = (+e.apply(this, arguments) + +t.apply(this, arguments)) / 2, d = (+i.apply(this, arguments) + +s.apply(this, arguments)) / 2 - Yr / 2;
-    return [Cn(d) * f, Pt(d) * f];
+    var f = (+e.apply(this, arguments) + +t.apply(this, arguments)) / 2, d = (+i.apply(this, arguments) + +s.apply(this, arguments)) / 2 - Xr / 2;
+    return [kn(d) * f, Pt(d) * f];
   }, u.innerRadius = function(f) {
-    return arguments.length ? (e = typeof f == "function" ? f : Fe(+f), u) : e;
+    return arguments.length ? (e = typeof f == "function" ? f : Ie(+f), u) : e;
   }, u.outerRadius = function(f) {
-    return arguments.length ? (t = typeof f == "function" ? f : Fe(+f), u) : t;
+    return arguments.length ? (t = typeof f == "function" ? f : Ie(+f), u) : t;
   }, u.cornerRadius = function(f) {
-    return arguments.length ? (n = typeof f == "function" ? f : Fe(+f), u) : n;
+    return arguments.length ? (n = typeof f == "function" ? f : Ie(+f), u) : n;
   }, u.padRadius = function(f) {
-    return arguments.length ? (r = f == null ? null : typeof f == "function" ? f : Fe(+f), u) : r;
+    return arguments.length ? (r = f == null ? null : typeof f == "function" ? f : Ie(+f), u) : r;
   }, u.startAngle = function(f) {
-    return arguments.length ? (i = typeof f == "function" ? f : Fe(+f), u) : i;
+    return arguments.length ? (i = typeof f == "function" ? f : Ie(+f), u) : i;
   }, u.endAngle = function(f) {
-    return arguments.length ? (s = typeof f == "function" ? f : Fe(+f), u) : s;
+    return arguments.length ? (s = typeof f == "function" ? f : Ie(+f), u) : s;
   }, u.padAngle = function(f) {
-    return arguments.length ? (a = typeof f == "function" ? f : Fe(+f), u) : a;
+    return arguments.length ? (a = typeof f == "function" ? f : Ie(+f), u) : a;
   }, u.context = function(f) {
     return arguments.length ? (o = f ?? null, u) : o;
   }, u;
 }
-function Qd(e) {
+function sp(e) {
   return typeof e == "object" && "length" in e ? e : Array.from(e);
 }
-function ep(e, t) {
+function ap(e, t) {
   return t < e ? -1 : t > e ? 1 : t >= e ? 0 : NaN;
 }
-function tp(e) {
+function op(e) {
   return e;
 }
-function as() {
-  var e = tp, t = ep, n = null, r = Fe(0), i = Fe(wi), s = Fe(0);
+function cs() {
+  var e = op, t = ap, n = null, r = Ie(0), i = Ie($i), s = Ie(0);
   function a(o) {
-    var l, u = (o = Qd(o)).length, f, d, h = 0, p = new Array(u), _ = new Array(u), x = +r.apply(this, arguments), y = Math.min(wi, Math.max(-wi, i.apply(this, arguments) - x)), b, O = Math.min(Math.abs(y) / u, s.apply(this, arguments)), N = O * (y < 0 ? -1 : 1), M;
+    var l, u = (o = sp(o)).length, f, d, h = 0, p = new Array(u), y = new Array(u), E = +r.apply(this, arguments), _ = Math.min($i, Math.max(-$i, i.apply(this, arguments) - E)), x, D = Math.min(Math.abs(_) / u, s.apply(this, arguments)), N = D * (_ < 0 ? -1 : 1), O;
     for (l = 0; l < u; ++l)
-      (M = _[p[l] = l] = +e(o[l], l, o)) > 0 && (h += M);
-    for (t != null ? p.sort(function(F, W) {
-      return t(_[F], _[W]);
-    }) : n != null && p.sort(function(F, W) {
-      return n(o[F], o[W]);
-    }), l = 0, d = h ? (y - u * N) / h : 0; l < u; ++l, x = b)
-      f = p[l], M = _[f], b = x + (M > 0 ? M * d : 0) + N, _[f] = {
+      (O = y[p[l] = l] = +e(o[l], l, o)) > 0 && (h += O);
+    for (t != null ? p.sort(function(I, K) {
+      return t(y[I], y[K]);
+    }) : n != null && p.sort(function(I, K) {
+      return n(o[I], o[K]);
+    }), l = 0, d = h ? (_ - u * N) / h : 0; l < u; ++l, E = x)
+      f = p[l], O = y[f], x = E + (O > 0 ? O * d : 0) + N, y[f] = {
         data: o[f],
         index: l,
-        value: M,
-        startAngle: x,
-        endAngle: b,
-        padAngle: O
+        value: O,
+        startAngle: E,
+        endAngle: x,
+        padAngle: D
       };
-    return _;
+    return y;
   }
   return a.value = function(o) {
-    return arguments.length ? (e = typeof o == "function" ? o : Fe(+o), a) : e;
+    return arguments.length ? (e = typeof o == "function" ? o : Ie(+o), a) : e;
   }, a.sortValues = function(o) {
     return arguments.length ? (t = o, n = null, a) : t;
   }, a.sort = function(o) {
     return arguments.length ? (n = o, t = null, a) : n;
   }, a.startAngle = function(o) {
-    return arguments.length ? (r = typeof o == "function" ? o : Fe(+o), a) : r;
+    return arguments.length ? (r = typeof o == "function" ? o : Ie(+o), a) : r;
   }, a.endAngle = function(o) {
-    return arguments.length ? (i = typeof o == "function" ? o : Fe(+o), a) : i;
+    return arguments.length ? (i = typeof o == "function" ? o : Ie(+o), a) : i;
   }, a.padAngle = function(o) {
-    return arguments.length ? (s = typeof o == "function" ? o : Fe(+o), a) : s;
+    return arguments.length ? (s = typeof o == "function" ? o : Ie(+o), a) : s;
   }, a;
 }
-function Dr(e, t, n) {
+function Ir(e, t, n) {
   this.k = e, this.x = t, this.y = n;
 }
-Dr.prototype = {
-  constructor: Dr,
+Ir.prototype = {
+  constructor: Ir,
   scale: function(e) {
-    return e === 1 ? this : new Dr(this.k * e, this.x, this.y);
+    return e === 1 ? this : new Ir(this.k * e, this.x, this.y);
   },
   translate: function(e, t) {
-    return e === 0 & t === 0 ? this : new Dr(this.k, this.x + this.k * e, this.y + this.k * t);
+    return e === 0 & t === 0 ? this : new Ir(this.k, this.x + this.k * e, this.y + this.k * t);
   },
   apply: function(e) {
     return [e[0] * this.k + this.x, e[1] * this.k + this.y];
@@ -4838,373 +4838,394 @@ Dr.prototype = {
     return "translate(" + this.x + "," + this.y + ") scale(" + this.k + ")";
   }
 };
-Dr.prototype;
-var np = /* @__PURE__ */ Zu('<svg class="pie-chart-svg svelte-80ulj4"><defs><filter id="text-top-filter"><feBlend mode="normal" in="SourceGraphic" in2="BackgroundImage"></feBlend></filter><pattern id="cross-hatch" width="7" height="7" patternUnits="userSpaceOnUse"><rect width="7" height="7" fill="transparent"></rect><circle cx="1.75" cy="1.75" r="1.5" fill="lightgray"></circle><circle cx="5.25" cy="5.25" r="1.5" fill="lightgray"></circle></pattern></defs></svg>');
-const rp = {
+Ir.prototype;
+var lp = /* @__PURE__ */ sf('<svg class="pie-chart-svg svelte-80ulj4"><defs><filter id="text-top-filter"><feBlend mode="normal" in="SourceGraphic" in2="BackgroundImage"></feBlend></filter><pattern id="cross-hatch" width="7" height="7" patternUnits="userSpaceOnUse"><rect width="7" height="7" fill="transparent"></rect><circle cx="1.75" cy="1.75" r="1.5" fill="lightgray"></circle><circle cx="5.25" cy="5.25" r="1.5" fill="lightgray"></circle></pattern></defs></svg>');
+const up = {
   hash: "svelte-80ulj4",
   code: `.pie-chart-svg.svelte-80ulj4 {width:100%;height:100%;max-width:700px;max-height:60vh;aspect-ratio:1 / 1; /* For a perfect circle, use 1:1 ratio */margin:0 auto;display:block;}
 
 @media (max-width: 768px) {.pie-chart-svg.svelte-80ulj4 {max-height:60vh;}
 }`
 };
-function xl(e, t) {
-  qi(t, !0), Hs(e, rp);
-  let n = ie(t, "jsonData", 7), r = ie(t, "currentRound", 7, 1), i = ie(t, "mouseEventType", 15), s = ie(t, "mouseData", 15), a = ie(t, "mouseX", 15), o = ie(t, "mouseY", 15), l = ie(t, "requestRoundChange", 7, (c) => {
-  }), u = ie(t, "requestSkipToRound", 7, (c) => {
-  }), f = ie(t, "candidateColors", 23, () => []), d = ie(t, "excludeFinalWinnerAndEliminatedCandidate", 7, !1), h = ie(t, "firstRoundDeterminesPercentages", 7, !1), p = ie(t, "randomizeOrder", 7, !1), _ = ie(t, "displayPhase", 15, 0);
+function El(e, t) {
+  Yi(t, !0), Ws(e, up);
+  let n = ee(t, "jsonData", 7), r = ee(t, "currentRound", 7, 1), i = ee(t, "mouseEventType", 15), s = ee(t, "mouseData", 15), a = ee(t, "mouseX", 15), o = ee(t, "mouseY", 15), l = ee(t, "requestRoundChange", 7, (c) => {
+  }), u = ee(t, "requestSkipToRound", 7, (c) => {
+  }), f = ee(t, "candidateColors", 23, () => []), d = ee(t, "excludeFinalWinnerAndEliminatedCandidate", 7, !1), h = ee(t, "firstRoundDeterminesPercentages", 7, !1), p = ee(t, "showVotes", 7, !0), y = ee(t, "showPercent", 7, !0), E = ee(t, "randomizeOrder", 7, !1), _ = ee(t, "displayPhase", 15, 0);
   function x(c) {
     return c.isTransfer ? `${c.label}__transfer` : c.transferIndex != null ? `${c.label}__${c.transferIndex}` : c.label;
   }
-  const y = 800, b = 800, O = Math.min(y, b) * 0.3, N = y / 2, M = b / 2, F = "Pie", W = "PieOutline", I = "Donut", ee = "TextLayer", fe = "url(#cross-hatch)", U = 1.15, re = 750, le = 800, D = "white", H = 1, te = "#ff00ff", je = 3;
-  function qe(c) {
+  const D = 800, N = 800, O = Math.min(D, N) * 0.3, I = D / 2, K = N / 2, V = "Pie", Q = "PieOutline", B = "Donut", U = "TextLayer", fe = "url(#cross-hatch)", ie = 1.15, M = 750, z = 800, Se = "white", Ge = 1, se = "#ff00ff", Pe = 3;
+  function me(c) {
     return "hatch-" + c.replace(/[^a-zA-Z0-9]/g, "-");
   }
-  let de = [], ce = [], _e = [], at = 0, G = 0;
-  const Pe = {}, St = "No Further Rankings";
-  let Z = /* @__PURE__ */ $e(null);
-  function hn() {
-    const c = he($(Z));
-    c.select("#" + F).remove(), c.select("#" + W).remove(), c.select("#" + I).remove(), c.select("#" + ee).remove();
+  let ye = [], at = [], Ce = [], Tt = null, Rt = 0, Y = 0;
+  const Me = {}, Xt = "No Further Rankings";
+  let ae = /* @__PURE__ */ xe(null);
+  function Wt() {
+    const c = ue(A(ae));
+    c.select("#" + V).remove(), c.select("#" + Q).remove(), c.select("#" + B).remove(), c.select("#" + U).remove();
   }
-  function Ct(c) {
-    l() && (oe = c, l()(c));
+  function Rn(c) {
+    l() && ($e = c, l()(c));
   }
-  function dn(c) {
+  function Ut(c) {
     var m;
     if (!((m = n()) != null && m.results) || c < 1 || c > n().results.length) return !1;
-    const g = n().results[c - 1].tallyResults;
-    return g.length > 0 && g.some((A) => Object.keys(A.transfers).length > 0);
+    const v = n().results[c - 1].tallyResults;
+    return v.length > 0 && v.some(($) => Object.keys($.transfers).length > 0);
   }
-  function Wt(c) {
-    for (let g = c; g < n().results.length; g++)
-      if (dn(g)) return g;
+  function Tr(c) {
+    for (let v = c; v < n().results.length; v++)
+      if (Ut(v)) return v;
     return n().results.length;
   }
-  function vt(c) {
-    hn(), _e = En(c), de = ta(c, F, _e, N, M, 0, Je()), ta(c, W, _e, N, M, 0, Je(), !1, !1, !0), Rr();
+  function Sn(c) {
+    Wt(), Ce = Ji(c), ye = sa(c, V, Ce, I, K, 0, Ke()), sa(c, Q, Ce, I, K, 0, Ke(), !1, !1, !0), Cr();
   }
-  sf(() => {
-    kt(), setTimeout(
+  cf(() => {
+    vn(), setTimeout(
       () => {
-        vt(r());
+        Sn(r());
       },
       0
     );
   });
-  function En(c) {
-    const g = Rn(c);
-    return at = Gi(c), g;
+  function Ji(c) {
+    const v = qe(c);
+    return Rt = Qi(1), v;
   }
-  function Je() {
+  function Ke() {
     return O;
   }
-  function $r() {
-    return Je() * 1.41;
+  function Rr() {
+    return Ke() * 1.41;
   }
-  function Ar(c) {
-    let g = 0;
+  function pn(c) {
+    let v = 0;
     for (let m = 1; m < c; m++) {
-      const A = n().results[m - 1].tallyResults;
-      for (let E = 0; E < A.length; E++) {
-        const T = A[E].transfers;
+      const $ = n().results[m - 1].tallyResults;
+      for (let b = 0; b < $.length; b++) {
+        const T = $[b].transfers;
         if (T) {
           const P = T.exhausted;
-          P && (g += Number(P));
+          P && (v += Number(P));
         }
       }
     }
-    return g;
+    return v;
   }
-  function Tn(c, g) {
-    if (c === "exhausted") return Ar(g);
+  function Qn(c, v) {
+    if (c === "exhausted") return pn(v);
     {
-      const m = n().results[g - 1].tally;
+      const m = n().results[v - 1].tally;
       return Number(m[c]);
     }
   }
-  function Jn(c, g) {
-    return Tn(c, g).toLocaleString("en-US");
+  function Zi(c, v) {
+    return Qn(c, v).toLocaleString("en-US");
   }
-  function Zr(c, g) {
-    const m = h() ? at : Ki(g);
-    return (Tn(c, g) / m).toLocaleString("en-US", { style: "percent", minimumFractionDigits: 1 });
+  function ti(c, v) {
+    const m = h() ? Rt : G(v);
+    return (Qn(c, v) / m).toLocaleString("en-US", { style: "percent", minimumFractionDigits: 1 });
   }
-  function Gi(c) {
-    const g = n().results[c - 1].tally;
+  function er(c, v) {
+    const m = Zi(c, v), $ = w(c) && !h(), b = y() && !$;
+    return p() && b ? m + " (" + ti(c, v) + ")" : b ? ti(c, v) : m;
+  }
+  function Qi(c) {
+    const v = n().results[c - 1].tally;
     let m = 0;
-    for (let [A, E] of Object.entries(g))
-      m += Number(E);
+    for (let [$, b] of Object.entries(v))
+      m += Number(b);
     return m;
   }
-  function Nt(c) {
+  function w(c) {
     return c === "exhausted" || c === "Inactive Ballots";
   }
-  function Ki(c) {
-    const g = n().results[c - 1].tally;
+  function G(c) {
+    const v = n().results[c - 1].tally;
     let m = 0;
-    for (let [A, E] of Object.entries(g))
-      Nt(A) || (m += Number(E));
+    for (let [$, b] of Object.entries(v))
+      w($) || (m += Number(b));
     return m;
   }
-  function w(c, g) {
+  function oe(c, v) {
     if (!c || c < 1 || c > n().results.length)
       return console.warn("In chosenCandidates: round ${round} is out of range."), [];
     if (d() && c === n().results.length)
       return [];
-    const m = n().results[c - 1].tallyResults, A = [];
-    for (let E = 0; E < m.length; E++) {
-      const T = m[E][g];
-      T != null && A.push(T);
+    const m = n().results[c - 1].tallyResults, $ = [];
+    for (let b = 0; b < m.length; b++) {
+      const T = m[b][v];
+      T != null && $.push(T);
     }
-    return A;
+    return $;
   }
-  function Y(c) {
-    return w(c, "eliminated");
+  function he(c) {
+    return oe(c, "eliminated");
   }
-  function se(c) {
-    let g = [];
-    for (let m = 1; m <= c; m++) g = g.concat(w(m, "elected"));
-    return [...new Set(g)];
+  function ge(c) {
+    let v = [];
+    for (let m = 1; m <= c; m++) v = v.concat(oe(m, "elected"));
+    return [...new Set(v)];
   }
-  function we(c, g) {
-    const m = n().results[g - 1].tallyResults;
-    let A = 0;
-    const E = m.findIndex((T) => (T == null ? void 0 : T.elected) && c == T.elected);
-    if (E >= 0) {
-      const T = m[E].transfers;
+  function le(c, v) {
+    const m = n().results[v - 1].tallyResults;
+    let $ = 0;
+    const b = m.findIndex((T) => (T == null ? void 0 : T.elected) && c == T.elected);
+    if (b >= 0) {
+      const T = m[b].transfers;
       if (T)
-        for (let [P, V] of Object.entries(T)) A += Number(V);
+        for (let [P, q] of Object.entries(T)) $ += Number(q);
     } else
       return 0;
-    return A;
+    return $;
   }
-  function ye(c, g) {
-    c.some((m) => Nt(m.label)) || c.push({ label: "exhausted", value: Ar(g) });
+  function De(c, v) {
+    c.some((m) => w(m.label)) || c.push({ label: "exhausted", value: pn(v) });
   }
-  function ue(c) {
-    let g = c | 0;
+  function Gt(c) {
+    let v = c | 0;
     return () => {
-      g = g + 1831565813 | 0;
-      let m = Math.imul(g ^ g >>> 15, 1 | g);
+      v = v + 1831565813 | 0;
+      let m = Math.imul(v ^ v >>> 15, 1 | v);
       return m = m + Math.imul(m ^ m >>> 7, 61 | m) ^ m, ((m ^ m >>> 14) >>> 0) / 4294967296;
     };
   }
-  function Ve(c) {
-    let g = 5381;
+  function St(c) {
+    let v = 5381;
     for (let m = 0; m < c.length; m++)
-      g = (g << 5) + g + c.charCodeAt(m) | 0;
-    return g;
+      v = (v << 5) + v + c.charCodeAt(m) | 0;
+    return v;
   }
-  function Ut(c) {
-    var E;
+  function Cn(c) {
+    var b;
     if (c.length <= 3) return c;
-    const g = Ve(((E = n().config) == null ? void 0 : E.contest) ?? ""), m = ue(g), A = [...c];
-    for (let T = A.length - 1; T > 0; T--) {
+    const v = St(((b = n().config) == null ? void 0 : b.contest) ?? ""), m = Gt(v), $ = [...c];
+    for (let T = $.length - 1; T > 0; T--) {
       const P = Math.floor(m() * (T + 1));
-      [A[T], A[P]] = [A[P], A[T]];
+      [$[T], $[P]] = [$[P], $[T]];
     }
-    return A;
+    return $;
   }
-  function gt() {
-    const c = Object.keys(n().results[0].tally), g = c.filter((E) => !Nt(E)), m = c.filter((E) => Nt(E));
-    return [...p() ? Ut(g) : g, ...m];
+  function Kt() {
+    const c = Object.keys(n().results[0].tally), v = c.filter((b) => !w(b)), m = c.filter((b) => w(b));
+    return [...E() ? Cn(v) : v, ...m];
   }
-  function Rn(c) {
-    const g = n().results[c - 1].tally, m = [];
-    for (const A of gt())
-      A in g && m.push({ label: A, value: Number(g[A]) });
-    return ye(m, c), m;
+  function qe(c) {
+    const v = n().results[c - 1].tally, m = [];
+    for (const $ of Kt())
+      $ in v && m.push({ label: $, value: Number(v[$]) });
+    return De(m, c), m;
   }
-  function pn(c) {
-    const g = n().results[c - 1].tally, m = [];
-    for (const A of gt())
-      m.push({ label: A, value: Number(g[A] ?? 0) });
-    return ye(m, c), m;
+  function Ct(c) {
+    const v = n().results[c - 1].tally, m = [];
+    for (const $ of Kt())
+      m.push({ label: $, value: Number(v[$] ?? 0) });
+    return De(m, c), m;
   }
-  function ze(c, g) {
+  function ot(c, v) {
     const m = [];
-    for (const A of c) {
-      if (A.label === "exhausted" || A.isTransfer) {
-        m.push(A);
+    for (const $ of c) {
+      if ($.label === "exhausted" || $.isTransfer) {
+        m.push($);
         continue;
       }
-      const E = we(A.label, g);
-      E > 0 ? (m.push({
-        label: A.label,
-        value: E,
+      const b = le($.label, v);
+      b > 0 ? (m.push({
+        label: $.label,
+        value: b,
         isTransfer: !0
-      }), m.push({ ...A, value: A.value - E })) : m.push(A);
+      }), m.push({ ...$, value: $.value - b })) : m.push($);
     }
     return m;
   }
-  function kt() {
-    const c = he($(Z)).select("defs").select("#cross-hatch");
-    let g = 0;
-    for (let [m, A] of Object.entries(n().results[0].tally)) {
-      !f() || f().length === 0 ? g < 10 ? Pe[m] = Yd[g] : Pe[m] = "#" + Math.floor(Math.random() * 16777215).toString(16).padStart(6, "0") : Pe[m] = f()[g % f().length], g++;
+  function vn() {
+    const c = ue(A(ae)).select("defs").select("#cross-hatch");
+    let v = 0;
+    for (let [m, $] of Object.entries(n().results[0].tally)) {
+      !f() || f().length === 0 ? v < 10 ? Me[m] = Kd[v] : Me[m] = "#" + Math.floor(Math.random() * 16777215).toString(16).padStart(6, "0") : Me[m] = f()[v % f().length], v++;
       {
-        const E = c.clone(!0);
-        E.attr("id", qe(m)).select("rect").attr("fill", Pe[m]), E.selectAll("circle").attr("fill", "#383838");
+        const b = c.clone(!0);
+        b.attr("id", me(m)).select("rect").attr("fill", Me[m]), b.selectAll("circle").attr("fill", "#383838");
       }
     }
-    Pe.exhausted = fe, Pe["Inactive Ballots"] = fe;
+    Me.exhausted = fe, Me["Inactive Ballots"] = fe;
   }
-  function ot() {
-    he($(Z)).select("#" + I).remove();
+  function tr() {
+    ue(A(ae)).select("#" + B).remove();
   }
-  function _t(c, g) {
-    const m = yi("global").duration(le);
-    g && m.on("end", g);
-    const A = ze(_e, c), T = as().sort(null).value((P) => P.value)(A);
-    sa(c, F, T, 0, Je()), sa(c, W, T, 0, Je(), !0), _e = A, de = T, ot(), Tl(c), Pl(), Ol(0, Je()), Rr();
+  function jt(c, v) {
+    const m = bi("global").duration(z);
+    v && m.on("end", v);
+    const $ = ot(Ce, c), T = cs().sort(null).value((P) => P.value)($);
+    ua(c, V, T, 0, Ke()), ua(c, Q, T, 0, Ke(), !0), Ce = $, ye = T, tr(), Pl(c), ql(), zl(0, Ke()), Cr();
   }
-  function Mt(c, g) {
-    const m = yi("global").duration(le);
-    g && m.on("end", g), Rl(c);
+  function Nt(c, v) {
+    const m = bi("global").duration(z);
+    v && m.on("end", v), Ml(c);
   }
-  function mt(c, g) {
-    const m = yi("global").duration(le);
-    g && m.on("end", g), Al(c), El(Je(), $r());
+  function Ve(c, v) {
+    const m = bi("global").duration(z);
+    v && m.on("end", v), Nl(c), kl(Ke(), Rr());
   }
-  let xe = !1, De = [];
-  function Ee() {
-    Rr(), xe = !1, Gt();
+  let ce = !1, lt = [];
+  function je() {
+    Cr(), ce = !1, gn();
   }
-  function Gt() {
-    if (De.length === 0) {
-      oe !== r() && (r() === oe + 1 && oe > 0 && r() <= n().results.length ? (oe = r(), Zn(r())) : r() >= 1 && r() <= n().results.length && (oe = r(), _(0), vt(r())));
+  function gn() {
+    if (lt.length === 0) {
+      $e !== r() && (r() === $e + 1 && $e > 0 && r() <= n().results.length ? ($e = r(), nr(r())) : r() >= 1 && r() <= n().results.length && ($e = r(), _(0), Sn(r())));
       return;
     }
-    const c = De.shift();
+    const c = lt.shift();
     switch (c.type) {
       case "round": {
-        const g = c.round;
-        g === oe + 1 && oe > 0 && g <= n().results.length ? (oe = g, Zn(g)) : (g !== oe && g >= 1 && g <= n().results.length && (oe = g, _(0), vt(g)), Gt());
+        const v = c.round;
+        v === $e + 1 && $e > 0 && v <= n().results.length ? ($e = v, nr(v)) : (v !== $e && v >= 1 && v <= n().results.length && ($e = v, _(0), Sn(v)), gn());
         break;
       }
       case "step":
-        Zs();
+        ra();
         break;
     }
   }
-  function Zn(c) {
+  function nr(c) {
     if (c <= 1 || c > n().results.length) {
-      Gt();
+      gn();
       return;
     }
-    xe = !0, G = c, _(0), _t(G - 1, () => {
-      _(1), Mt(G - 1, () => {
-        _(2), mt(G, () => {
-          _(0), Ee();
+    ce = !0, Y = c, _(0), jt(Y - 1, () => {
+      _(1), Nt(Y - 1, () => {
+        _(2), Ve(Y, () => {
+          _(0), je();
         });
       });
     });
   }
-  function Er() {
-    xe || (xe = !0, G = r(), Qn());
+  function Jt() {
+    ce || (ce = !0, Y = r(), kt());
   }
-  function Qn() {
+  function kt() {
     if (_(
       0
       // if in the middle of "one small step" animation, reset to 0.
-    ), De.length > 0) {
-      Ee();
+    ), lt.length > 0) {
+      je();
       return;
     }
-    const c = G < n().results.length - 1 ? Qn : () => {
-      _(0), Ee();
+    const c = Y < n().results.length - 1 ? kt : () => {
+      _(0), je();
     };
-    _t(G, () => {
-      _(1), Mt(G, () => {
-        _(2), G++, Ct(G), mt(G, c);
+    jt(Y, () => {
+      _(1), Nt(Y, () => {
+        _(2), Y++, Rn(Y), Ve(Y, c);
       });
     });
   }
-  Is(() => {
-    Kt();
+  Ri(() => {
+    Rl();
   });
-  let oe = 0;
-  function Kt() {
-    if (oe != r()) {
-      if (xe) {
-        De.push({ type: "round", round: r() });
+  function es() {
+    if (!Tt) return;
+    ue(A(ae)).select("#" + U).remove();
+    const c = Tt;
+    ts(c.round, c.pieInfo, c.x, c.y, c.outerRadius, c.eliminated);
+  }
+  let na = !1;
+  Ri(() => {
+    if (h(), p(), y(), !na) {
+      na = !0;
+      return;
+    }
+    ce || Qr(() => es());
+  });
+  let $e = 0;
+  function Rl() {
+    if ($e != r()) {
+      if (ce) {
+        lt.push({ type: "round", round: r() });
         return;
       }
-      if (oe == r() - 1 && oe > 0)
-        if (dn(oe))
-          $l();
+      if ($e == r() - 1 && $e > 0)
+        if (Ut($e))
+          Cl();
         else {
-          const c = Wt(r());
+          const c = Tr(r());
           if (u()) {
-            oe = c, c < n().results.length ? u()(c + 1) : u()(c);
+            $e = c, c < n().results.length ? u()(c + 1) : u()(c);
             return;
           }
         }
       else
-        ji(r());
-      oe = r();
+        Sl(r());
+      $e = r();
     }
   }
-  function ji(c) {
-    if (xe) {
-      De.push({ type: "round", round: c });
+  function Sl(c) {
+    if (ce) {
+      lt.push({ type: "round", round: c });
       return;
     }
-    _(0), vt(c);
+    _(0), Sn(c);
   }
-  function $l() {
-    if (xe) {
-      De.push({ type: "round", round: r() });
+  function Cl() {
+    if (ce) {
+      lt.push({ type: "round", round: r() });
       return;
     }
     if (r() <= 1) {
       console.warn(`animateOneRoundFn: can't animate to round ${r()}`);
       return;
     }
-    if (G = r(), G > n().results.length) {
-      Rr(), xe = !1;
+    if (Y = r(), Y > n().results.length) {
+      Cr(), ce = !1;
       return;
     }
-    xe = !0, _() === 0 ? _t(G - 1, () => {
-      _(1), Mt(G - 1, () => {
-        _(2), mt(G, () => {
-          _(0), Ee();
+    ce = !0, _() === 0 ? jt(Y - 1, () => {
+      _(1), Nt(Y - 1, () => {
+        _(2), Ve(Y, () => {
+          _(0), je();
         });
       });
-    }) : _() === 1 ? Mt(G - 1, () => {
-      _(2), mt(G, () => {
-        _(0), Ee();
+    }) : _() === 1 ? Nt(Y - 1, () => {
+      _(2), Ve(Y, () => {
+        _(0), je();
       });
-    }) : _() === 2 && mt(G, () => {
-      _(0), Ee();
+    }) : _() === 2 && Ve(Y, () => {
+      _(0), je();
     });
   }
-  function Zs() {
+  function ra() {
     if (r() > n().results.length) {
-      Rr(), xe = !1;
+      Cr(), ce = !1;
       return;
     }
-    if (xe) {
-      De.push({ type: "step" });
+    if (ce) {
+      lt.push({ type: "step" });
       return;
     }
-    xe = !0, G = r(), _() === 0 ? _t(G, () => {
-      _(1), Ee();
-    }) : _() === 1 ? Mt(G, () => {
-      _(2), Ee();
-    }) : _() === 2 ? (G++, Ct(G), mt(G, () => {
-      _(0), Ee();
-    })) : (xe = !1, console.warn("displayPhase out of range at ", _()));
+    ce = !0, Y = r(), _() === 0 ? jt(Y, () => {
+      _(1), je();
+    }) : _() === 1 ? Nt(Y, () => {
+      _(2), je();
+    }) : _() === 2 ? (Y++, Rn(Y), Ve(Y, () => {
+      _(0), je();
+    })) : (ce = !1, console.warn("displayPhase out of range at ", _()));
   }
-  function Al(c) {
-    _e = pn(c), de = ra(c, F, _e, 0, Je(), !0), ra(c, W, _e, 0, Je(), !1, !0);
+  function Nl(c) {
+    const v = Ct(c), m = new Set(Ce.filter((b) => b.isTransfer).map((b) => b.label)), $ = [];
+    for (const b of v)
+      m.has(b.label) && $.push({ label: b.label, value: 0, isTransfer: !0 }), $.push(b);
+    Ce = v, ye = oa(c, V, $, 0, Ke(), !0), oa(c, Q, $, 0, Ke(), !1, !0);
   }
-  function El(c, g) {
-    const m = he($(Z)).select("#" + I), E = he($(Z)).select("#" + F), T = {};
-    for (const C of de) {
+  function kl(c, v) {
+    const m = ue(A(ae)).select("#" + B), b = ue(A(ae)).select("#" + V), T = {};
+    for (const C of ye) {
       const k = C.data.label;
       if (C.data.isTransfer) continue;
-      const R = E.select("#" + CSS.escape(x(C.data)));
+      const R = b.select("#" + CSS.escape(x(C.data)));
       R.empty() || (T[k] = {
         oldStart: Number(R.attr("prevStart")),
         oldEnd: Number(R.attr("prevEnd")),
@@ -5213,81 +5234,81 @@ function xl(e, t) {
       });
     }
     const P = m.selectAll(".slice");
-    let V = P.size();
-    function L() {
-      V--, V === 0 && Dl();
+    let q = P.size();
+    function F() {
+      q--, q === 0 && Vl();
     }
-    P.select("path").transition("global").duration(re).attrTween("d", function(C) {
-      const k = C.startAngle, R = C.endAngle, S = R - k, ke = T[C.data.label];
-      let Q, He;
-      if (ke) {
-        const er = (ke.oldStart + ke.oldEnd) / 2, ql = (ke.newStart + ke.newEnd) / 2, Vl = k - er;
-        Q = ql + Vl, He = Q + S;
+    P.select("path").transition("global").duration(M).attrTween("d", function(C) {
+      const k = C.startAngle, R = C.endAngle, S = R - k, Ne = T[C.data.label];
+      let ne, Je;
+      if (Ne) {
+        const rr = (Ne.oldStart + Ne.oldEnd) / 2, Xl = (Ne.newStart + Ne.newEnd) / 2, Wl = k - rr;
+        ne = Xl + Wl, Je = ne + S;
       } else
-        Q = k, He = R;
-      const ae = Jt(k, Q), Te = Jt(R, He), ei = Jt(g, c), Sr = yt();
-      return function(er) {
-        return Sr.innerRadius(Math.min(ei(er), c) - 1).outerRadius(ei(er)).startAngle(ae(er)).endAngle(Te(er)), Sr(C);
+        ne = k, Je = R;
+      const re = Qt(k, ne), ut = Qt(R, Je), ri = Qt(v, c), Nr = _t();
+      return function(rr) {
+        return Nr.innerRadius(Math.min(ri(rr), c) - 1).outerRadius(ri(rr)).startAngle(re(rr)).endAngle(ut(rr)), Nr(C);
       };
-    }).on("end", (C) => L());
+    }).on("end", (C) => F());
   }
-  function Tl(c) {
-    const g = Cl(c, de);
-    ce = na(c, I, g, N, M, Je(), $r(), !1, !0);
-    const m = he($(Z));
-    m.select("#" + F).raise(), m.select("#" + W).raise();
+  function Pl(c) {
+    const v = Ol(c, ye);
+    at = aa(c, B, v, I, K, Ke(), Rr(), !1, !0);
+    const m = ue(A(ae));
+    m.select("#" + V).raise(), m.select("#" + Q).raise();
   }
-  function Rl(c) {
-    const g = kl(c, ce, de);
-    ce = aa(c, I, g, Je(), $r(), !1);
+  function Ml(c) {
+    const v = Fl(c, at, ye);
+    at = fa(c, B, v, Ke(), Rr(), !1);
   }
-  function Tr(c) {
-    return Pe[c.data.label];
+  function Sr(c) {
+    return Me[c.data.label];
   }
-  function Sl(c) {
-    const g = {}, m = n().results[c - 1].tallyResults;
-    for (let A = 0; A < m.length; A++) {
-      let E = m[A].eliminated;
-      if (E === void 0 && (E = m[A].elected), E === void 0) {
+  function Dl(c) {
+    const v = {}, m = n().results[c - 1].tallyResults;
+    for (let $ = 0; $ < m.length; $++) {
+      let b = m[$].eliminated;
+      if (b === void 0 && (b = m[$].elected), b === void 0) {
         console.warn("getTransferVotes: Eliminated and Elected undefined...");
         continue;
       }
-      const T = m[A].transfers;
+      const T = m[$].transfers;
       if (T === void 0) {
         console.warn("getTransferVotes: transfers undefined...");
         continue;
       }
-      for (let [P, V] of Object.entries(T))
-        g[P] === void 0 ? g[P] = Number(V) : g[P] += Number(V);
+      for (let [P, q] of Object.entries(T))
+        v[P] === void 0 ? v[P] = Number(q) : v[P] += Number(q);
     }
-    return g;
+    return v;
   }
-  function Cl(c, g) {
-    const m = [], A = at, E = n().results[c - 1].tallyResults;
-    for (let T = 0; T < E.length; T++) {
-      let P = E[T].eliminated;
-      if (P === void 0 && (P = E[T].elected), P === void 0) {
+  function Ol(c, v) {
+    const m = [], $ = Rt, b = n().results[c - 1].tallyResults;
+    for (let T = 0; T < b.length; T++) {
+      let P = b[T].eliminated;
+      if (P === void 0 && (P = b[T].elected), P === void 0) {
         console.warn("MakeDonutInfo: Eliminated and Elected undefined...");
         continue;
       }
-      const V = E[T].transfers;
-      if (V === void 0) {
+      const q = b[T].transfers;
+      if (q === void 0) {
         console.warn("makeDonutInfo: transfers undefined...");
         continue;
       }
-      let L = g.find((k) => k.data.label == P && k.data.isTransfer);
-      L === void 0 && (L = g.find((k) => k.data.label == P && !k.data.isTransfer));
+      let F = v.find((k) => k.data.label == P && k.data.isTransfer);
+      F === void 0 && (F = v.find((k) => k.data.label == P && !k.data.isTransfer));
       let C = 0;
-      if (L) C = L.startAngle;
+      if (F) C = F.startAngle;
       else {
         console.warn("makeDonutInfo: No transfers");
         continue;
       }
-      for (let [k, R] of Object.entries(V)) {
+      for (let [k, R] of Object.entries(q)) {
         let S;
-        const ke = g.find((ae) => ae.data.label == k);
-        if (ke)
-          S = structuredClone(ke);
+        const Ne = v.find((re) => re.data.label == k);
+        if (Ne)
+          S = structuredClone(Ne);
         else if (k == "exhausted")
           S = {
             data: { label: k, value: Number(R) },
@@ -5303,272 +5324,286 @@ function xl(e, t) {
           console.warn("makeDonutInfo: unrecognized name in transfers ", k);
           continue;
         }
-        const He = Number(R) / A * 2 * Math.PI;
-        S.startAngle = C, C = S.endAngle = C + He, S.index = T, S.data.transferIndex = T, m.push(S);
+        const Je = Number(R) / $ * 2 * Math.PI;
+        S.startAngle = C, C = S.endAngle = C + Je, S.index = T, S.data.transferIndex = T, m.push(S);
       }
     }
     return m;
   }
-  function Nl(c, g, m) {
-    const A = {};
-    for (let [E, T] of Object.entries(c)) {
-      const P = m.find((C) => E == C.data.label);
+  function Il(c, v, m) {
+    const $ = {};
+    for (let [b, T] of Object.entries(c)) {
+      const P = m.find((C) => b == C.data.label);
       if (P === void 0) {
-        E !== "residual surplus" && console.warn("getTransferStartAngles: mainPieObj not found for ", E);
+        b !== "residual surplus" && console.warn("getTransferStartAngles: mainPieObj not found for ", b);
         continue;
       }
-      const V = (P.startAngle + P.endAngle) / 2, L = c[P.data.label] / g * 2 * Math.PI;
-      A[P.data.label] = V - L / 2;
+      const q = (P.startAngle + P.endAngle) / 2, F = c[P.data.label] / v * 2 * Math.PI;
+      $[P.data.label] = q - F / 2;
     }
-    return A;
+    return $;
   }
-  function kl(c, g, m) {
-    const A = [], E = at, T = Sl(c), P = Nl(T, E, m);
-    for (let [V, L] of g.entries()) {
-      const C = structuredClone(L), k = L.endAngle - L.startAngle, R = m.find((S) => L.data.label === S.data.label && !S.data.isTransfer);
+  function Fl(c, v, m) {
+    const $ = [], b = Rt, T = Dl(c), P = Il(T, b, m);
+    for (let [q, F] of v.entries()) {
+      const C = structuredClone(F), k = F.endAngle - F.startAngle, R = m.find((S) => F.data.label === S.data.label && !S.data.isTransfer);
       if (R) {
         const S = R.data.label;
         C.startAngle = P[S], P[S] += k, C.endAngle = C.startAngle + k;
-      } else if (L.data.label === "exhausted")
-        C.startAngle = L.startAngle, C.endAngle = L.endAngle;
+      } else if (F.data.label === "exhausted")
+        C.startAngle = F.startAngle, C.endAngle = F.endAngle;
       else {
-        console.warn("updateDonutInfo: unrecognized slice name ", L.data.label);
+        console.warn("updateDonutInfo: unrecognized slice name ", F.data.label);
         continue;
       }
-      C.index = V, A.push(C);
+      C.index = q, $.push(C);
     }
-    return A;
+    return $;
   }
-  function Qs(c, g, m, A) {
-    const E = yt().innerRadius(m * U).outerRadius(m * U), T = g.filter((k) => !k.data.isTransfer && k.data.value > 0), P = [], V = A.append("g").attr("opacity", 0);
+  function ia(c, v, m, $) {
+    const b = _t().innerRadius(m * ie).outerRadius(m * ie), T = v.filter((k) => !k.data.isTransfer && k.data.value > 0), P = [], q = $.append("g").attr("opacity", 0);
     for (const k of T) {
-      const R = k.data.label === "exhausted" ? St : k.data.label, S = E.centroid(k), ke = Qr(k.startAngle, k.endAngle), Q = Jn(k.data.label, c);
-      let He;
-      !h() && Nt(k.data.label) ? He = Q : He = Q + " (" + Zr(k.data.label, c) + ")";
-      const ae = V.append("text").attr("transform", `translate(${S})`).attr("text-anchor", ke).text(R);
-      ae.append("tspan").attr("x", 0).attr("dy", "1.2em").text(He);
-      const Te = ae.node().getBBox();
+      const R = k.data.label === "exhausted" ? Xt : k.data.label, S = b.centroid(k), Ne = ni(k.startAngle, k.endAngle), ne = er(k.data.label, c), Je = q.append("text").attr("transform", `translate(${S})`).attr("text-anchor", Ne).text(R);
+      Je.append("tspan").attr("x", 0).attr("dy", "1.2em").text(ne);
+      const re = Je.node().getBBox();
       P.push({
         label: k.data.label,
         value: k.data.value,
-        bbox: new DOMRect(Te.x + S[0], Te.y + S[1], Te.width, Te.height)
+        bbox: new DOMRect(re.x + S[0], re.y + S[1], re.width, re.height)
       });
     }
-    V.remove(), P.sort((k, R) => R.value - k.value);
-    const L = [], C = /* @__PURE__ */ new Set();
+    q.remove(), P.sort((k, R) => R.value - k.value);
+    const F = [], C = /* @__PURE__ */ new Set();
     for (const k of P)
-      L.some((S) => k.bbox.left < S.right && k.bbox.right > S.left && k.bbox.top < S.bottom && k.bbox.bottom > S.top) || (C.add(k.label), L.push(k.bbox));
+      F.some((S) => k.bbox.left < S.right && k.bbox.right > S.left && k.bbox.top < S.bottom && k.bbox.bottom > S.top) || (C.add(k.label), F.push(k.bbox));
     return C;
   }
-  function ea(c, g, m, A, E, T) {
-    const V = he($(Z)).append("g").attr("id", ee).attr("transform", `translate(${m}, ${A})`), L = yt().innerRadius(E * U).outerRadius(E * U), C = Qs(c, g, E, V);
-    V.selectAll("text").data(g).enter().each(function(k) {
-      !k.data.isTransfer && C.has(k.data.label) && he(this).append("g").attr("id", (R) => x(R.data)).classed("eliminated", (R) => T.includes(R.data.label) || R.data.isTransfer === !0).each(function(R, S) {
-        R.data.label === "exhausted" && he(this).on("mouseenter", (ke, Q) => Fl(ke)).on("mouseleave", (ke, Q) => Il());
-      }).append("text").attr("transform", (R) => `translate(${L.centroid(R)})`).attr("text-anchor", (R) => Qr(R.startAngle, R.endAngle)).text((R) => R.data.label === "exhausted" ? St : R.data.label).append("tspan").attr("x", 0).attr("dy", "1.2em").text((R) => {
-        const S = Jn(R.data.label, c);
-        return !h() && Nt(R.data.label) ? S : S + " (" + Zr(R.data.label, c) + ")";
-      });
+  function ts(c, v, m, $, b, T) {
+    Tt = {
+      round: c,
+      pieInfo: v,
+      x: m,
+      y: $,
+      outerRadius: b,
+      eliminated: T
+    };
+    const q = ue(A(ae)).append("g").attr("id", U).attr("transform", `translate(${m}, ${$})`), F = _t().innerRadius(b * ie).outerRadius(b * ie), C = ia(c, v, b, q);
+    q.selectAll("text").data(v).enter().each(function(k) {
+      !k.data.isTransfer && C.has(k.data.label) && ue(this).append("g").attr("id", (R) => x(R.data)).classed("eliminated", (R) => T.includes(R.data.label) || R.data.isTransfer === !0).each(function(R, S) {
+        R.data.label === "exhausted" && ue(this).on("mouseenter", (Ne, ne) => Hl(Ne)).on("mouseleave", (Ne, ne) => Yl());
+      }).append("text").attr("transform", (R) => `translate(${F.centroid(R)})`).attr("text-anchor", (R) => ni(R.startAngle, R.endAngle)).text((R) => R.data.label === "exhausted" ? Xt : R.data.label).append("tspan").attr("x", 0).attr("dy", "1.2em").text((R) => er(R.data.label, c));
     });
   }
-  function Ml(c, g, m, A) {
-    const T = he($(Z)).select("#" + ee), P = Qs(c, g, m, T);
+  function Ll(c, v, m, $) {
+    const T = ue(A(ae)).select("#" + U), P = ia(c, v, m, T);
     T.selectAll("g").each(function(S) {
-      S && S.data && !S.data.isTransfer && !P.has(S.data.label) && he(this).remove();
+      S && S.data && !S.data.isTransfer && !P.has(S.data.label) && ue(this).remove();
     });
-    const V = T.selectAll("tspan"), L = T.selectAll("g").data(g, (S) => x(S.data)).classed("eliminated", (S) => A.includes(S.data.label) || S.data.isTransfer === !0), C = yt().innerRadius(m * U).outerRadius(m * U + 1);
-    V.transition("global").duration(re).attr("transform", (S) => `translate(${C.centroid(S)})`).attr("text-anchor", (S) => Qr(S.startAngle, S.endAngle)), L.select("text").transition("global").duration(re).attr("transform", (S) => `translate(${C.centroid(S)})`).attr("text-anchor", (S) => Qr(S.startAngle, S.endAngle)).on("end", (S) => R());
-    let k = L.size();
+    const q = T.selectAll("tspan"), F = T.selectAll("g").data(v, (S) => x(S.data)).classed("eliminated", (S) => $.includes(S.data.label) || S.data.isTransfer === !0), C = _t().innerRadius(m * ie).outerRadius(m * ie + 1);
+    q.transition("global").duration(M).attr("transform", (S) => `translate(${C.centroid(S)})`).attr("text-anchor", (S) => ni(S.startAngle, S.endAngle)), F.select("text").transition("global").duration(M).attr("transform", (S) => `translate(${C.centroid(S)})`).attr("text-anchor", (S) => ni(S.startAngle, S.endAngle)).on("end", (S) => R());
+    let k = F.size();
     function R(S) {
-      k--, k === 0 && (T.remove(), ea(c, g, N, M, m, A));
+      k--, k === 0 && (T.remove(), ts(c, v, I, K, m, $));
     }
   }
-  function ta(c, g, m, A, E, T, P, V = !0, L = !1, C = !1) {
-    const R = as().sort(null).value((S) => S.value)(m);
-    return na(c, g, R, A, E, T, P, V, L, C), R;
+  function sa(c, v, m, $, b, T, P, q = !0, F = !1, C = !1) {
+    const R = cs().sort(null).value((S) => S.value)(m);
+    return aa(c, v, R, $, b, T, P, q, F, C), R;
   }
-  function Rr() {
-    he($(Z)).select("#" + W).selectAll(".elected").select("path").style("stroke", te).style("stroke-width", `${je}px`);
+  function Cr() {
+    ue(A(ae)).select("#" + Q).selectAll(".elected").select("path").style("stroke", se).style("stroke-width", `${Pe}px`);
   }
-  function na(c, g, m, A, E, T, P, V, L, C = !1) {
-    const k = Y(c), R = se(c), Q = he($(Z)).attr("viewBox", `0 0 ${y} ${b}`).attr("preserveAspectRatio", "xMidYMid meet").classed("pie-chart-svg", !0).append("g").attr("id", g).attr("transform", `translate(${A}, ${E})`).selectAll(".slice").data(m).enter().append("g").attr("class", "slice").classed("eliminated", (ae) => k.includes(ae.data.label) || ae.data.isTransfer === !0).classed("elected", (ae) => R.includes(ae.data.label) && !ae.data.isTransfer).attr("id", (ae) => x(ae.data));
-    C ? Q.style("pointer-events", "none") : Q.on("mouseenter", (ae, Te) => Zi(ae, Te)).on("mouseleave", (ae, Te) => Qi(ae, Te));
-    const He = yt().outerRadius(P).innerRadius(T);
-    if (L) {
-      const ae = yt().outerRadius(T + 1).innerRadius(T);
-      Q.append("path").attr("d", ae).attr("stroke", C ? "none" : T === 0 ? D : "none").attr("stroke-width", C ? 0 : T === 0 ? H : 0).attr("fill", C ? "none" : (Te) => Tr(Te)).transition("global").duration(re).attr("d", (Te) => He(Te)).on("end", (Te) => {
-        C || Ji();
+  function aa(c, v, m, $, b, T, P, q, F, C = !1) {
+    const k = he(c), R = ge(c), ne = ue(A(ae)).attr("viewBox", `0 0 ${D} ${N}`).attr("preserveAspectRatio", "xMidYMid meet").classed("pie-chart-svg", !0).append("g").attr("id", v).attr("transform", `translate(${$}, ${b})`).selectAll(".slice").data(m).enter().append("g").attr("class", "slice").classed("eliminated", (re) => k.includes(re.data.label) || re.data.isTransfer === !0).classed("elected", (re) => R.includes(re.data.label) && !re.data.isTransfer).attr("id", (re) => x(re.data));
+    C ? ne.style("pointer-events", "none") : ne.on("mouseenter", (re, ut) => rs(re, ut)).on("mouseleave", (re, ut) => is(re, ut));
+    const Je = _t().outerRadius(P).innerRadius(T);
+    if (F) {
+      const re = _t().outerRadius(T + 1).innerRadius(T);
+      ne.append("path").attr("d", re).attr("stroke", C ? "none" : T === 0 ? Se : "none").attr("stroke-width", C ? 0 : T === 0 ? Ge : 0).attr("fill", C ? "none" : (ut) => Sr(ut)).transition("global").duration(M).attr("d", (ut) => Je(ut)).on("end", (ut) => {
+        C || ns();
       });
     } else
-      Q.append("path").attr("d", (ae) => He(ae)).attr("fill", C ? "none" : (ae) => Tr(ae)).attr("stroke", C ? "none" : D).attr("stroke-width", C ? 0 : H), C || Ji();
-    return V && !C && ea(c, m, A, E, P, k), m;
+      ne.append("path").attr("d", (re) => Je(re)).attr("fill", C ? "none" : (re) => Sr(re)).attr("stroke", C ? "none" : Se).attr("stroke-width", C ? 0 : Ge), C || ns();
+    return q && !C && ts(c, m, $, b, P, k), m;
   }
-  function Pl() {
-    const m = he($(Z)).select("#" + ee).selectAll(".eliminated");
+  function ql() {
+    const m = ue(A(ae)).select("#" + U).selectAll(".eliminated");
     m.size() > 0 && m.classed("finished", !0);
   }
-  function Dl() {
-    const m = he($(Z)).select("#" + ee).selectAll(".finished");
+  function Vl() {
+    const m = ue(A(ae)).select("#" + U).selectAll(".finished");
     m.size() > 0 && m.remove();
   }
-  function Ol(c, g) {
-    const E = he($(Z)).select("#" + F).selectAll(".eliminated"), T = yt().innerRadius(c), P = yt().outerRadius(g);
-    E.classed("finished", !0).select("path").attr("stroke", "none").transition("global").duration(re).attrTween("d", function(V) {
-      const L = Jt(g, c);
+  function zl(c, v) {
+    const b = ue(A(ae)).select("#" + V).selectAll(".eliminated"), T = _t().innerRadius(c), P = _t().outerRadius(v);
+    b.classed("finished", !0).select("path").attr("stroke", "none").transition("global").duration(M).attrTween("d", function(q) {
+      const F = Qt(v, c);
       return function(C) {
-        return P.innerRadius(L(C)), P(V);
+        return P.innerRadius(F(C)), P(q);
       };
-    }).attr("fill", (V) => `url(#${qe(V.data.label)})`), E.clone(!0).classed("finished", !0).select("path").transition("global").duration(re).attrTween("d", function(V) {
-      const L = Jt(g, c);
+    }).attr("fill", (q) => `url(#${me(q.data.label)})`), b.clone(!0).classed("finished", !0).select("path").transition("global").duration(M).attrTween("d", function(q) {
+      const F = Qt(v, c);
       return function(C) {
-        return T.outerRadius(L(C)), T(V);
+        return T.outerRadius(F(C)), T(q);
       };
-    }).attr("fill", (V) => Tr(V));
+    }).attr("fill", (q) => Sr(q));
   }
-  function Qr(c, g) {
-    const m = (c + g) / 2;
+  function ni(c, v) {
+    const m = (c + v) / 2;
     return m > Math.PI * 11 / 6 || m < Math.PI * 1 / 6 || m > Math.PI * 5 / 6 && m < Math.PI * 7 / 6 ? "middle" : m < Math.PI ? "start" : "end";
   }
-  function Ji() {
-    he($(
-      Z
+  function ns() {
+    ue(A(
+      ae
       // force redisplay of text labels
-    )).select("#" + ee).raise().append("g").remove();
+    )).select("#" + U).raise().append("g").remove();
   }
-  function ra(c, g, m, A, E, T, P = !1) {
-    const L = as().sort(null).value((C) => C.value)(m);
-    return aa(c, g, L, A, E, T, P), L;
+  function oa(c, v, m, $, b, T, P = !1) {
+    const F = cs().sort(null).value((C) => C.value)(m);
+    return fa(c, v, F, $, b, T, P), F;
   }
-  function ia(c, g, m, A, E = !1) {
-    const T = Y(c), P = se(c), C = he($(Z)).select("#" + g).selectAll(".slice").data(m, (R) => x(R.data));
+  function la(c, v, m, $, b = !1) {
+    const T = he(c), P = ge(c), C = ue(A(ae)).select("#" + v).selectAll(".slice").data(m, (R) => x(R.data));
     C.exit().remove();
     const k = C.enter().append("g").attr("class", "slice").attr("id", (R) => x(R.data)).classed("eliminated", !0);
-    return E ? k.style("pointer-events", "none") : k.on("mouseenter", (R, S) => Zi(R, S)).on("mouseleave", (R, S) => Qi(R, S)), k.append("path").attr("d", (R) => A(R)).attr("fill", E ? "none" : (R) => Tr(R)).attr("stroke", E ? "none" : D).attr("stroke-width", E ? 0 : H), C.classed("eliminated", (R) => T.includes(R.data.label)).classed("elected", (R) => P.includes(R.data.label)), E || C.on("mouseenter", (R, S) => Zi(R, S)).on("mouseleave", (R, S) => Qi(R, S)), C;
+    return b ? k.style("pointer-events", "none") : k.on("mouseenter", (R, S) => rs(R, S)).on("mouseleave", (R, S) => is(R, S)), k.append("path").attr("d", (R) => $(R)).attr("fill", b ? "none" : (R) => Sr(R)).attr("stroke", b ? "none" : Se).attr("stroke-width", b ? 0 : Ge), C.classed("eliminated", (R) => T.includes(R.data.label)).classed("elected", (R) => P.includes(R.data.label)), b || C.on("mouseenter", (R, S) => rs(R, S)).on("mouseleave", (R, S) => is(R, S)), C;
   }
-  function sa(c, g, m, A, E, T = !1) {
-    const P = yt().outerRadius(E).innerRadius(A);
-    ia(c, g, m, P, T).select("path").attr("d", (L) => P(L)).attr("fill", T ? "none" : (L) => Tr(L));
+  function ua(c, v, m, $, b, T = !1) {
+    const P = _t().outerRadius(b).innerRadius($);
+    la(c, v, m, P, T).select("path").attr("d", (F) => P(F)).attr("fill", T ? "none" : (F) => Sr(F));
   }
-  function aa(c, g, m, A, E, T, P = !1) {
-    const V = yt().outerRadius(E).innerRadius(A).startAngle((Q) => Q.startAngle).endAngle((Q) => Q.endAngle), L = yt().outerRadius(E).innerRadius(A);
-    he($(Z)).select("#" + g).selectAll(".slice").attr("prevStart", (Q) => Q.startAngle).attr("prevEnd", (Q) => Q.endAngle);
-    const R = ia(c, g, m, L, P);
+  function fa(c, v, m, $, b, T, P = !1) {
+    const q = _t().outerRadius(b).innerRadius($).startAngle((ne) => ne.startAngle).endAngle((ne) => ne.endAngle), F = _t().outerRadius(b).innerRadius($);
+    ue(A(ae)).select("#" + v).selectAll(".slice").attr("prevStart", (ne) => ne.startAngle).attr("prevEnd", (ne) => ne.endAngle);
+    const R = la(c, v, m, F, P);
     let S = R.size();
-    function ke() {
-      S--, S <= 0 && (P || Ji());
+    function Ne() {
+      S--, S <= 0 && (P || ns());
     }
-    return R.select("path").transition("global").duration(re).attrTween("d", function(Q) {
-      const He = Number(he(this.parentNode).attr("prevStart")), ae = Number(he(this.parentNode).attr("prevEnd")), Te = Jt(He, Q.startAngle), ei = Jt(ae, Q.endAngle);
-      return (Sr) => (V.startAngle(Te(Sr)).endAngle(ei(Sr)), V(Q));
-    }).on("end", function(Q) {
-      Q.startAngle === Q.endAngle && he(this).attr("stroke", "none"), ke();
-    }), T && !P && Ml(c, m, E, Y(c)), m;
+    return R.select("path").transition("global").duration(M).attrTween("d", function(ne) {
+      const Je = Number(ue(this.parentNode).attr("prevStart")), re = Number(ue(this.parentNode).attr("prevEnd")), ut = Qt(Je, ne.startAngle), ri = Qt(re, ne.endAngle);
+      return (Nr) => (q.startAngle(ut(Nr)).endAngle(ri(Nr)), q(ne));
+    }).on("end", function(ne) {
+      ne.startAngle === ne.endAngle && ue(this).attr("stroke", "none"), Ne();
+    }), T && !P && Ll(c, m, b, he(c)), m;
   }
-  function Zi(c, g) {
-    s(g.data.label), i("enter"), a(c.clientX), o(c.clientY);
+  function rs(c, v) {
+    s(v.data.label), i("enter"), a(c.clientX), o(c.clientY);
   }
-  function Qi(c, g) {
-    s(g.data.label), i("leave");
+  function is(c, v) {
+    s(v.data.label), i("leave");
   }
-  function Fl(c, g) {
+  function Hl(c, v) {
     i("show-exhausted"), a(c.clientX), o(c.clientY);
   }
-  function Il(c, g) {
+  function Yl(c, v) {
     i("hide-exhausted");
   }
-  var Ll = {
-    pieColors: Pe,
-    exhaustedLabel: St,
-    countExhaustedVotes: Ar,
-    getEliminatedCandidates: Y,
-    getElectedCandidates: se,
-    runFullAnimationFn: Er,
-    animateOnePhaseFn: Zs,
+  var Bl = {
+    pieColors: Me,
+    exhaustedLabel: Xt,
+    countExhaustedVotes: pn,
+    getEliminatedCandidates: he,
+    getElectedCandidates: ge,
+    runFullAnimationFn: Jt,
+    animateOnePhaseFn: ra,
     get jsonData() {
       return n();
     },
     set jsonData(c) {
-      n(c), ne();
+      n(c), j();
     },
     get currentRound() {
       return r();
     },
     set currentRound(c = 1) {
-      r(c), ne();
+      r(c), j();
     },
     get mouseEventType() {
       return i();
     },
     set mouseEventType(c) {
-      i(c), ne();
+      i(c), j();
     },
     get mouseData() {
       return s();
     },
     set mouseData(c) {
-      s(c), ne();
+      s(c), j();
     },
     get mouseX() {
       return a();
     },
     set mouseX(c) {
-      a(c), ne();
+      a(c), j();
     },
     get mouseY() {
       return o();
     },
     set mouseY(c) {
-      o(c), ne();
+      o(c), j();
     },
     get requestRoundChange() {
       return l();
     },
-    set requestRoundChange(c = (g) => {
+    set requestRoundChange(c = (v) => {
     }) {
-      l(c), ne();
+      l(c), j();
     },
     get requestSkipToRound() {
       return u();
     },
-    set requestSkipToRound(c = (g) => {
+    set requestSkipToRound(c = (v) => {
     }) {
-      u(c), ne();
+      u(c), j();
     },
     get candidateColors() {
       return f();
     },
     set candidateColors(c = []) {
-      f(c), ne();
+      f(c), j();
     },
     get excludeFinalWinnerAndEliminatedCandidate() {
       return d();
     },
     set excludeFinalWinnerAndEliminatedCandidate(c = !1) {
-      d(c), ne();
+      d(c), j();
     },
     get firstRoundDeterminesPercentages() {
       return h();
     },
     set firstRoundDeterminesPercentages(c = !1) {
-      h(c), ne();
+      h(c), j();
     },
-    get randomizeOrder() {
+    get showVotes() {
       return p();
     },
+    set showVotes(c = !0) {
+      p(c), j();
+    },
+    get showPercent() {
+      return y();
+    },
+    set showPercent(c = !0) {
+      y(c), j();
+    },
+    get randomizeOrder() {
+      return E();
+    },
     set randomizeOrder(c = !1) {
-      p(c), ne();
+      E(c), j();
     },
     get displayPhase() {
       return _();
     },
     set displayPhase(c = 0) {
-      _(c), ne();
+      _(c), j();
     }
-  }, oa = np();
-  return pi(oa, (c) => ve(Z, c), () => $(Z)), We(e, oa), Vi(Ll);
+  }, ca = lp();
+  return _i(ca, (c) => pe(ae, c), () => A(ae)), Be(e, ca), Bi(Bl);
 }
-Ys(
-  xl,
+Us(
+  El,
   {
     jsonData: {},
     currentRound: {},
@@ -5581,6 +5616,8 @@ Ys(
     candidateColors: {},
     excludeFinalWinnerAndEliminatedCandidate: {},
     firstRoundDeterminesPercentages: {},
+    showVotes: {},
+    showPercent: {},
     randomizeOrder: {},
     displayPhase: {}
   },
@@ -5596,14 +5633,14 @@ Ys(
   ],
   { mode: "open" }
 );
-var ip = /* @__PURE__ */ Bt("<div></div>"), sp = /* @__PURE__ */ Bt('<!> <div class="step svelte-1l4eyw0"><div></div> <span> </span></div>', 1), ap = /* @__PURE__ */ Bt('<div role="button" aria-label="Advance animation phase"></div>');
-const op = {
+var fp = /* @__PURE__ */ Yt("<div></div>"), cp = /* @__PURE__ */ Yt('<!> <div class="step svelte-1l4eyw0"><div></div> <span> </span></div>', 1), hp = /* @__PURE__ */ Yt('<div role="button" aria-label="Advance animation phase"></div>');
+const dp = {
   hash: "svelte-1l4eyw0",
   code: ".stepper.svelte-1l4eyw0 {display:inline-flex;align-items:center;cursor:pointer;user-select:none;padding:4px 8px;border-radius:4px;}.stepper.svelte-1l4eyw0:hover:not(.disabled) {background-color:#f0f0f0;}.stepper.disabled.svelte-1l4eyw0 {cursor:default;opacity:0.4;}.step.svelte-1l4eyw0 {display:flex;align-items:center;gap:4px;}.dot.svelte-1l4eyw0 {width:10px;height:10px;border-radius:50%;border:2px solid #ccc;background:white;transition:background-color 0.3s, border-color 0.3s;}.dot.active.svelte-1l4eyw0 {background:#4747ff;border-color:#4747ff;}.dot.completed.svelte-1l4eyw0 {background:#8888ff;border-color:#8888ff;}.label.svelte-1l4eyw0 {font-size:0.75rem;color:#888;transition:color 0.3s, font-weight 0.3s;}.label.active.svelte-1l4eyw0 {color:#4747ff;font-weight:bold;}.label.completed.svelte-1l4eyw0 {color:#8888ff;}.connector.svelte-1l4eyw0 {width:20px;height:2px;background:#ccc;margin:0 4px;transition:background-color 0.3s;}.connector.completed.svelte-1l4eyw0 {background:#8888ff;}"
 };
-function bl(e, t) {
-  qi(t, !0), Hs(e, op);
-  let n = ie(t, "labels", 23, () => ["Eliminate", "Transfer", "Consolidate"]), r = ie(t, "currentStep", 7, 0), i = ie(t, "disabled", 7, !1), s = ie(t, "onAdvance", 7, () => {
+function Tl(e, t) {
+  Yi(t, !0), Ws(e, dp);
+  let n = ee(t, "labels", 23, () => ["Eliminate", "Transfer", "Consolidate"]), r = ee(t, "currentStep", 7, 0), i = ee(t, "disabled", 7, !1), s = ee(t, "onAdvance", 7, () => {
   });
   function a() {
     i() || s()();
@@ -5616,63 +5653,63 @@ function bl(e, t) {
       return n();
     },
     set labels(d = ["Eliminate", "Transfer", "Consolidate"]) {
-      n(d), ne();
+      n(d), j();
     },
     get currentStep() {
       return r();
     },
     set currentStep(d = 0) {
-      r(d), ne();
+      r(d), j();
     },
     get disabled() {
       return i();
     },
     set disabled(d = !1) {
-      i(d), ne();
+      i(d), j();
     },
     get onAdvance() {
       return s();
     },
     set onAdvance(d = () => {
     }) {
-      s(d), ne();
+      s(d), j();
     }
-  }, u = ap();
+  }, u = hp();
   let f;
-  return u.__click = a, u.__keydown = o, di(u, 21, n, hi, (d, h, p) => {
-    var _ = sp(), x = gn(_);
+  return u.__click = a, u.__keydown = o, gi(u, 21, n, vi, (d, h, p) => {
+    var y = cp(), E = mn(y);
     {
-      var y = (I) => {
-        var ee = ip();
-        let fe;
-        Zt(() => fe = ri(ee, 1, "connector svelte-1l4eyw0", null, fe, { completed: !i() && p <= r() })), We(I, ee);
+      var _ = (V) => {
+        var Q = fp();
+        let B;
+        en(() => B = ai(Q, 1, "connector svelte-1l4eyw0", null, B, { completed: !i() && p <= r() })), Be(V, Q);
       };
-      tr(x, (I) => {
-        p > 0 && I(y);
+      ir(E, (V) => {
+        p > 0 && V(_);
       });
     }
-    var b = Ze(x, 2), O = Be(b);
+    var x = Ze(E, 2), D = He(x);
     let N;
-    var M = Ze(O, 2);
-    let F;
-    var W = Be(M, !0);
-    Oe(M), Oe(b), Zt(() => {
-      N = ri(O, 1, "dot svelte-1l4eyw0", null, N, {
+    var O = Ze(D, 2);
+    let I;
+    var K = He(O, !0);
+    Oe(O), Oe(x), en(() => {
+      N = ai(D, 1, "dot svelte-1l4eyw0", null, N, {
         active: !i() && p === r(),
         completed: !i() && p < r()
-      }), F = ri(M, 1, "label svelte-1l4eyw0", null, F, {
+      }), I = ai(O, 1, "label svelte-1l4eyw0", null, I, {
         active: !i() && p === r(),
         completed: !i() && p < r()
-      }), _n(W, $(h));
-    }), We(d, _);
-  }), Oe(u), Zt(() => {
-    f = ri(u, 1, "stepper svelte-1l4eyw0", null, f, { disabled: i() }), ba(u, "tabindex", i() ? -1 : 0), ba(u, "aria-disabled", i());
-  }), We(e, u), Vi(l);
+      }), yn(K, A(h));
+    }), Be(d, y);
+  }), Oe(u), en(() => {
+    f = ai(u, 1, "stepper svelte-1l4eyw0", null, f, { disabled: i() }), Ta(u, "tabindex", i() ? -1 : 0), Ta(u, "aria-disabled", i());
+  }), Be(e, u), Bi(l);
 }
-Ku(["click", "keydown"]);
-Ys(bl, { labels: {}, currentStep: {}, disabled: {}, onAdvance: {} }, [], [], { mode: "open" });
-var lp = /* @__PURE__ */ Bt("<span> </span> <!>", 1), up = /* @__PURE__ */ Bt("About to eliminate: <!>", 1), fp = /* @__PURE__ */ Bt("<span> </span> <!>", 1), cp = /* @__PURE__ */ Bt(" <!>", 1), hp = /* @__PURE__ */ Bt('<h3 class="svelte-1r6y5gl"> </h3> <h4 class="svelte-1r6y5gl"><!> <!></h4>', 1), dp = /* @__PURE__ */ Bt("<span> </span> <br/>", 1), pp = /* @__PURE__ */ Bt('<div class="animation-button-container svelte-1r6y5gl"><!></div> <div class="common-header svelte-1r6y5gl"></div> <div class="page-container svelte-1r6y5gl"><div class="visualizations-container svelte-1r6y5gl"><div class="pie-chart-container svelte-1r6y5gl"><!></div></div> <!></div> <div class="tooltip svelte-1r6y5gl"><h3 class="svelte-1r6y5gl"> </h3> <!></div> <div class="tooltip svelte-1r6y5gl"> <br/> these ballots have already been eliminated.</div>', 1);
-const vp = {
+tf(["click", "keydown"]);
+Us(Tl, { labels: {}, currentStep: {}, disabled: {}, onAdvance: {} }, [], [], { mode: "open" });
+var pp = /* @__PURE__ */ Yt("<span> </span> <!>", 1), vp = /* @__PURE__ */ Yt("About to eliminate: <!>", 1), gp = /* @__PURE__ */ Yt("<span> </span> <!>", 1), _p = /* @__PURE__ */ Yt(" <!>", 1), mp = /* @__PURE__ */ Yt('<h3 class="svelte-1r6y5gl"> </h3> <h4 class="svelte-1r6y5gl"><!> <!></h4>', 1), yp = /* @__PURE__ */ Yt("<span> </span> <br/>", 1), wp = /* @__PURE__ */ Yt('<div class="animation-button-container svelte-1r6y5gl"><!></div> <div class="common-header svelte-1r6y5gl"></div> <div class="page-container svelte-1r6y5gl"><div class="visualizations-container svelte-1r6y5gl"><div class="pie-chart-container svelte-1r6y5gl"><!></div></div> <!></div> <div class="tooltip svelte-1r6y5gl"><h3 class="svelte-1r6y5gl"> </h3> <!></div> <div class="tooltip svelte-1r6y5gl"> <br/> these ballots have already been eliminated.</div>', 1);
+const xp = {
   hash: "svelte-1r6y5gl",
   code: `.page-container.svelte-1r6y5gl {width:95%;max-width:1800px;margin:0 auto;padding:0 20px;box-sizing:border-box;display:flex;flex-direction:column;align-items:center;}.common-header.svelte-1r6y5gl {width:100%;margin-bottom:1rem;text-align:center;}.tooltip.svelte-1r6y5gl {position:fixed;width:max-content;max-width:calc(100vw - 24px);text-align:left;padding:.5rem;background:#FFFFFF;color:#313639;border:1px solid #313639;border-radius:8px;pointer-events:none;font-size:0.8rem;font-weight:normal;opacity:0;z-index:100;}.tooltip.svelte-1r6y5gl h3:where(.svelte-1r6y5gl) {text-align:center;}.animation-button-container.svelte-1r6y5gl {display:flex;justify-content:center;gap:10px;margin:0.5rem;}.pie-chart-container.svelte-1r6y5gl {width:100%;min-width:auto;flex-grow:0;margin:0 auto;margin-top:-3vh;}.visualizations-container.svelte-1r6y5gl {display:flex;justify-content:space-between;width:100%;padding:0 20px;gap:20px;}
 
@@ -5687,13 +5724,13 @@ const vp = {
   
 }`
 };
-function gp(e, t) {
-  qi(t, !0), Hs(e, vp);
+function bp(e, t) {
+  Yi(t, !0), Ws(e, xp);
   const n = 0.85;
-  let r = ie(t, "electionSummary", 7), i = ie(t, "currentRound", 7, 1), s = ie(t, "requestRoundChange", 7, (w) => {
-  }), a = ie(t, "requestSkipToRound", 7, (w) => {
-  }), o = ie(t, "candidateColors", 23, () => []), l = ie(t, "textForWinner", 7, "elected"), u = ie(t, "excludeFinalWinnerAndEliminatedCandidate", 7, !1), f = ie(t, "firstRoundDeterminesPercentages", 7, !1), d = ie(t, "randomizeOrder", 7, !1), h = ie(t, "showCaptions", 7, !1);
-  const p = {
+  let r = ee(t, "electionSummary", 7), i = ee(t, "currentRound", 7, 1), s = ee(t, "requestRoundChange", 7, (w) => {
+  }), a = ee(t, "requestSkipToRound", 7, (w) => {
+  }), o = ee(t, "candidateColors", 23, () => []), l = ee(t, "textForWinner", 7, "won"), u = ee(t, "excludeFinalWinnerAndEliminatedCandidate", 7, !1), f = ee(t, "firstRoundDeterminesPercentages", 7, !1), d = ee(t, "showVotes", 7, !0), h = ee(t, "showPercent", 7, !0), p = ee(t, "randomizeOrder", 7, !1), y = ee(t, "showCaptions", 7, !1);
+  const E = {
     elected: {
       caption: "Elected",
       event: "was elected",
@@ -5711,198 +5748,210 @@ function gp(e, t) {
       infinitive: "to take the lead"
     }
   };
-  let _ = /* @__PURE__ */ Sn(() => p[l()] ?? p.elected), x = /* @__PURE__ */ $e(null), y = /* @__PURE__ */ $e(null), b = /* @__PURE__ */ $e(""), O = /* @__PURE__ */ $e(Pn([])), N = /* @__PURE__ */ $e(""), M = /* @__PURE__ */ $e(""), F = /* @__PURE__ */ $e(0), W = /* @__PURE__ */ $e(0), I = /* @__PURE__ */ Sn(() => ee(r()));
-  function ee(w) {
+  let _ = /* @__PURE__ */ Nn(() => E[l()] ?? E.won), x = /* @__PURE__ */ xe(null), D = /* @__PURE__ */ xe(null), N = /* @__PURE__ */ xe(""), O = /* @__PURE__ */ xe(On([])), I = /* @__PURE__ */ xe(""), K = /* @__PURE__ */ xe(""), V = /* @__PURE__ */ xe(0), Q = /* @__PURE__ */ xe(0), B = /* @__PURE__ */ Nn(() => U(r()));
+  function U(w) {
     if (typeof w == "string")
       try {
         w = JSON.parse(w);
-      } catch (Y) {
-        return console.error("Failed to parse JSON string:", Y), {};
+      } catch (G) {
+        return console.error("Failed to parse JSON string:", G), {};
       }
     return w || {};
   }
   function fe(w) {
     s() ? s()(w) : console.warn("onRoundChange in PieChart: requestRoundChange is null");
   }
-  function U(w, Y, se) {
-    w.style.left = Y + "px", w.style.top = se + 20 + "px", w.style.transform = "none", requestAnimationFrame(() => {
-      const ue = w.getBoundingClientRect();
-      let Ve = Y, Ut = se + 20;
-      Ve + ue.width > window.innerWidth - 12 && (Ve = window.innerWidth - ue.width - 12), Ve < 12 && (Ve = 12), Ut + ue.height > window.innerHeight - 12 && (Ut = se - ue.height - 12), w.style.left = Ve + "px", w.style.top = Ut + "px";
+  function ie(w, G, oe) {
+    w.style.left = G + "px", w.style.top = oe + 20 + "px", w.style.transform = "none", requestAnimationFrame(() => {
+      const le = w.getBoundingClientRect();
+      let De = G, Gt = oe + 20;
+      De + le.width > window.innerWidth - 12 && (De = window.innerWidth - le.width - 12), De < 12 && (De = 12), Gt + le.height > window.innerHeight - 12 && (Gt = oe - le.height - 12), w.style.left = De + "px", w.style.top = Gt + "px";
     });
   }
-  function re() {
-    switch ($(N)) {
+  function M() {
+    switch (A(I)) {
       case "enter":
         ((w) => {
-          var Y = su(w, 2);
-          ve(O, Y[0], !0), ve(b, Y[1], !0);
-        })(D($(M), i())), $(x) && (U($(x), $(F) || 0, $(W) || 0), $(x).style.opacity = String(n));
+          var G = cu(w, 2);
+          pe(O, G[0], !0), pe(N, G[1], !0);
+        })(Se(A(K), i())), A(x) && (ie(A(x), A(V) || 0, A(Q) || 0), A(x).style.opacity = String(n));
         break;
       case "leave":
-        $(x) && ($(x).style.opacity = "0"), ve(O, [], !0), ve(b, "");
+        A(x) && (A(x).style.opacity = "0"), pe(O, [], !0), pe(N, "");
         break;
       case "show-exhausted":
-        $(y) && (U($(y), $(F) || 0, $(W) || 0), $(y).style.opacity = String(n));
+        A(D) && (ie(A(D), A(V) || 0, A(Q) || 0), A(D).style.opacity = String(n));
         break;
       case "hide-exhausted":
-        $(y) && ($(y).style.opacity = "0");
+        A(D) && (A(D).style.opacity = "0");
         break;
       case "":
         break;
       default:
-        console.log("Unknown mouse event: ", $(N));
+        console.log("Unknown mouse event: ", A(I));
         break;
     }
   }
-  Is(() => re());
-  function le(w, Y) {
-    return w === 1 ? Y ? "vote was" : "vote will be" : Y ? "votes were" : "votes will be";
+  Ri(() => M());
+  function z(w, G) {
+    return w === 1 ? G ? "vote was" : "vote will be" : G ? "votes were" : "votes will be";
   }
-  function D(w, Y) {
-    const se = [], we = w === "exhausted" ? Pe() : w;
-    let ye;
-    w === "exhausted" ? ye = at(1) : ye = $(I).results[0].tally[w], se.push(`${we} started with ${ye} votes.`);
-    for (let ue = 1; ue <= Y; ue++) {
-      ue === Y && (w === "exhausted" ? ye = at(Y) : ye = $(I).results[Y - 1].tally[w], se.push(`${we} has ${ye} votes at round ${Y}.`));
-      const Ve = $(I).results[ue - 1].tallyResults, Ut = de(ue);
-      for (let gt = 0; gt < Ve.length; gt++) {
-        const Rn = Ve[gt].transfers, pn = Ve[gt].eliminated, ze = Ve[gt].elected;
-        if (!Ut) {
-          if (pn)
-            pn === w && se.push(`${we} will be eliminated on round ${ue}.`);
-          else if (w === ze && (se.push(`${we} ${$(_).event} on round ${ue}.`), Rn))
-            for (let [ot, _t] of Object.entries(Rn))
-              se.push(`${_t} ${le(Number(_t), ue < Y)} transferred to ${ot} on round ${ue}.`);
+  function Se(w, G) {
+    const oe = [], he = w === "exhausted" ? Y() : w;
+    let ge;
+    w === "exhausted" ? ge = Tt(1) : ge = A(B).results[0].tally[w], oe.push(`${he} started with ${ge} votes.`);
+    for (let le = 1; le <= G; le++) {
+      le === G && (w === "exhausted" ? ge = Tt(G) : ge = A(B).results[G - 1].tally[w], oe.push(`${he} has ${ge} votes at round ${G}.`));
+      const De = A(B).results[le - 1].tallyResults, Gt = ye(le);
+      for (let St = 0; St < De.length; St++) {
+        const Cn = De[St].transfers, Kt = De[St].eliminated, qe = De[St].elected;
+        if (!Gt) {
+          if (Kt)
+            Kt === w && oe.push(`${he} will be eliminated on round ${le}.`);
+          else if (w === qe && (oe.push(`${he} ${A(_).event} on round ${le}.`), Cn))
+            for (let [ot, vn] of Object.entries(Cn))
+              oe.push(`${vn} ${z(Number(vn), le < G)} transferred to ${ot} on round ${le}.`);
         }
-        const kt = pn || ze;
-        if (kt) {
-          const ot = Number(Rn[w]);
-          ot && se.push(`${ot} ${le(ot, ue < Y)} transferred from ${kt} on round ${ue}.`);
+        const Ct = Kt || qe;
+        if (Ct) {
+          const ot = Number(Cn[w]);
+          ot && oe.push(`${ot} ${z(ot, le < G)} transferred from ${Ct} on round ${le}.`);
         }
       }
     }
-    return [se, we];
+    return [oe, he];
   }
-  function H() {
+  function Ge() {
     let w = 0;
-    for (let Y = 1; Y <= $(I).results.length; Y++) {
-      if (de(Y)) continue;
-      const se = $(I).results[Y - 1].tallyResults;
-      for (let we = 0; we < se.length; we++)
-        se[we].elected && w++;
+    for (let G = 1; G <= A(B).results.length; G++) {
+      if (ye(G)) continue;
+      const oe = A(B).results[G - 1].tallyResults;
+      for (let he = 0; he < oe.length; he++)
+        oe[he].elected && w++;
     }
     return w;
   }
-  let te, je = /* @__PURE__ */ $e(0);
-  function qe(w) {
-    var ye;
-    return !((ye = $(I)) != null && ye.results) || w < 1 || w > $(I).results.length ? ["Eliminate", "Transfer", "Consolidate"] : [$(I).results[w - 1].tallyResults.some((ue) => ue.eliminated) ? "Eliminate" : "Surplus", "Transfer", "Consolidate"];
+  let se, Pe = /* @__PURE__ */ xe(0);
+  function me(w) {
+    var ge;
+    return !((ge = A(B)) != null && ge.results) || w < 1 || w > A(B).results.length ? ["Eliminate", "Transfer", "Consolidate"] : [A(B).results[w - 1].tallyResults.some((le) => le.eliminated) ? "Eliminate" : "Surplus", "Transfer", "Consolidate"];
   }
-  function de(w) {
-    return u() && $(I).results && w === $(I).results.length;
-  }
-  function ce(w) {
-    return de(w) ? [] : te ? te.getEliminatedCandidates(w) : [];
-  }
-  function _e(w) {
-    return de(w) ? [] : te ? te.getElectedCandidates(w) : [];
+  function ye(w) {
+    return u() && A(B).results && w === A(B).results.length;
   }
   function at(w) {
-    return te ? te.countExhaustedVotes(w) : 0;
+    return ye(w) ? [] : se ? se.getEliminatedCandidates(w) : [];
   }
-  function G() {
-    te && te.animateOnePhaseFn && te.animateOnePhaseFn();
+  function Ce(w) {
+    return ye(w) ? [] : se ? se.getElectedCandidates(w) : [];
   }
-  function Pe() {
-    return te ? te.exhaustedLabel : "";
+  function Tt(w) {
+    return se ? se.countExhaustedVotes(w) : 0;
   }
-  function St() {
-    return te ? te.pieColors : {};
+  function Rt() {
+    se && se.animateOnePhaseFn && se.animateOnePhaseFn();
   }
-  var Z = {
+  function Y() {
+    return se ? se.exhaustedLabel : "";
+  }
+  function Me() {
+    return se ? se.pieColors : {};
+  }
+  var Xt = {
     get electionSummary() {
       return r();
     },
     set electionSummary(w) {
-      r(w), ne();
+      r(w), j();
     },
     get currentRound() {
       return i();
     },
     set currentRound(w = 1) {
-      i(w), ne();
+      i(w), j();
     },
     get requestRoundChange() {
       return s();
     },
-    set requestRoundChange(w = (Y) => {
+    set requestRoundChange(w = (G) => {
     }) {
-      s(w), ne();
+      s(w), j();
     },
     get requestSkipToRound() {
       return a();
     },
-    set requestSkipToRound(w = (Y) => {
+    set requestSkipToRound(w = (G) => {
     }) {
-      a(w), ne();
+      a(w), j();
     },
     get candidateColors() {
       return o();
     },
     set candidateColors(w = []) {
-      o(w), ne();
+      o(w), j();
     },
     get textForWinner() {
       return l();
     },
-    set textForWinner(w = "elected") {
-      l(w), ne();
+    set textForWinner(w = "won") {
+      l(w), j();
     },
     get excludeFinalWinnerAndEliminatedCandidate() {
       return u();
     },
     set excludeFinalWinnerAndEliminatedCandidate(w = !1) {
-      u(w), ne();
+      u(w), j();
     },
     get firstRoundDeterminesPercentages() {
       return f();
     },
     set firstRoundDeterminesPercentages(w = !1) {
-      f(w), ne();
+      f(w), j();
     },
-    get randomizeOrder() {
+    get showVotes() {
       return d();
     },
-    set randomizeOrder(w = !1) {
-      d(w), ne();
+    set showVotes(w = !0) {
+      d(w), j();
     },
-    get showCaptions() {
+    get showPercent() {
       return h();
     },
+    set showPercent(w = !0) {
+      h(w), j();
+    },
+    get randomizeOrder() {
+      return p();
+    },
+    set randomizeOrder(w = !1) {
+      p(w), j();
+    },
+    get showCaptions() {
+      return y();
+    },
     set showCaptions(w = !1) {
-      h(w), ne();
+      y(w), j();
     }
-  }, hn = pp(), Ct = gn(hn), dn = Be(Ct);
+  }, ae = wp(), Wt = mn(ae), Rn = He(Wt);
   {
-    let w = /* @__PURE__ */ Sn(() => qe(i()));
-    bl(dn, {
+    let w = /* @__PURE__ */ Nn(() => me(i()));
+    Tl(Rn, {
       get labels() {
-        return $(w);
+        return A(w);
       },
       get currentStep() {
-        return $(je);
+        return A(Pe);
       },
       disabled: !1,
-      onAdvance: G
+      onAdvance: Rt
     });
   }
-  Oe(Ct);
-  var Wt = Ze(Ct, 4), vt = Be(Wt), En = Be(vt), Je = Be(En);
-  pi(
-    xl(Je, {
+  Oe(Wt);
+  var Ut = Ze(Wt, 4), Tr = He(Ut), Sn = He(Tr), Ji = He(Sn);
+  _i(
+    El(Ji, {
       get jsonData() {
-        return $(I);
+        return A(B);
       },
       get currentRound() {
         return i();
@@ -5920,134 +5969,140 @@ function gp(e, t) {
       get firstRoundDeterminesPercentages() {
         return f();
       },
-      get randomizeOrder() {
+      get showVotes() {
         return d();
       },
+      get showPercent() {
+        return h();
+      },
+      get randomizeOrder() {
+        return p();
+      },
       get mouseEventType() {
-        return $(N);
+        return A(I);
       },
       set mouseEventType(w) {
-        ve(N, w, !0);
+        pe(I, w, !0);
       },
       get mouseData() {
-        return $(M);
+        return A(K);
       },
       set mouseData(w) {
-        ve(M, w, !0);
+        pe(K, w, !0);
       },
       get mouseX() {
-        return $(F);
+        return A(V);
       },
       set mouseX(w) {
-        ve(F, w, !0);
+        pe(V, w, !0);
       },
       get mouseY() {
-        return $(W);
+        return A(Q);
       },
       set mouseY(w) {
-        ve(W, w, !0);
+        pe(Q, w, !0);
       },
       get displayPhase() {
-        return $(je);
+        return A(Pe);
       },
       set displayPhase(w) {
-        ve(je, w, !0);
+        pe(Pe, w, !0);
       }
     }),
-    (w) => te = w,
-    () => te
-  ), Oe(En), Oe(vt);
-  var $r = Ze(vt, 2);
+    (w) => se = w,
+    () => se
+  ), Oe(Sn), Oe(Tr);
+  var Ke = Ze(Tr, 2);
   {
-    var Ar = (w) => {
-      var Y = hp(), se = gn(Y), we = Be(se);
-      Oe(se);
-      var ye = Ze(se, 2), ue = Be(ye);
+    var Rr = (w) => {
+      var G = mp(), oe = mn(G), he = He(oe);
+      Oe(oe);
+      var ge = Ze(oe, 2), le = He(ge);
       {
-        var Ve = (ze) => {
-          var kt = up(), ot = Ze(gn(kt));
-          di(ot, 17, () => ce(i()), hi, (_t, Mt, mt) => {
-            var xe = lp(), De = gn(xe);
-            let Ee;
-            var Gt = Be(De, !0);
-            Oe(De);
-            var Zn = Ze(De, 2);
+        var De = (qe) => {
+          var Ct = vp(), ot = Ze(mn(Ct));
+          gi(ot, 17, () => at(i()), vi, (vn, tr, jt) => {
+            var Nt = pp(), Ve = mn(Nt);
+            let ce;
+            var lt = He(Ve, !0);
+            Oe(Ve);
+            var je = Ze(Ve, 2);
             {
-              var Er = (oe) => {
-                var Kt = _a(", ");
-                We(oe, Kt);
-              }, Qn = /* @__PURE__ */ Sn(() => mt < ce(i()).length - 1);
-              tr(Zn, (oe) => {
-                $(Qn) && oe(Er);
+              var gn = (Jt) => {
+                var kt = xa(", ");
+                Be(Jt, kt);
+              }, nr = /* @__PURE__ */ Nn(() => jt < at(i()).length - 1);
+              ir(je, (Jt) => {
+                A(nr) && Jt(gn);
               });
             }
-            Zt(
-              (oe) => {
-                Ee = xa(De, "", Ee, oe), _n(Gt, $(Mt));
+            en(
+              (Jt) => {
+                ce = Ea(Ve, "", ce, Jt), yn(lt, A(tr));
               },
-              [() => ({ color: St()[$(Mt)] })]
-            ), We(_t, xe);
-          }), We(ze, kt);
-        }, Ut = /* @__PURE__ */ Sn(() => ce(i()).length > 0);
-        tr(ue, (ze) => {
-          $(Ut) && ze(Ve);
+              [() => ({ color: Me()[A(tr)] })]
+            ), Be(vn, Nt);
+          }), Be(qe, Ct);
+        }, Gt = /* @__PURE__ */ Nn(() => at(i()).length > 0);
+        ir(le, (qe) => {
+          A(Gt) && qe(De);
         });
       }
-      var gt = Ze(ue, 2);
+      var St = Ze(le, 2);
       {
-        var Rn = (ze) => {
-          var kt = cp(), ot = gn(kt), _t = Ze(ot);
-          di(_t, 17, () => _e(i()), hi, (Mt, mt, xe) => {
-            var De = fp(), Ee = gn(De);
-            let Gt;
-            var Zn = Be(Ee, !0);
-            Oe(Ee);
-            var Er = Ze(Ee, 2);
+        var Cn = (qe) => {
+          var Ct = _p(), ot = mn(Ct), vn = Ze(ot);
+          gi(vn, 17, () => Ce(i()), vi, (tr, jt, Nt) => {
+            var Ve = gp(), ce = mn(Ve);
+            let lt;
+            var je = He(ce, !0);
+            Oe(ce);
+            var gn = Ze(ce, 2);
             {
-              var Qn = (Kt) => {
-                var ji = _a(", ");
-                We(Kt, ji);
-              }, oe = /* @__PURE__ */ Sn(() => xe < _e(i()).length - 1);
-              tr(Er, (Kt) => {
-                $(oe) && Kt(Qn);
+              var nr = (kt) => {
+                var es = xa(", ");
+                Be(kt, es);
+              }, Jt = /* @__PURE__ */ Nn(() => Nt < Ce(i()).length - 1);
+              ir(gn, (kt) => {
+                A(Jt) && kt(nr);
               });
             }
-            Zt(
-              (Kt) => {
-                Gt = xa(Ee, "", Gt, Kt), _n(Zn, $(mt));
+            en(
+              (kt) => {
+                lt = Ea(ce, "", lt, kt), yn(je, A(jt));
               },
-              [() => ({ color: St()[$(mt)] })]
-            ), We(Mt, De);
-          }), Zt(() => _n(ot, `${$(_).caption ?? ""}: `)), We(ze, kt);
-        }, pn = /* @__PURE__ */ Sn(() => _e(i()).length > 0);
-        tr(gt, (ze) => {
-          $(pn) && ze(Rn);
+              [() => ({ color: Me()[A(jt)] })]
+            ), Be(tr, Ve);
+          }), en(() => yn(ot, `${A(_).caption ?? ""}: `)), Be(qe, Ct);
+        }, Kt = /* @__PURE__ */ Nn(() => Ce(i()).length > 0);
+        ir(St, (qe) => {
+          A(Kt) && qe(Cn);
         });
       }
-      Oe(ye), Zt((ze) => _n(we, `${$(I).config.contest ?? ""}, ${ze ?? ""} ${$(_).infinitive ?? ""}, Round ${i() ?? ""}.`), [H]), We(w, Y);
+      Oe(ge), en((qe) => yn(he, `${A(B).config.contest ?? ""}, ${qe ?? ""} ${A(_).infinitive ?? ""}, Round ${i() ?? ""}.`), [Ge]), Be(w, G);
     };
-    tr($r, (w) => {
-      h() && w(Ar);
+    ir(Ke, (w) => {
+      y() && w(Rr);
     });
   }
-  Oe(Wt);
-  var Tn = Ze(Wt, 2), Jn = Be(Tn), Zr = Be(Jn, !0);
-  Oe(Jn);
-  var Gi = Ze(Jn, 2);
-  di(Gi, 17, () => $(O), hi, (w, Y) => {
-    var se = dp(), we = gn(se), ye = Be(we, !0);
-    Oe(we), us(2), Zt(() => _n(ye, $(Y))), We(w, se);
-  }), Oe(Tn), pi(Tn, (w) => ve(x, w), () => $(x));
-  var Nt = Ze(Tn, 2), Ki = Be(Nt);
-  return us(2), Oe(Nt), pi(Nt, (w) => ve(y, w), () => $(y)), Zt(
+  Oe(Ut);
+  var pn = Ze(Ut, 2), Qn = He(pn), Zi = He(Qn, !0);
+  Oe(Qn);
+  var ti = Ze(Qn, 2);
+  gi(ti, 17, () => A(O), vi, (w, G) => {
+    var oe = yp(), he = mn(oe), ge = He(he, !0);
+    Oe(he), ps(2), en(() => yn(ge, A(G))), Be(w, oe);
+  }), Oe(pn), _i(pn, (w) => pe(x, w), () => A(x));
+  var er = Ze(pn, 2), Qi = He(er);
+  return ps(2), Oe(er), _i(er, (w) => pe(D, w), () => A(D)), en(
     (w) => {
-      _n(Zr, $(b)), _n(Ki, `"${w ?? ""}" means all the candidates ranked on `);
+      yn(Zi, A(N)), yn(Qi, `"${w ?? ""}" means all the candidates ranked on `);
     },
-    [Pe]
-  ), We(e, hn), Vi(Z);
+    [Y]
+  ), Be(e, ae), Bi(Xt);
 }
-customElements.define("pie-chart", Ys(
-  gp,
+customElements.define("pie-chart", Us(
+  bp,
   {
     electionSummary: {},
     currentRound: {},
@@ -6057,6 +6112,8 @@ customElements.define("pie-chart", Ys(
     textForWinner: {},
     excludeFinalWinnerAndEliminatedCandidate: {},
     firstRoundDeterminesPercentages: {},
+    showVotes: {},
+    showPercent: {},
     randomizeOrder: {},
     showCaptions: {}
   },

--- a/static/pie/pie-chart.es.js
+++ b/static/pie/pie-chart.es.js
@@ -1,17 +1,17 @@
-var Ul = Object.defineProperty;
+var Gl = Object.defineProperty;
 var ha = (e) => {
   throw TypeError(e);
 };
-var Gl = (e, t, n) => t in e ? Ul(e, t, { enumerable: !0, configurable: !0, writable: !0, value: n }) : e[t] = n;
-var de = (e, t, n) => Gl(e, typeof t != "symbol" ? t + "" : t, n), ss = (e, t, n) => t.has(e) || ha("Cannot " + n);
+var Kl = (e, t, n) => t in e ? Gl(e, t, { enumerable: !0, configurable: !0, writable: !0, value: n }) : e[t] = n;
+var he = (e, t, n) => Kl(e, typeof t != "symbol" ? t + "" : t, n), ss = (e, t, n) => t.has(e) || ha("Cannot " + n);
 var g = (e, t, n) => (ss(e, t, "read from private field"), n ? n.call(e) : t.get(e)), H = (e, t, n) => t.has(e) ? ha("Cannot add the same private member more than once") : t instanceof WeakSet ? t.add(e) : t.set(e, n), L = (e, t, n, r) => (ss(e, t, "write to private field"), r ? r.call(e, n) : t.set(e, n), n), we = (e, t, n) => (ss(e, t, "access private method"), n);
 var Wa;
 typeof window < "u" && ((Wa = window.__svelte ?? (window.__svelte = {})).v ?? (Wa.v = /* @__PURE__ */ new Set())).add("5");
-const Kl = 1, jl = 2, ja = 4, Jl = 8, Zl = 16, Ql = 1, eu = 4, tu = 8, nu = 16, ru = 1, iu = 2, Os = "[", Li = "[!", Is = "]", pr = {}, Ae = Symbol(), Ja = "http://www.w3.org/1999/xhtml", hs = !1;
-var Za = Array.isArray, su = Array.prototype.indexOf, vr = Array.prototype.includes, qi = Array.from, Ai = Object.keys, Ei = Object.defineProperty, Bn = Object.getOwnPropertyDescriptor, au = Object.getOwnPropertyDescriptors, ou = Object.prototype, lu = Array.prototype, Qa = Object.getPrototypeOf, da = Object.isExtensible;
-const uu = () => {
+const jl = 1, Jl = 2, ja = 4, Zl = 8, Ql = 16, eu = 1, tu = 4, nu = 8, ru = 16, iu = 1, su = 2, Os = "[", qi = "[!", Is = "]", pr = {}, Ae = Symbol(), Ja = "http://www.w3.org/1999/xhtml", hs = !1;
+var Za = Array.isArray, au = Array.prototype.indexOf, vr = Array.prototype.includes, Vi = Array.from, Ei = Object.keys, Ti = Object.defineProperty, Bn = Object.getOwnPropertyDescriptor, ou = Object.getOwnPropertyDescriptors, lu = Object.prototype, uu = Array.prototype, Qa = Object.getPrototypeOf, da = Object.isExtensible;
+const fu = () => {
 };
-function fu(e) {
+function cu(e) {
   for (var t = 0; t < e.length; t++)
     e[t]();
 }
@@ -21,7 +21,7 @@ function eo() {
   });
   return { promise: n, resolve: e, reject: t };
 }
-function cu(e, t) {
+function hu(e, t) {
   if (Array.isArray(e))
     return e;
   if (!(Symbol.iterator in e))
@@ -31,90 +31,90 @@ function cu(e, t) {
     if (n.push(r), n.length === t) break;
   return n;
 }
-const Te = 2, Vr = 4, Vi = 8, to = 1 << 24, dn = 16, At = 32, Tn = 64, no = 128, pt = 512, be = 1024, Re = 2048, $t = 4096, nt = 8192, un = 16384, $r = 32768, gr = 65536, pa = 1 << 17, ro = 1 << 18, Zn = 1 << 19, hu = 1 << 20, on = 1 << 25, Gn = 65536, ds = 1 << 21, Fs = 1 << 22, xn = 1 << 23, Fr = Symbol("$state"), io = Symbol("legacy props"), du = Symbol(""), Mn = new class extends Error {
+const Te = 2, Vr = 4, zi = 8, to = 1 << 24, hn = 16, Et = 32, Tn = 64, no = 128, pt = 512, be = 1024, Re = 2048, At = 4096, rt = 8192, ln = 16384, $r = 32768, gr = 65536, pa = 1 << 17, ro = 1 << 18, Zn = 1 << 19, du = 1 << 20, an = 1 << 25, Gn = 65536, ds = 1 << 21, Fs = 1 << 22, xn = 1 << 23, Fr = Symbol("$state"), io = Symbol("legacy props"), pu = Symbol(""), Mn = new class extends Error {
   constructor() {
     super(...arguments);
-    de(this, "name", "StaleReactionError");
-    de(this, "message", "The reaction that called `getAbortSignal()` was re-run or destroyed");
+    he(this, "name", "StaleReactionError");
+    he(this, "message", "The reaction that called `getAbortSignal()` was re-run or destroyed");
   }
 }();
 var Ua;
-const pu = ((Ua = globalThis.document) == null ? void 0 : /* @__PURE__ */ Ua.contentType.includes("xml")) ?? !1, Jr = 3, Ar = 8;
-function vu(e) {
+const vu = ((Ua = globalThis.document) == null ? void 0 : /* @__PURE__ */ Ua.contentType.includes("xml")) ?? !1, Jr = 3, Ar = 8;
+function gu(e) {
   throw new Error("https://svelte.dev/e/lifecycle_outside_component");
 }
-function gu() {
+function _u() {
   throw new Error("https://svelte.dev/e/async_derived_orphan");
 }
-function _u(e, t, n) {
+function mu(e, t, n) {
   throw new Error("https://svelte.dev/e/each_key_duplicate");
 }
-function mu(e) {
+function yu(e) {
   throw new Error("https://svelte.dev/e/effect_in_teardown");
 }
-function yu() {
+function wu() {
   throw new Error("https://svelte.dev/e/effect_in_unowned_derived");
 }
-function wu(e) {
+function xu(e) {
   throw new Error("https://svelte.dev/e/effect_orphan");
 }
-function xu() {
+function bu() {
   throw new Error("https://svelte.dev/e/effect_update_depth_exceeded");
 }
-function bu() {
+function $u() {
   throw new Error("https://svelte.dev/e/hydration_failed");
 }
-function $u(e) {
+function Au(e) {
   throw new Error("https://svelte.dev/e/props_invalid_value");
 }
-function Au() {
+function Eu() {
   throw new Error("https://svelte.dev/e/state_descriptors_fixed");
 }
-function Eu() {
+function Tu() {
   throw new Error("https://svelte.dev/e/state_prototype_fixed");
 }
-function Tu() {
+function Ru() {
   throw new Error("https://svelte.dev/e/state_unsafe_mutation");
 }
-function Ru() {
+function Su() {
   throw new Error("https://svelte.dev/e/svelte_boundary_reset_onerror");
 }
-function zi(e) {
+function Hi(e) {
   console.warn("https://svelte.dev/e/hydration_mismatch");
 }
-function Su() {
+function Cu() {
   console.warn("https://svelte.dev/e/svelte_boundary_reset_noop");
 }
 let Z = !1;
-function ln(e) {
+function on(e) {
   Z = e;
 }
-let W;
+let U;
 function Fe(e) {
   if (e === null)
-    throw zi(), pr;
-  return W = e;
+    throw Hi(), pr;
+  return U = e;
 }
-function Hi() {
-  return Fe(/* @__PURE__ */ zt(W));
+function Yi() {
+  return Fe(/* @__PURE__ */ Ht(U));
 }
 function Oe(e) {
   if (Z) {
-    if (/* @__PURE__ */ zt(W) !== null)
-      throw zi(), pr;
-    W = e;
+    if (/* @__PURE__ */ Ht(U) !== null)
+      throw Hi(), pr;
+    U = e;
   }
 }
 function ps(e = 1) {
   if (Z) {
-    for (var t = e, n = W; t--; )
+    for (var t = e, n = U; t--; )
       n = /** @type {TemplateNode} */
-      /* @__PURE__ */ zt(n);
-    W = n;
+      /* @__PURE__ */ Ht(n);
+    U = n;
   }
 }
-function Ti(e = !0) {
-  for (var t = 0, n = W; ; ) {
+function Ri(e = !0) {
+  for (var t = 0, n = U; ; ) {
     if (n.nodeType === Ar) {
       var r = (
         /** @type {Comment} */
@@ -123,19 +123,19 @@ function Ti(e = !0) {
       if (r === Is) {
         if (t === 0) return n;
         t -= 1;
-      } else (r === Os || r === Li || // "[1", "[2", etc. for if blocks
+      } else (r === Os || r === qi || // "[1", "[2", etc. for if blocks
       r[0] === "[" && !isNaN(Number(r.slice(1)))) && (t += 1);
     }
     var i = (
       /** @type {TemplateNode} */
-      /* @__PURE__ */ zt(n)
+      /* @__PURE__ */ Ht(n)
     );
     e && n.remove(), n = i;
   }
 }
 function so(e) {
   if (!e || e.nodeType !== Ar)
-    throw zi(), pr;
+    throw Hi(), pr;
   return (
     /** @type {Comment} */
     e.data
@@ -144,19 +144,19 @@ function so(e) {
 function ao(e) {
   return e === this.v;
 }
-function Cu(e, t) {
+function Nu(e, t) {
   return e != e ? t == t : e !== t || e !== null && typeof e == "object" || typeof e == "function";
 }
 function oo(e) {
-  return !Cu(e, this.v);
+  return !Nu(e, this.v);
 }
-let Nu = !1, it = null;
+let ku = !1, st = null;
 function _r(e) {
-  it = e;
+  st = e;
 }
-function Yi(e, t = !1, n) {
-  it = {
-    p: it,
+function Bi(e, t = !1, n) {
+  st = {
+    p: st,
     i: !1,
     c: null,
     e: null,
@@ -165,17 +165,17 @@ function Yi(e, t = !1, n) {
     l: null
   };
 }
-function Bi(e) {
+function Xi(e) {
   var t = (
     /** @type {ComponentContext} */
-    it
+    st
   ), n = t.e;
   if (n !== null) {
     t.e = null;
     for (var r of n)
       Mo(r);
   }
-  return e !== void 0 && (t.x = e), t.i = !0, it = t.p, e ?? /** @type {T} */
+  return e !== void 0 && (t.x = e), t.i = !0, st = t.p, e ?? /** @type {T} */
   {};
 }
 function lo() {
@@ -184,7 +184,7 @@ function lo() {
 let Dn = [];
 function uo() {
   var e = Dn;
-  Dn = [], fu(e);
+  Dn = [], cu(e);
 }
 function bn(e) {
   if (Dn.length === 0 && !Lr) {
@@ -195,14 +195,14 @@ function bn(e) {
   }
   Dn.push(e);
 }
-function ku() {
+function Pu() {
   for (; Dn.length > 0; )
     uo();
 }
 function fo(e) {
   var t = te;
   if (t === null)
-    return X.f |= xn, e;
+    return W.f |= xn, e;
   if ((t.f & $r) === 0 && (t.f & Vr) === 0)
     throw e;
   mr(e, t);
@@ -223,12 +223,12 @@ function mr(e, t) {
   }
   throw e;
 }
-const Pu = -7169;
-function ve(e, t) {
-  e.f = e.f & Pu | t;
+const Mu = -7169;
+function pe(e, t) {
+  e.f = e.f & Mu | t;
 }
 function Ls(e) {
-  (e.f & pt) !== 0 || e.deps === null ? ve(e, be) : ve(e, $t);
+  (e.f & pt) !== 0 || e.deps === null ? pe(e, be) : pe(e, At);
 }
 function co(e) {
   if (e !== null)
@@ -239,27 +239,27 @@ function co(e) {
       ));
 }
 function ho(e, t, n) {
-  (e.f & Re) !== 0 ? t.add(e) : (e.f & $t) !== 0 && n.add(e), co(e.deps), ve(e, be);
+  (e.f & Re) !== 0 ? t.add(e) : (e.f & At) !== 0 && n.add(e), co(e.deps), pe(e, be);
 }
-const ii = /* @__PURE__ */ new Set();
-let J = null, Ee = null, Xe = [], Xi = null, vs = !1, Lr = !1;
-var or, lr, Ln, ur, Wr, Ur, qn, tn, fr, Vt, gs, _s, po;
+const si = /* @__PURE__ */ new Set();
+let J = null, Ee = null, Xe = [], Wi = null, vs = !1, Lr = !1;
+var or, lr, Ln, ur, Wr, Ur, qn, en, fr, zt, gs, _s, po;
 const ta = class ta {
   constructor() {
-    H(this, Vt);
-    de(this, "committed", !1);
+    H(this, zt);
+    he(this, "committed", !1);
     /**
      * The current values of any sources that are updated in this batch
      * They keys of this map are identical to `this.#previous`
      * @type {Map<Source, any>}
      */
-    de(this, "current", /* @__PURE__ */ new Map());
+    he(this, "current", /* @__PURE__ */ new Map());
     /**
      * The values of any sources that are updated in this batch _before_ those updates took place.
      * They keys of this map are identical to `this.#current`
      * @type {Map<Source, any>}
      */
-    de(this, "previous", /* @__PURE__ */ new Map());
+    he(this, "previous", /* @__PURE__ */ new Map());
     /**
      * When the batch is committed (and the DOM is updated), we need to remove old branches
      * and append new ones by calling the functions added inside (if/each/key/etc) blocks
@@ -302,8 +302,8 @@ const ta = class ta {
      * so they can be rescheduled if the branch survives.
      * @type {Map<Effect, { d: Effect[], m: Effect[] }>}
      */
-    H(this, tn, /* @__PURE__ */ new Map());
-    de(this, "is_fork", !1);
+    H(this, en, /* @__PURE__ */ new Map());
+    he(this, "is_fork", !1);
     H(this, fr, !1);
   }
   is_deferred() {
@@ -314,7 +314,7 @@ const ta = class ta {
    * @param {Effect} effect
    */
   skip_effect(t) {
-    g(this, tn).has(t) || g(this, tn).set(t, { d: [], m: [] });
+    g(this, en).has(t) || g(this, en).set(t, { d: [], m: [] });
   }
   /**
    * Remove an effect from the #skipped_branches map and reschedule
@@ -322,13 +322,13 @@ const ta = class ta {
    * @param {Effect} effect
    */
   unskip_effect(t) {
-    var n = g(this, tn).get(t);
+    var n = g(this, en).get(t);
     if (n) {
-      g(this, tn).delete(t);
+      g(this, en).delete(t);
       for (var r of n.d)
-        ve(r, Re), xt(r);
+        pe(r, Re), bt(r);
       for (r of n.m)
-        ve(r, $t), xt(r);
+        pe(r, At), bt(r);
     }
   }
   /**
@@ -340,14 +340,14 @@ const ta = class ta {
     Xe = [], this.apply();
     var n = [], r = [];
     for (const s of t)
-      we(this, Vt, gs).call(this, s, n, r);
+      we(this, zt, gs).call(this, s, n, r);
     if (this.is_deferred()) {
-      we(this, Vt, _s).call(this, r), we(this, Vt, _s).call(this, n);
-      for (const [s, a] of g(this, tn))
+      we(this, zt, _s).call(this, r), we(this, zt, _s).call(this, n);
+      for (const [s, a] of g(this, en))
         mo(s, a);
     } else {
       for (const s of g(this, or)) s();
-      g(this, or).clear(), g(this, Ln) === 0 && we(this, Vt, po).call(this), J = null, va(r), va(n), (i = g(this, Wr)) == null || i.resolve();
+      g(this, or).clear(), g(this, Ln) === 0 && we(this, zt, po).call(this), J = null, va(r), va(n), (i = g(this, Wr)) == null || i.resolve();
     }
     Ee = null;
   }
@@ -395,9 +395,9 @@ const ta = class ta {
   }
   revive() {
     for (const t of g(this, Ur))
-      g(this, qn).delete(t), ve(t, Re), xt(t);
+      g(this, qn).delete(t), pe(t, Re), bt(t);
     for (const t of g(this, qn))
-      ve(t, $t), xt(t);
+      pe(t, At), bt(t);
     this.flush();
   }
   /** @param {() => void} fn */
@@ -414,7 +414,7 @@ const ta = class ta {
   static ensure() {
     if (J === null) {
       const t = J = new ta();
-      ii.add(J), Lr || bn(() => {
+      si.add(J), Lr || bn(() => {
         J === t && t.flush();
       });
     }
@@ -423,7 +423,7 @@ const ta = class ta {
   apply() {
   }
 };
-or = new WeakMap(), lr = new WeakMap(), Ln = new WeakMap(), ur = new WeakMap(), Wr = new WeakMap(), Ur = new WeakMap(), qn = new WeakMap(), tn = new WeakMap(), fr = new WeakMap(), Vt = new WeakSet(), /**
+or = new WeakMap(), lr = new WeakMap(), Ln = new WeakMap(), ur = new WeakMap(), Wr = new WeakMap(), Ur = new WeakMap(), qn = new WeakMap(), en = new WeakMap(), fr = new WeakMap(), zt = new WeakSet(), /**
  * Traverse the effect tree, executing effects or stashing
  * them for later execution as appropriate
  * @param {Effect} root
@@ -433,9 +433,9 @@ or = new WeakMap(), lr = new WeakMap(), Ln = new WeakMap(), ur = new WeakMap(), 
 gs = function(t, n, r) {
   t.f ^= be;
   for (var i = t.first, s = null; i !== null; ) {
-    var a = i.f, o = (a & (At | Tn)) !== 0, l = o && (a & be) !== 0, u = l || (a & nt) !== 0 || g(this, tn).has(i);
+    var a = i.f, o = (a & (Et | Tn)) !== 0, l = o && (a & be) !== 0, u = l || (a & rt) !== 0 || g(this, en).has(i);
     if (!u && i.fn !== null) {
-      o ? i.f ^= be : s !== null && (a & (Vr | Vi | to)) !== 0 ? s.b.defer_effect(i) : (a & Vr) !== 0 ? n.push(i) : Zr(i) && ((a & dn) !== 0 && g(this, qn).add(i), wr(i));
+      o ? i.f ^= be : s !== null && (a & (Vr | zi | to)) !== 0 ? s.b.defer_effect(i) : (a & Vr) !== 0 ? n.push(i) : Zr(i) && ((a & hn) !== 0 && g(this, qn).add(i), wr(i));
       var f = i.first;
       if (f !== null) {
         i = f;
@@ -454,10 +454,10 @@ _s = function(t) {
     ho(t[n], g(this, Ur), g(this, qn));
 }, po = function() {
   var i;
-  if (ii.size > 1) {
+  if (si.size > 1) {
     this.previous.clear();
     var t = Ee, n = !0;
-    for (const s of ii) {
+    for (const s of si) {
       if (s === this) {
         n = !1;
         continue;
@@ -483,7 +483,7 @@ _s = function(t) {
         if (Xe.length > 0) {
           J = s, s.apply();
           for (const f of Xe)
-            we(i = s, Vt, gs).call(i, f, [], []);
+            we(i = s, zt, gs).call(i, f, [], []);
           s.deactivate();
         }
         Xe = r;
@@ -491,16 +491,16 @@ _s = function(t) {
     }
     J = null, Ee = t;
   }
-  this.committed = !0, ii.delete(this);
+  this.committed = !0, si.delete(this);
 };
-let fn = ta;
+let un = ta;
 function j(e) {
   var t = Lr;
   Lr = !0;
   try {
     for (var n; ; ) {
-      if (ku(), Xe.length === 0 && (J == null || J.flush(), Xe.length === 0))
-        return Xi = null, /** @type {T} */
+      if (Pu(), Xe.length === 0 && (J == null || J.flush(), Xe.length === 0))
+        return Wi = null, /** @type {T} */
         n;
       vo();
     }
@@ -513,47 +513,47 @@ function vo() {
   var e = null;
   try {
     for (var t = 0; Xe.length > 0; ) {
-      var n = fn.ensure();
+      var n = un.ensure();
       if (t++ > 1e3) {
         var r, i;
-        Mu();
+        Du();
       }
       n.process(Xe), $n.clear();
     }
   } finally {
-    Xe = [], vs = !1, Xi = null;
+    Xe = [], vs = !1, Wi = null;
   }
 }
-function Mu() {
+function Du() {
   try {
-    xu();
+    bu();
   } catch (e) {
-    mr(e, Xi);
+    mr(e, Wi);
   }
 }
-let mt = null;
+let yt = null;
 function va(e) {
   var t = e.length;
   if (t !== 0) {
     for (var n = 0; n < t; ) {
       var r = e[n++];
-      if ((r.f & (un | nt)) === 0 && Zr(r) && (mt = /* @__PURE__ */ new Set(), wr(r), r.deps === null && r.first === null && r.nodes === null && r.teardown === null && r.ac === null && Io(r), (mt == null ? void 0 : mt.size) > 0)) {
+      if ((r.f & (ln | rt)) === 0 && Zr(r) && (yt = /* @__PURE__ */ new Set(), wr(r), r.deps === null && r.first === null && r.nodes === null && r.teardown === null && r.ac === null && Io(r), (yt == null ? void 0 : yt.size) > 0)) {
         $n.clear();
-        for (const i of mt) {
-          if ((i.f & (un | nt)) !== 0) continue;
+        for (const i of yt) {
+          if ((i.f & (ln | rt)) !== 0) continue;
           const s = [i];
           let a = i.parent;
           for (; a !== null; )
-            mt.has(a) && (mt.delete(a), s.push(a)), a = a.parent;
+            yt.has(a) && (yt.delete(a), s.push(a)), a = a.parent;
           for (let o = s.length - 1; o >= 0; o--) {
             const l = s[o];
-            (l.f & (un | nt)) === 0 && wr(l);
+            (l.f & (ln | rt)) === 0 && wr(l);
           }
         }
-        mt.clear();
+        yt.clear();
       }
     }
-    mt = null;
+    yt = null;
   }
 }
 function go(e, t, n, r) {
@@ -566,7 +566,7 @@ function go(e, t, n, r) {
         t,
         n,
         r
-      ) : (s & (Fs | dn)) !== 0 && (s & Re) === 0 && _o(i, t, r) && (ve(i, Re), xt(
+      ) : (s & (Fs | hn)) !== 0 && (s & Re) === 0 && _o(i, t, r) && (pe(i, Re), bt(
         /** @type {Effect} */
         i
       ));
@@ -593,13 +593,13 @@ function _o(e, t, n) {
     }
   return n.set(e, !1), !1;
 }
-function xt(e) {
-  for (var t = Xi = e; t.parent !== null; ) {
+function bt(e) {
+  for (var t = Wi = e; t.parent !== null; ) {
     t = t.parent;
     var n = t.f;
-    if (vs && t === te && (n & dn) !== 0 && (n & ro) === 0)
+    if (vs && t === te && (n & hn) !== 0 && (n & ro) === 0)
       return;
-    if ((n & (Tn | At)) !== 0) {
+    if ((n & (Tn | Et)) !== 0) {
       if ((n & be) === 0) return;
       t.f ^= be;
     }
@@ -607,13 +607,13 @@ function xt(e) {
   Xe.push(t);
 }
 function mo(e, t) {
-  if (!((e.f & At) !== 0 && (e.f & be) !== 0)) {
-    (e.f & Re) !== 0 ? t.d.push(e) : (e.f & $t) !== 0 && t.m.push(e), ve(e, be);
+  if (!((e.f & Et) !== 0 && (e.f & be) !== 0)) {
+    (e.f & Re) !== 0 ? t.d.push(e) : (e.f & At) !== 0 && t.m.push(e), pe(e, be);
     for (var n = e.first; n !== null; )
       mo(n, t), n = n.next;
   }
 }
-function Du(e) {
+function Ou(e) {
   let t = 0, n = Kn(0), r;
   return () => {
     zs() && (A(n), Hs(() => (t === 0 && (r = Qr(() => e(() => qr(n)))), t += 1, () => {
@@ -623,44 +623,44 @@ function Du(e) {
     })));
   };
 }
-var Ou = gr | Zn | no;
-function Iu(e, t, n) {
-  new Fu(e, t, n);
+var Iu = gr | Zn | no;
+function Fu(e, t, n) {
+  new Lu(e, t, n);
 }
-var et, Gr, Mt, Vn, Dt, ct, Ye, Ot, nn, wn, zn, rn, cr, Hn, hr, dr, sn, Ii, _e, yo, wo, ms, hi, di, ys;
-class Fu {
+var tt, Gr, Dt, Vn, Ot, ct, Ye, It, tn, wn, zn, nn, cr, Hn, hr, dr, rn, Fi, ve, yo, wo, ms, di, pi, ys;
+class Lu {
   /**
    * @param {TemplateNode} node
    * @param {BoundaryProps} props
    * @param {((anchor: Node) => void)} children
    */
   constructor(t, n, r) {
-    H(this, _e);
+    H(this, ve);
     /** @type {Boundary | null} */
-    de(this, "parent");
-    de(this, "is_pending", !1);
+    he(this, "parent");
+    he(this, "is_pending", !1);
     /** @type {TemplateNode} */
-    H(this, et);
+    H(this, tt);
     /** @type {TemplateNode | null} */
-    H(this, Gr, Z ? W : null);
+    H(this, Gr, Z ? U : null);
     /** @type {BoundaryProps} */
-    H(this, Mt);
+    H(this, Dt);
     /** @type {((anchor: Node) => void)} */
     H(this, Vn);
     /** @type {Effect} */
-    H(this, Dt);
+    H(this, Ot);
     /** @type {Effect | null} */
     H(this, ct, null);
     /** @type {Effect | null} */
     H(this, Ye, null);
     /** @type {Effect | null} */
-    H(this, Ot, null);
+    H(this, It, null);
     /** @type {DocumentFragment | null} */
-    H(this, nn, null);
+    H(this, tn, null);
     /** @type {TemplateNode | null} */
     H(this, wn, null);
     H(this, zn, 0);
-    H(this, rn, 0);
+    H(this, nn, 0);
     H(this, cr, !1);
     H(this, Hn, !1);
     /** @type {Set<Effect>} */
@@ -674,31 +674,31 @@ class Fu {
      * calls followed by no-op flushes
      * @type {Source<number> | null}
      */
-    H(this, sn, null);
-    H(this, Ii, Du(() => (L(this, sn, Kn(g(this, zn))), () => {
-      L(this, sn, null);
+    H(this, rn, null);
+    H(this, Fi, Ou(() => (L(this, rn, Kn(g(this, zn))), () => {
+      L(this, rn, null);
     })));
-    L(this, et, t), L(this, Mt, n), L(this, Vn, r), this.parent = /** @type {Effect} */
-    te.b, this.is_pending = !!g(this, Mt).pending, L(this, Dt, Ys(() => {
+    L(this, tt, t), L(this, Dt, n), L(this, Vn, r), this.parent = /** @type {Effect} */
+    te.b, this.is_pending = !!g(this, Dt).pending, L(this, Ot, Ys(() => {
       if (te.b = this, Z) {
         const s = g(this, Gr);
-        Hi(), /** @type {Comment} */
+        Yi(), /** @type {Comment} */
         s.nodeType === Ar && /** @type {Comment} */
-        s.data === Li ? we(this, _e, wo).call(this) : (we(this, _e, yo).call(this), g(this, rn) === 0 && (this.is_pending = !1));
+        s.data === qi ? we(this, ve, wo).call(this) : (we(this, ve, yo).call(this), g(this, nn) === 0 && (this.is_pending = !1));
       } else {
-        var i = we(this, _e, ms).call(this);
+        var i = we(this, ve, ms).call(this);
         try {
           L(this, ct, dt(() => r(i)));
         } catch (s) {
           this.error(s);
         }
-        g(this, rn) > 0 ? we(this, _e, di).call(this) : this.is_pending = !1;
+        g(this, nn) > 0 ? we(this, ve, pi).call(this) : this.is_pending = !1;
       }
       return () => {
         var s;
         (s = g(this, wn)) == null || s.remove();
       };
-    }, Ou)), Z && L(this, et, W);
+    }, Iu)), Z && L(this, tt, U);
   }
   /**
    * Defer an effect inside a pending boundary until the boundary resolves
@@ -715,7 +715,7 @@ class Fu {
     return !this.is_pending && (!this.parent || this.parent.is_rendered());
   }
   has_pending_snippet() {
-    return !!g(this, Mt).pending;
+    return !!g(this, Dt).pending;
   }
   /**
    * Update the source that powers `$effect.pending()` inside this boundary,
@@ -724,48 +724,48 @@ class Fu {
    * @param {1 | -1} d
    */
   update_pending_count(t) {
-    we(this, _e, ys).call(this, t), L(this, zn, g(this, zn) + t), !(!g(this, sn) || g(this, cr)) && (L(this, cr, !0), bn(() => {
-      L(this, cr, !1), g(this, sn) && yr(g(this, sn), g(this, zn));
+    we(this, ve, ys).call(this, t), L(this, zn, g(this, zn) + t), !(!g(this, rn) || g(this, cr)) && (L(this, cr, !0), bn(() => {
+      L(this, cr, !1), g(this, rn) && yr(g(this, rn), g(this, zn));
     }));
   }
   get_effect_pending() {
-    return g(this, Ii).call(this), A(
+    return g(this, Fi).call(this), A(
       /** @type {Source<number>} */
-      g(this, sn)
+      g(this, rn)
     );
   }
   /** @param {unknown} error */
   error(t) {
-    var n = g(this, Mt).onerror;
-    let r = g(this, Mt).failed;
+    var n = g(this, Dt).onerror;
+    let r = g(this, Dt).failed;
     if (g(this, Hn) || !n && !r)
       throw t;
-    g(this, ct) && (Le(g(this, ct)), L(this, ct, null)), g(this, Ye) && (Le(g(this, Ye)), L(this, Ye, null)), g(this, Ot) && (Le(g(this, Ot)), L(this, Ot, null)), Z && (Fe(
+    g(this, ct) && (Le(g(this, ct)), L(this, ct, null)), g(this, Ye) && (Le(g(this, Ye)), L(this, Ye, null)), g(this, It) && (Le(g(this, It)), L(this, It, null)), Z && (Fe(
       /** @type {TemplateNode} */
       g(this, Gr)
-    ), ps(), Fe(Ti()));
+    ), ps(), Fe(Ri()));
     var i = !1, s = !1;
     const a = () => {
       if (i) {
-        Su();
+        Cu();
         return;
       }
-      i = !0, s && Ru(), fn.ensure(), L(this, zn, 0), g(this, Ot) !== null && Xn(g(this, Ot), () => {
-        L(this, Ot, null);
-      }), this.is_pending = this.has_pending_snippet(), L(this, ct, we(this, _e, hi).call(this, () => (L(this, Hn, !1), dt(() => g(this, Vn).call(this, g(this, et)))))), g(this, rn) > 0 ? we(this, _e, di).call(this) : this.is_pending = !1;
+      i = !0, s && Su(), un.ensure(), L(this, zn, 0), g(this, It) !== null && Xn(g(this, It), () => {
+        L(this, It, null);
+      }), this.is_pending = this.has_pending_snippet(), L(this, ct, we(this, ve, di).call(this, () => (L(this, Hn, !1), dt(() => g(this, Vn).call(this, g(this, tt)))))), g(this, nn) > 0 ? we(this, ve, pi).call(this) : this.is_pending = !1;
     };
     bn(() => {
       try {
         s = !0, n == null || n(t, a), s = !1;
       } catch (o) {
-        mr(o, g(this, Dt) && g(this, Dt).parent);
+        mr(o, g(this, Ot) && g(this, Ot).parent);
       }
-      r && L(this, Ot, we(this, _e, hi).call(this, () => {
-        fn.ensure(), L(this, Hn, !0);
+      r && L(this, It, we(this, ve, di).call(this, () => {
+        un.ensure(), L(this, Hn, !0);
         try {
           return dt(() => {
             r(
-              g(this, et),
+              g(this, tt),
               () => t,
               () => a
             );
@@ -774,7 +774,7 @@ class Fu {
           return mr(
             o,
             /** @type {Effect} */
-            g(this, Dt).parent
+            g(this, Ot).parent
           ), null;
         } finally {
           L(this, Hn, !1);
@@ -783,17 +783,17 @@ class Fu {
     });
   }
 }
-et = new WeakMap(), Gr = new WeakMap(), Mt = new WeakMap(), Vn = new WeakMap(), Dt = new WeakMap(), ct = new WeakMap(), Ye = new WeakMap(), Ot = new WeakMap(), nn = new WeakMap(), wn = new WeakMap(), zn = new WeakMap(), rn = new WeakMap(), cr = new WeakMap(), Hn = new WeakMap(), hr = new WeakMap(), dr = new WeakMap(), sn = new WeakMap(), Ii = new WeakMap(), _e = new WeakSet(), yo = function() {
+tt = new WeakMap(), Gr = new WeakMap(), Dt = new WeakMap(), Vn = new WeakMap(), Ot = new WeakMap(), ct = new WeakMap(), Ye = new WeakMap(), It = new WeakMap(), tn = new WeakMap(), wn = new WeakMap(), zn = new WeakMap(), nn = new WeakMap(), cr = new WeakMap(), Hn = new WeakMap(), hr = new WeakMap(), dr = new WeakMap(), rn = new WeakMap(), Fi = new WeakMap(), ve = new WeakSet(), yo = function() {
   try {
-    L(this, ct, dt(() => g(this, Vn).call(this, g(this, et))));
+    L(this, ct, dt(() => g(this, Vn).call(this, g(this, tt))));
   } catch (t) {
     this.error(t);
   }
 }, wo = function() {
-  const t = g(this, Mt).pending;
-  t && (L(this, Ye, dt(() => t(g(this, et)))), bn(() => {
-    var n = we(this, _e, ms).call(this);
-    L(this, ct, we(this, _e, hi).call(this, () => (fn.ensure(), dt(() => g(this, Vn).call(this, n))))), g(this, rn) > 0 ? we(this, _e, di).call(this) : (Xn(
+  const t = g(this, Dt).pending;
+  t && (L(this, Ye, dt(() => t(g(this, tt)))), bn(() => {
+    var n = we(this, ve, ms).call(this);
+    L(this, ct, we(this, ve, di).call(this, () => (un.ensure(), dt(() => g(this, Vn).call(this, n))))), g(this, nn) > 0 ? we(this, ve, pi).call(this) : (Xn(
       /** @type {Effect} */
       g(this, Ye),
       () => {
@@ -802,30 +802,30 @@ et = new WeakMap(), Gr = new WeakMap(), Mt = new WeakMap(), Vn = new WeakMap(), 
     ), this.is_pending = !1);
   }));
 }, ms = function() {
-  var t = g(this, et);
-  return this.is_pending && (L(this, wn, rt()), g(this, et).before(g(this, wn)), t = g(this, wn)), t;
+  var t = g(this, tt);
+  return this.is_pending && (L(this, wn, it()), g(this, tt).before(g(this, wn)), t = g(this, wn)), t;
 }, /**
  * @param {() => Effect | null} fn
  */
-hi = function(t) {
-  var n = te, r = X, i = it;
-  qt(g(this, Dt)), gt(g(this, Dt)), _r(g(this, Dt).ctx);
+di = function(t) {
+  var n = te, r = W, i = st;
+  Vt(g(this, Ot)), gt(g(this, Ot)), _r(g(this, Ot).ctx);
   try {
     return t();
   } catch (s) {
     return fo(s), null;
   } finally {
-    qt(n), gt(r), _r(i);
+    Vt(n), gt(r), _r(i);
   }
-}, di = function() {
+}, pi = function() {
   const t = (
     /** @type {(anchor: Node) => void} */
-    g(this, Mt).pending
+    g(this, Dt).pending
   );
-  g(this, ct) !== null && (L(this, nn, document.createDocumentFragment()), g(this, nn).append(
+  g(this, ct) !== null && (L(this, tn, document.createDocumentFragment()), g(this, tn).append(
     /** @type {TemplateNode} */
     g(this, wn)
-  ), qo(g(this, ct), g(this, nn))), g(this, Ye) === null && L(this, Ye, dt(() => t(g(this, et))));
+  ), qo(g(this, ct), g(this, tn))), g(this, Ye) === null && L(this, Ye, dt(() => t(g(this, tt))));
 }, /**
  * Updates the pending count associated with the currently visible pending snippet,
  * if any, such that we can replace the snippet with content once work is done
@@ -834,22 +834,22 @@ hi = function(t) {
 ys = function(t) {
   var n;
   if (!this.has_pending_snippet()) {
-    this.parent && we(n = this.parent, _e, ys).call(n, t);
+    this.parent && we(n = this.parent, ve, ys).call(n, t);
     return;
   }
-  if (L(this, rn, g(this, rn) + t), g(this, rn) === 0) {
+  if (L(this, nn, g(this, nn) + t), g(this, nn) === 0) {
     this.is_pending = !1;
     for (const r of g(this, hr))
-      ve(r, Re), xt(r);
+      pe(r, Re), bt(r);
     for (const r of g(this, dr))
-      ve(r, $t), xt(r);
+      pe(r, At), bt(r);
     g(this, hr).clear(), g(this, dr).clear(), g(this, Ye) && Xn(g(this, Ye), () => {
       L(this, Ye, null);
-    }), g(this, nn) && (g(this, et).before(g(this, nn)), L(this, nn, null));
+    }), g(this, tn) && (g(this, tt).before(g(this, tn)), L(this, tn, null));
   }
 };
-function Lu(e, t, n, r) {
-  const i = Wi;
+function qu(e, t, n, r) {
+  const i = Ui;
   var s = e.filter((h) => !h.settled);
   if (n.length === 0 && s.length === 0) {
     r(t.map(i));
@@ -858,13 +858,13 @@ function Lu(e, t, n, r) {
   var a = J, o = (
     /** @type {Effect} */
     te
-  ), l = qu(), u = s.length === 1 ? s[0].promise : s.length > 1 ? Promise.all(s.map((h) => h.promise)) : null;
+  ), l = Vu(), u = s.length === 1 ? s[0].promise : s.length > 1 ? Promise.all(s.map((h) => h.promise)) : null;
   function f(h) {
     l();
     try {
       r(h);
     } catch (p) {
-      (o.f & un) === 0 && mr(p, o);
+      (o.f & ln) === 0 && mr(p, o);
     }
     a == null || a.deactivate(), ws();
   }
@@ -873,27 +873,27 @@ function Lu(e, t, n, r) {
     return;
   }
   function d() {
-    l(), Promise.all(n.map((h) => /* @__PURE__ */ Vu(h))).then((h) => f([...t.map(i), ...h])).catch((h) => mr(h, o));
+    l(), Promise.all(n.map((h) => /* @__PURE__ */ zu(h))).then((h) => f([...t.map(i), ...h])).catch((h) => mr(h, o));
   }
   u ? u.then(d) : d();
 }
-function qu() {
-  var e = te, t = X, n = it, r = J;
+function Vu() {
+  var e = te, t = W, n = st, r = J;
   return function(s = !0) {
-    qt(e), gt(t), _r(n), s && (r == null || r.activate());
+    Vt(e), gt(t), _r(n), s && (r == null || r.activate());
   };
 }
 function ws() {
-  qt(null), gt(null), _r(null);
+  Vt(null), gt(null), _r(null);
 }
 // @__NO_SIDE_EFFECTS__
-function Wi(e) {
-  var t = Te | Re, n = X !== null && (X.f & Te) !== 0 ? (
+function Ui(e) {
+  var t = Te | Re, n = W !== null && (W.f & Te) !== 0 ? (
     /** @type {Derived} */
-    X
+    W
   ) : null;
   return te !== null && (te.f |= Zn), {
-    ctx: it,
+    ctx: st,
     deps: null,
     effects: null,
     equals: ao,
@@ -911,12 +911,12 @@ function Wi(e) {
   };
 }
 // @__NO_SIDE_EFFECTS__
-function Vu(e, t, n) {
+function zu(e, t, n) {
   let r = (
     /** @type {Effect | null} */
     te
   );
-  r === null && gu();
+  r === null && _u();
   var i = (
     /** @type {Boundary} */
     r.b
@@ -927,8 +927,8 @@ function Vu(e, t, n) {
   ), a = Kn(
     /** @type {V} */
     Ae
-  ), o = !X, l = /* @__PURE__ */ new Map();
-  return ju(() => {
+  ), o = !W, l = /* @__PURE__ */ new Map();
+  return Ju(() => {
     var p;
     var u = eo();
     s = u.promise;
@@ -960,7 +960,7 @@ function Vu(e, t, n) {
       o && (i.update_pending_count(-1), f.decrement(d));
     };
     u.promise.then(h, (y) => h(null, y || "unknown"));
-  }), Uu(() => {
+  }), Gu(() => {
     for (const u of l.values())
       u.reject(Mn);
   }), new Promise((u) => {
@@ -975,15 +975,15 @@ function Vu(e, t, n) {
 }
 // @__NO_SIDE_EFFECTS__
 function Nn(e) {
-  const t = /* @__PURE__ */ Wi(e);
+  const t = /* @__PURE__ */ Ui(e);
   return Vo(t), t;
 }
 // @__NO_SIDE_EFFECTS__
 function xo(e) {
-  const t = /* @__PURE__ */ Wi(e);
+  const t = /* @__PURE__ */ Ui(e);
   return t.equals = oo, t;
 }
-function zu(e) {
+function Hu(e) {
   var t = e.effects;
   if (t !== null) {
     e.effects = null;
@@ -994,10 +994,10 @@ function zu(e) {
       );
   }
 }
-function Hu(e) {
+function Yu(e) {
   for (var t = e.parent; t !== null; ) {
     if ((t.f & Te) === 0)
-      return (t.f & un) === 0 ? (
+      return (t.f & ln) === 0 ? (
         /** @type {Effect} */
         t
       ) : null;
@@ -1007,27 +1007,27 @@ function Hu(e) {
 }
 function qs(e) {
   var t, n = te;
-  qt(Hu(e));
+  Vt(Yu(e));
   try {
-    e.f &= ~Gn, zu(e), t = Bo(e);
+    e.f &= ~Gn, Hu(e), t = Bo(e);
   } finally {
-    qt(n);
+    Vt(n);
   }
   return t;
 }
 function bo(e) {
   var t = qs(e);
   if (!e.equals(t) && (e.wv = Ho(), (!(J != null && J.is_fork) || e.deps === null) && (e.v = t, e.deps === null))) {
-    ve(e, be);
+    pe(e, be);
     return;
   }
   En || (Ee !== null ? (zs() || J != null && J.is_fork) && Ee.set(e, t) : Ls(e));
 }
-function Yu(e) {
+function Bu(e) {
   var t, n;
   if (e.effects !== null)
     for (const r of e.effects)
-      (r.teardown || r.ac) && ((t = r.teardown) == null || t.call(r), (n = r.ac) == null || n.abort(Mn), r.teardown = uu, r.ac = null, zr(r, 0), Bs(r));
+      (r.teardown || r.ac) && ((t = r.teardown) == null || t.call(r), (n = r.ac) == null || n.abort(Mn), r.teardown = fu, r.ac = null, zr(r, 0), Bs(r));
 }
 function $o(e) {
   if (e.effects !== null)
@@ -1059,10 +1059,10 @@ function Eo(e, t = !1, n = !0) {
   const r = Kn(e);
   return t || (r.equals = oo), r;
 }
-function pe(e, t, n = !1) {
-  X !== null && // since we are untracking the function inside `$inspect.with` we need to add this check
+function de(e, t, n = !1) {
+  W !== null && // since we are untracking the function inside `$inspect.with` we need to add this check
   // to ensure we error if state is set inside an inspect effect
-  (!bt || (X.f & pa) !== 0) && lo() && (X.f & (Te | dn | Fs | pa)) !== 0 && (vt === null || !vr.call(vt, e)) && Tu();
+  (!$t || (W.f & pa) !== 0) && lo() && (W.f & (Te | hn | Fs | pa)) !== 0 && (vt === null || !vr.call(vt, e)) && Ru();
   let r = n ? On(t) : t;
   return yr(e, r);
 }
@@ -1070,7 +1070,7 @@ function yr(e, t) {
   if (!e.equals(t)) {
     var n = e.v;
     En ? $n.set(e, t) : $n.set(e, n), e.v = t;
-    var r = fn.ensure();
+    var r = un.ensure();
     if (r.capture(e, n), (e.f & Te) !== 0) {
       const i = (
         /** @type {Derived} */
@@ -1078,34 +1078,34 @@ function yr(e, t) {
       );
       (e.f & Re) !== 0 && qs(i), Ls(i);
     }
-    e.wv = Ho(), To(e, Re), te !== null && (te.f & be) !== 0 && (te.f & (At | Tn)) === 0 && (ft === null ? Qu([e]) : ft.push(e)), !r.is_fork && xs.size > 0 && !Ao && Bu();
+    e.wv = Ho(), To(e, Re), te !== null && (te.f & be) !== 0 && (te.f & (Et | Tn)) === 0 && (ft === null ? ef([e]) : ft.push(e)), !r.is_fork && xs.size > 0 && !Ao && Xu();
   }
   return t;
 }
-function Bu() {
+function Xu() {
   Ao = !1;
   for (const e of xs)
-    (e.f & be) !== 0 && ve(e, $t), Zr(e) && wr(e);
+    (e.f & be) !== 0 && pe(e, At), Zr(e) && wr(e);
   xs.clear();
 }
 function qr(e) {
-  pe(e, e.v + 1);
+  de(e, e.v + 1);
 }
 function To(e, t) {
   var n = e.reactions;
   if (n !== null)
     for (var r = n.length, i = 0; i < r; i++) {
       var s = n[i], a = s.f, o = (a & Re) === 0;
-      if (o && ve(s, t), (a & Te) !== 0) {
+      if (o && pe(s, t), (a & Te) !== 0) {
         var l = (
           /** @type {Derived} */
           s
         );
-        Ee == null || Ee.delete(l), (a & Gn) === 0 && (a & pt && (s.f |= Gn), To(l, $t));
-      } else o && ((a & dn) !== 0 && mt !== null && mt.add(
+        Ee == null || Ee.delete(l), (a & Gn) === 0 && (a & pt && (s.f |= Gn), To(l, At));
+      } else o && ((a & hn) !== 0 && yt !== null && yt.add(
         /** @type {Effect} */
         s
-      ), xt(
+      ), bt(
         /** @type {Effect} */
         s
       ));
@@ -1115,12 +1115,12 @@ function On(e) {
   if (typeof e != "object" || e === null || Fr in e)
     return e;
   const t = Qa(e);
-  if (t !== ou && t !== lu)
+  if (t !== lu && t !== uu)
     return e;
   var n = /* @__PURE__ */ new Map(), r = Za(e), i = /* @__PURE__ */ xe(0), s = Wn, a = (o) => {
     if (Wn === s)
       return o();
-    var l = X, u = Wn;
+    var l = W, u = Wn;
     gt(null), ma(s);
     var f = o();
     return gt(l), ma(u), f;
@@ -1133,12 +1133,12 @@ function On(e) {
     e,
     {
       defineProperty(o, l, u) {
-        (!("value" in u) || u.configurable === !1 || u.enumerable === !1 || u.writable === !1) && Au();
+        (!("value" in u) || u.configurable === !1 || u.enumerable === !1 || u.writable === !1) && Eu();
         var f = n.get(l);
         return f === void 0 ? a(() => {
           var d = /* @__PURE__ */ xe(u.value);
           return n.set(l, d), d;
-        }) : pe(f, u.value, !0), !0;
+        }) : de(f, u.value, !0), !0;
       },
       deleteProperty(o, l) {
         var u = n.get(l);
@@ -1148,7 +1148,7 @@ function On(e) {
             n.set(l, f), qr(i);
           }
         } else
-          pe(u, Ae), qr(i);
+          de(u, Ae), qr(i);
         return !0;
       },
       get(o, l, u) {
@@ -1205,14 +1205,14 @@ function On(e) {
           for (var p = u; p < /** @type {Source<number>} */
           d.v; p += 1) {
             var y = n.get(p + "");
-            y !== void 0 ? pe(y, Ae) : p in o && (y = a(() => /* @__PURE__ */ xe(Ae)), n.set(p + "", y));
+            y !== void 0 ? de(y, Ae) : p in o && (y = a(() => /* @__PURE__ */ xe(Ae)), n.set(p + "", y));
           }
         if (d === void 0)
-          (!h || (N = Bn(o, l)) != null && N.writable) && (d = a(() => /* @__PURE__ */ xe(void 0)), pe(d, On(u)), n.set(l, d));
+          (!h || (N = Bn(o, l)) != null && N.writable) && (d = a(() => /* @__PURE__ */ xe(void 0)), de(d, On(u)), n.set(l, d));
         else {
           h = d.v !== Ae;
           var E = a(() => On(u));
-          pe(d, E);
+          de(d, E);
         }
         var _ = Reflect.getOwnPropertyDescriptor(o, l);
         if (_ != null && _.set && _.set.call(f, u), !h) {
@@ -1221,7 +1221,7 @@ function On(e) {
               /** @type {Source<number>} */
               n.get("length")
             ), D = Number(l);
-            Number.isInteger(D) && D >= x.v && pe(x, D + 1);
+            Number.isInteger(D) && D >= x.v && de(x, D + 1);
           }
           qr(i);
         }
@@ -1238,7 +1238,7 @@ function On(e) {
         return l;
       },
       setPrototypeOf() {
-        Eu();
+        Tu();
       }
     }
   );
@@ -1251,18 +1251,18 @@ function bs() {
     So = Bn(t, "firstChild").get, Co = Bn(t, "nextSibling").get, da(e) && (e.__click = void 0, e.__className = void 0, e.__attributes = null, e.__style = void 0, e.__e = void 0), da(n) && (n.__t = void 0);
   }
 }
-function rt(e = "") {
+function it(e = "") {
   return document.createTextNode(e);
 }
 // @__NO_SIDE_EFFECTS__
-function cn(e) {
+function fn(e) {
   return (
     /** @type {TemplateNode | null} */
     So.call(e)
   );
 }
 // @__NO_SIDE_EFFECTS__
-function zt(e) {
+function Ht(e) {
   return (
     /** @type {TemplateNode | null} */
     Co.call(e)
@@ -1270,49 +1270,49 @@ function zt(e) {
 }
 function He(e, t) {
   if (!Z)
-    return /* @__PURE__ */ cn(e);
-  var n = /* @__PURE__ */ cn(W);
+    return /* @__PURE__ */ fn(e);
+  var n = /* @__PURE__ */ fn(U);
   if (n === null)
-    n = W.appendChild(rt());
+    n = U.appendChild(it());
   else if (t && n.nodeType !== Jr) {
-    var r = rt();
+    var r = it();
     return n == null || n.before(r), Fe(r), r;
   }
-  return t && Ui(
+  return t && Gi(
     /** @type {Text} */
     n
   ), Fe(n), n;
 }
 function mn(e, t = !1) {
   if (!Z) {
-    var n = /* @__PURE__ */ cn(e);
-    return n instanceof Comment && n.data === "" ? /* @__PURE__ */ zt(n) : n;
+    var n = /* @__PURE__ */ fn(e);
+    return n instanceof Comment && n.data === "" ? /* @__PURE__ */ Ht(n) : n;
   }
   if (t) {
-    if ((W == null ? void 0 : W.nodeType) !== Jr) {
-      var r = rt();
-      return W == null || W.before(r), Fe(r), r;
+    if ((U == null ? void 0 : U.nodeType) !== Jr) {
+      var r = it();
+      return U == null || U.before(r), Fe(r), r;
     }
-    Ui(
+    Gi(
       /** @type {Text} */
-      W
+      U
     );
   }
-  return W;
+  return U;
 }
-function Ze(e, t = 1, n = !1) {
-  let r = Z ? W : e;
+function Qe(e, t = 1, n = !1) {
+  let r = Z ? U : e;
   for (var i; t--; )
     i = r, r = /** @type {TemplateNode} */
-    /* @__PURE__ */ zt(r);
+    /* @__PURE__ */ Ht(r);
   if (!Z)
     return r;
   if (n) {
     if ((r == null ? void 0 : r.nodeType) !== Jr) {
-      var s = rt();
+      var s = it();
       return r === null ? i == null || i.after(s) : r.before(s), Fe(s), s;
     }
-    Ui(
+    Gi(
       /** @type {Text} */
       r
     );
@@ -1331,7 +1331,7 @@ function Vs(e, t, n) {
     document.createElementNS(Ja, e, void 0)
   );
 }
-function Ui(e) {
+function Gi(e) {
   if (
     /** @type {string} */
     e.nodeValue.length < 65536
@@ -1343,26 +1343,26 @@ function Ui(e) {
     t.nodeValue, t = e.nextSibling;
 }
 function Po(e) {
-  var t = X, n = te;
-  gt(null), qt(null);
+  var t = W, n = te;
+  gt(null), Vt(null);
   try {
     return e();
   } finally {
-    gt(t), qt(n);
+    gt(t), Vt(n);
   }
 }
-function Xu(e) {
-  te === null && (X === null && wu(), yu()), En && mu();
+function Wu(e) {
+  te === null && (W === null && xu(), wu()), En && yu();
 }
-function Wu(e, t) {
+function Uu(e, t) {
   var n = t.last;
   n === null ? t.last = t.first = e : (n.next = e, e.prev = n, t.last = e);
 }
-function Ht(e, t, n) {
+function Yt(e, t, n) {
   var r = te;
-  r !== null && (r.f & nt) !== 0 && (e |= nt);
+  r !== null && (r.f & rt) !== 0 && (e |= rt);
   var i = {
-    ctx: it,
+    ctx: st,
     deps: null,
     nodes: null,
     f: e | Re | pt,
@@ -1383,53 +1383,53 @@ function Ht(e, t, n) {
     } catch (o) {
       throw Le(i), o;
     }
-  else t !== null && xt(i);
+  else t !== null && bt(i);
   var s = i;
   if (n && s.deps === null && s.teardown === null && s.nodes === null && s.first === s.last && // either `null`, or a singular child
-  (s.f & Zn) === 0 && (s = s.first, (e & dn) !== 0 && (e & gr) !== 0 && s !== null && (s.f |= gr)), s !== null && (s.parent = r, r !== null && Wu(s, r), X !== null && (X.f & Te) !== 0 && (e & Tn) === 0)) {
+  (s.f & Zn) === 0 && (s = s.first, (e & hn) !== 0 && (e & gr) !== 0 && s !== null && (s.f |= gr)), s !== null && (s.parent = r, r !== null && Uu(s, r), W !== null && (W.f & Te) !== 0 && (e & Tn) === 0)) {
     var a = (
       /** @type {Derived} */
-      X
+      W
     );
     (a.effects ?? (a.effects = [])).push(s);
   }
   return i;
 }
 function zs() {
-  return X !== null && !bt;
+  return W !== null && !$t;
 }
-function Uu(e) {
-  const t = Ht(Vi, null, !1);
-  return ve(t, be), t.teardown = e, t;
+function Gu(e) {
+  const t = Yt(zi, null, !1);
+  return pe(t, be), t.teardown = e, t;
 }
-function Ri(e) {
-  Xu();
+function Si(e) {
+  Wu();
   var t = (
     /** @type {Effect} */
     te.f
-  ), n = !X && (t & At) !== 0 && (t & $r) === 0;
+  ), n = !W && (t & Et) !== 0 && (t & $r) === 0;
   if (n) {
     var r = (
       /** @type {ComponentContext} */
-      it
+      st
     );
     (r.e ?? (r.e = [])).push(e);
   } else
     return Mo(e);
 }
 function Mo(e) {
-  return Ht(Vr | hu, e, !1);
+  return Yt(Vr | du, e, !1);
 }
-function Gu(e) {
-  fn.ensure();
-  const t = Ht(Tn | Zn, e, !0);
+function Ku(e) {
+  un.ensure();
+  const t = Yt(Tn | Zn, e, !0);
   return () => {
     Le(t);
   };
 }
-function Ku(e) {
-  fn.ensure();
-  const t = Ht(Tn | Zn, e, !0);
+function ju(e) {
+  un.ensure();
+  const t = Yt(Tn | Zn, e, !0);
   return (n = {}) => new Promise((r) => {
     n.outro ? Xn(t, () => {
       Le(t), r(void 0);
@@ -1437,30 +1437,30 @@ function Ku(e) {
   });
 }
 function Do(e) {
-  return Ht(Vr, e, !1);
+  return Yt(Vr, e, !1);
 }
-function ju(e) {
-  return Ht(Fs | Zn, e, !0);
+function Ju(e) {
+  return Yt(Fs | Zn, e, !0);
 }
 function Hs(e, t = 0) {
-  return Ht(Vi | t, e, !0);
+  return Yt(zi | t, e, !0);
 }
-function en(e, t = [], n = [], r = []) {
-  Lu(r, t, n, (i) => {
-    Ht(Vi, () => e(...i.map(A)), !0);
+function Qt(e, t = [], n = [], r = []) {
+  qu(r, t, n, (i) => {
+    Yt(zi, () => e(...i.map(A)), !0);
   });
 }
 function Ys(e, t = 0) {
-  var n = Ht(dn | t, e, !0);
+  var n = Yt(hn | t, e, !0);
   return n;
 }
 function dt(e) {
-  return Ht(At | Zn, e, !0);
+  return Yt(Et | Zn, e, !0);
 }
 function Oo(e) {
   var t = e.teardown;
   if (t !== null) {
-    const n = En, r = X;
+    const n = En, r = W;
     _a(!0), gt(null);
     try {
       t.call(null);
@@ -1480,19 +1480,19 @@ function Bs(e, t = !1) {
     (n.f & Tn) !== 0 ? n.parent = null : Le(n, t), n = r;
   }
 }
-function Ju(e) {
+function Zu(e) {
   for (var t = e.first; t !== null; ) {
     var n = t.next;
-    (t.f & At) === 0 && Le(t), t = n;
+    (t.f & Et) === 0 && Le(t), t = n;
   }
 }
 function Le(e, t = !0) {
   var n = !1;
-  (t || (e.f & ro) !== 0) && e.nodes !== null && e.nodes.end !== null && (Zu(
+  (t || (e.f & ro) !== 0) && e.nodes !== null && e.nodes.end !== null && (Qu(
     e.nodes.start,
     /** @type {TemplateNode} */
     e.nodes.end
-  ), n = !0), Bs(e, t && !n), zr(e, 0), ve(e, un);
+  ), n = !0), Bs(e, t && !n), zr(e, 0), pe(e, ln);
   var r = e.nodes && e.nodes.t;
   if (r !== null)
     for (const s of r)
@@ -1501,9 +1501,9 @@ function Le(e, t = !0) {
   var i = e.parent;
   i !== null && i.first !== null && Io(e), e.next = e.prev = e.teardown = e.ctx = e.deps = e.fn = e.nodes = e.ac = null;
 }
-function Zu(e, t) {
+function Qu(e, t) {
   for (; e !== null; ) {
-    var n = e === t ? null : /* @__PURE__ */ zt(e);
+    var n = e === t ? null : /* @__PURE__ */ Ht(e);
     e.remove(), e = n;
   }
 }
@@ -1525,8 +1525,8 @@ function Xn(e, t, n = !0) {
     i();
 }
 function Fo(e, t, n) {
-  if ((e.f & nt) === 0) {
-    e.f ^= nt;
+  if ((e.f & rt) === 0) {
+    e.f ^= rt;
     var r = e.nodes && e.nodes.t;
     if (r !== null)
       for (const o of r)
@@ -1535,7 +1535,7 @@ function Fo(e, t, n) {
       var s = i.next, a = (i.f & gr) !== 0 || // If this is a branch effect without a block effect parent,
       // it means the parent block effect was pruned. In that case,
       // transparency information was transferred to the branch effect.
-      (i.f & At) !== 0 && (e.f & dn) !== 0;
+      (i.f & Et) !== 0 && (e.f & hn) !== 0;
       Fo(i, t, a ? n : !1), i = s;
     }
   }
@@ -1544,10 +1544,10 @@ function Xs(e) {
   Lo(e, !0);
 }
 function Lo(e, t) {
-  if ((e.f & nt) !== 0) {
-    e.f ^= nt, (e.f & be) === 0 && (ve(e, Re), xt(e));
+  if ((e.f & rt) !== 0) {
+    e.f ^= rt, (e.f & be) === 0 && (pe(e, Re), bt(e));
     for (var n = e.first; n !== null; ) {
-      var r = n.next, i = (n.f & gr) !== 0 || (n.f & At) !== 0;
+      var r = n.next, i = (n.f & gr) !== 0 || (n.f & Et) !== 0;
       Lo(n, i ? t : !1), n = r;
     }
     var s = e.nodes && e.nodes.t;
@@ -1559,28 +1559,28 @@ function Lo(e, t) {
 function qo(e, t) {
   if (e.nodes)
     for (var n = e.nodes.start, r = e.nodes.end; n !== null; ) {
-      var i = n === r ? null : /* @__PURE__ */ zt(n);
+      var i = n === r ? null : /* @__PURE__ */ Ht(n);
       t.append(n), n = i;
     }
 }
-let pi = !1, En = !1;
+let vi = !1, En = !1;
 function _a(e) {
   En = e;
 }
-let X = null, bt = !1;
+let W = null, $t = !1;
 function gt(e) {
-  X = e;
+  W = e;
 }
 let te = null;
-function qt(e) {
+function Vt(e) {
   te = e;
 }
 let vt = null;
 function Vo(e) {
-  X !== null && (vt === null ? vt = [e] : vt.push(e));
+  W !== null && (vt === null ? vt = [e] : vt.push(e));
 }
-let We = null, Qe = 0, ft = null;
-function Qu(e) {
+let We = null, et = 0, ft = null;
+function ef(e) {
   ft = e;
 }
 let zo = 1, In = 0, Wn = In;
@@ -1594,7 +1594,7 @@ function Zr(e) {
   var t = e.f;
   if ((t & Re) !== 0)
     return !0;
-  if (t & Te && (e.f &= ~Gn), (t & $t) !== 0) {
+  if (t & Te && (e.f &= ~Gn), (t & At) !== 0) {
     for (var n = (
       /** @type {Value[]} */
       e.deps
@@ -1611,7 +1611,7 @@ function Zr(e) {
     }
     (t & pt) !== 0 && // During time traveling we don't want to reset the status so that
     // traversal of the graph in the other batches still happens
-    Ee === null && ve(e, be);
+    Ee === null && pe(e, be);
   }
   return !1;
 }
@@ -1625,7 +1625,7 @@ function Yo(e, t, n = !0) {
         s,
         t,
         !1
-      ) : t === s && (n ? ve(s, Re) : (s.f & be) !== 0 && ve(s, $t), xt(
+      ) : t === s && (n ? pe(s, Re) : (s.f & be) !== 0 && pe(s, At), bt(
         /** @type {Effect} */
         s
       ));
@@ -1633,9 +1633,9 @@ function Yo(e, t, n = !0) {
 }
 function Bo(e) {
   var E;
-  var t = We, n = Qe, r = ft, i = X, s = vt, a = it, o = bt, l = Wn, u = e.f;
+  var t = We, n = et, r = ft, i = W, s = vt, a = st, o = $t, l = Wn, u = e.f;
   We = /** @type {null | Value[]} */
-  null, Qe = 0, ft = null, X = (u & (At | Tn)) === 0 ? e : null, vt = null, _r(e.ctx), bt = !1, Wn = ++In, e.ac !== null && (Po(() => {
+  null, et = 0, ft = null, W = (u & (Et | Tn)) === 0 ? e : null, vt = null, _r(e.ctx), $t = !1, Wn = ++In, e.ac !== null && (Po(() => {
     e.ac.abort(Mn);
   }), e.ac = null);
   try {
@@ -1648,16 +1648,16 @@ function Bo(e) {
     var h = e.deps, p = J == null ? void 0 : J.is_fork;
     if (We !== null) {
       var y;
-      if (p || zr(e, Qe), h !== null && Qe > 0)
-        for (h.length = Qe + We.length, y = 0; y < We.length; y++)
-          h[Qe + y] = We[y];
+      if (p || zr(e, et), h !== null && et > 0)
+        for (h.length = et + We.length, y = 0; y < We.length; y++)
+          h[et + y] = We[y];
       else
         e.deps = h = We;
       if (zs() && (e.f & pt) !== 0)
-        for (y = Qe; y < h.length; y++)
+        for (y = et; y < h.length; y++)
           ((E = h[y]).reactions ?? (E.reactions = [])).push(e);
-    } else !p && h !== null && Qe < h.length && (zr(e, Qe), h.length = Qe);
-    if (lo() && ft !== null && !bt && h !== null && (e.f & (Te | $t | Re)) === 0)
+    } else !p && h !== null && et < h.length && (zr(e, et), h.length = et);
+    if (lo() && ft !== null && !$t && h !== null && (e.f & (Te | At | Re)) === 0)
       for (y = 0; y < /** @type {Source[]} */
       ft.length; y++)
         Yo(
@@ -1679,13 +1679,13 @@ function Bo(e) {
   } catch (_) {
     return fo(_);
   } finally {
-    e.f ^= ds, We = t, Qe = n, ft = r, X = i, vt = s, _r(a), bt = o, Wn = l;
+    e.f ^= ds, We = t, et = n, ft = r, W = i, vt = s, _r(a), $t = o, Wn = l;
   }
 }
-function ef(e, t) {
+function tf(e, t) {
   let n = t.reactions;
   if (n !== null) {
-    var r = su.call(n, e);
+    var r = au.call(n, e);
     if (r !== -1) {
       var i = n.length - 1;
       i === 0 ? n = t.reactions = null : (n[r] = n[i], n.pop());
@@ -1699,44 +1699,44 @@ function ef(e, t) {
       /** @type {Derived} */
       t
     );
-    (s.f & pt) !== 0 && (s.f ^= pt, s.f &= ~Gn), Ls(s), Yu(s), zr(s, 0);
+    (s.f & pt) !== 0 && (s.f ^= pt, s.f &= ~Gn), Ls(s), Bu(s), zr(s, 0);
   }
 }
 function zr(e, t) {
   var n = e.deps;
   if (n !== null)
     for (var r = t; r < n.length; r++)
-      ef(e, n[r]);
+      tf(e, n[r]);
 }
 function wr(e) {
   var t = e.f;
-  if ((t & un) === 0) {
-    ve(e, be);
-    var n = te, r = pi;
-    te = e, pi = !0;
+  if ((t & ln) === 0) {
+    pe(e, be);
+    var n = te, r = vi;
+    te = e, vi = !0;
     try {
-      (t & (dn | to)) !== 0 ? Ju(e) : Bs(e), Oo(e);
+      (t & (hn | to)) !== 0 ? Zu(e) : Bs(e), Oo(e);
       var i = Bo(e);
       e.teardown = typeof i == "function" ? i : null, e.wv = zo;
       var s;
-      hs && Nu && (e.f & Re) !== 0 && e.deps;
+      hs && ku && (e.f & Re) !== 0 && e.deps;
     } finally {
-      pi = r, te = n;
+      vi = r, te = n;
     }
   }
 }
 function A(e) {
   var t = e.f, n = (t & Te) !== 0;
-  if (X !== null && !bt) {
-    var r = te !== null && (te.f & un) !== 0;
+  if (W !== null && !$t) {
+    var r = te !== null && (te.f & ln) !== 0;
     if (!r && (vt === null || !vr.call(vt, e))) {
-      var i = X.deps;
-      if ((X.f & ds) !== 0)
-        e.rv < In && (e.rv = In, We === null && i !== null && i[Qe] === e ? Qe++ : We === null ? We = [e] : We.push(e));
+      var i = W.deps;
+      if ((W.f & ds) !== 0)
+        e.rv < In && (e.rv = In, We === null && i !== null && i[et] === e ? et++ : We === null ? We = [e] : We.push(e));
       else {
-        (X.deps ?? (X.deps = [])).push(e);
+        (W.deps ?? (W.deps = [])).push(e);
         var s = e.reactions;
-        s === null ? e.reactions = [X] : vr.call(s, X) || s.push(X);
+        s === null ? e.reactions = [W] : vr.call(s, W) || s.push(W);
       }
     }
   }
@@ -1751,7 +1751,7 @@ function A(e) {
       var o = a.v;
       return ((a.f & be) === 0 && a.reactions !== null || Wo(a)) && (o = qs(a)), $n.set(a, o), o;
     }
-    var l = (a.f & pt) === 0 && !bt && X !== null && (pi || (X.f & pt) !== 0), u = (a.f & $r) === 0;
+    var l = (a.f & pt) === 0 && !$t && W !== null && (vi || (W.f & pt) !== 0), u = (a.f & $r) === 0;
     Zr(a) && (l && (a.f |= pt), bo(a)), l && !u && ($o(a), Xo(a));
   }
   if (Ee != null && Ee.has(e))
@@ -1783,15 +1783,15 @@ function Wo(e) {
   return !1;
 }
 function Qr(e) {
-  var t = bt;
+  var t = $t;
   try {
-    return bt = !0, e();
+    return $t = !0, e();
   } finally {
-    bt = t;
+    $t = t;
   }
 }
 const Uo = /* @__PURE__ */ new Set(), $s = /* @__PURE__ */ new Set();
-function tf(e) {
+function nf(e) {
   for (var t = 0; t < e.length; t++)
     Uo.add(e[t]);
   for (var n of $s)
@@ -1823,14 +1823,14 @@ function wa(e) {
   }
   if (s = /** @type {Element} */
   i[a] || e.target, s !== t) {
-    Ei(e, "currentTarget", {
+    Ti(e, "currentTarget", {
       configurable: !0,
       get() {
         return s || n;
       }
     });
-    var f = X, d = te;
-    gt(null), qt(null);
+    var f = W, d = te;
+    gt(null), Vt(null);
     try {
       for (var h, p = []; s !== null; ) {
         var y = s.assignedSlot || s.parentNode || /** @type {any} */
@@ -1856,7 +1856,7 @@ function wa(e) {
         throw h;
       }
     } finally {
-      e.__root = t, delete e.currentTarget, gt(f), qt(d);
+      e.__root = t, delete e.currentTarget, gt(f), Vt(d);
     }
   }
 }
@@ -1868,7 +1868,7 @@ const as = (Ka = (Ga = globalThis == null ? void 0 : globalThis.window) == null 
     createHTML: (e) => e
   }
 );
-function nf(e) {
+function rf(e) {
   return (
     /** @type {string} */
     (as == null ? void 0 : as.createHTML(e)) ?? e
@@ -1876,7 +1876,7 @@ function nf(e) {
 }
 function Go(e, t = !1) {
   var n = Vs("template");
-  return e = e.replaceAll("<!>", "<!---->"), n.innerHTML = t ? nf(e) : e, n.content;
+  return e = e.replaceAll("<!>", "<!---->"), n.innerHTML = t ? rf(e) : e, n.content;
 }
 function An(e, t) {
   var n = (
@@ -1886,13 +1886,13 @@ function An(e, t) {
   n.nodes === null && (n.nodes = { start: e, end: t, a: null, t: null });
 }
 // @__NO_SIDE_EFFECTS__
-function Yt(e, t) {
-  var n = (t & ru) !== 0, r = (t & iu) !== 0, i, s = !e.startsWith("<!>");
+function Bt(e, t) {
+  var n = (t & iu) !== 0, r = (t & su) !== 0, i, s = !e.startsWith("<!>");
   return () => {
     if (Z)
-      return An(W, null), W;
+      return An(U, null), U;
     i === void 0 && (i = Go(s ? e : "<!>" + e, !0), n || (i = /** @type {TemplateNode} */
-    /* @__PURE__ */ cn(i)));
+    /* @__PURE__ */ fn(i)));
     var a = (
       /** @type {TemplateNode} */
       r || Ro ? document.importNode(i, !0) : i.cloneNode(!0)
@@ -1900,7 +1900,7 @@ function Yt(e, t) {
     if (n) {
       var o = (
         /** @type {TemplateNode} */
-        /* @__PURE__ */ cn(a)
+        /* @__PURE__ */ fn(a)
       ), l = (
         /** @type {TemplateNode} */
         a.lastChild
@@ -1912,21 +1912,21 @@ function Yt(e, t) {
   };
 }
 // @__NO_SIDE_EFFECTS__
-function rf(e, t, n = "svg") {
+function sf(e, t, n = "svg") {
   var r = !e.startsWith("<!>"), i = `<${n}>${r ? e : "<!>" + e}</${n}>`, s;
   return () => {
     if (Z)
-      return An(W, null), W;
+      return An(U, null), U;
     if (!s) {
       var a = (
         /** @type {DocumentFragment} */
         Go(i, !0)
       ), o = (
         /** @type {Element} */
-        /* @__PURE__ */ cn(a)
+        /* @__PURE__ */ fn(a)
       );
       s = /** @type {Element} */
-      /* @__PURE__ */ cn(o);
+      /* @__PURE__ */ fn(o);
     }
     var l = (
       /** @type {TemplateNode} */
@@ -1936,16 +1936,16 @@ function rf(e, t, n = "svg") {
   };
 }
 // @__NO_SIDE_EFFECTS__
-function sf(e, t) {
-  return /* @__PURE__ */ rf(e, t, "svg");
+function af(e, t) {
+  return /* @__PURE__ */ sf(e, t, "svg");
 }
 function xa(e = "") {
   if (!Z) {
-    var t = rt(e + "");
+    var t = it(e + "");
     return An(t, t), t;
   }
-  var n = W;
-  return n.nodeType !== Jr ? (n.before(n = rt()), Fe(n)) : Ui(
+  var n = U;
+  return n.nodeType !== Jr ? (n.before(n = it()), Fe(n)) : Gi(
     /** @type {Text} */
     n
   ), An(n, n), n;
@@ -1956,7 +1956,7 @@ function Be(e, t) {
       /** @type {Effect & { nodes: EffectNodes }} */
       te
     );
-    ((n.f & $r) === 0 || n.nodes.end === null) && (n.nodes.end = W), Hi();
+    ((n.f & $r) === 0 || n.nodes.end === null) && (n.nodes.end = U), Yi();
     return;
   }
   e !== null && e.before(
@@ -1964,9 +1964,9 @@ function Be(e, t) {
     t
   );
 }
-const af = ["touchstart", "touchmove"];
-function of(e) {
-  return af.includes(e);
+const of = ["touchstart", "touchmove"];
+function lf(e) {
+  return of.includes(e);
 }
 function yn(e, t) {
   var n = t == null ? "" : typeof t == "object" ? t + "" : t;
@@ -1975,32 +1975,32 @@ function yn(e, t) {
 function Ko(e, t) {
   return jo(e, t);
 }
-function lf(e, t) {
+function uf(e, t) {
   bs(), t.intro = t.intro ?? !1;
-  const n = t.target, r = Z, i = W;
+  const n = t.target, r = Z, i = U;
   try {
-    for (var s = /* @__PURE__ */ cn(n); s && (s.nodeType !== Ar || /** @type {Comment} */
+    for (var s = /* @__PURE__ */ fn(n); s && (s.nodeType !== Ar || /** @type {Comment} */
     s.data !== Os); )
-      s = /* @__PURE__ */ zt(s);
+      s = /* @__PURE__ */ Ht(s);
     if (!s)
       throw pr;
-    ln(!0), Fe(
+    on(!0), Fe(
       /** @type {Comment} */
       s
     );
     const a = jo(e, { ...t, anchor: s });
-    return ln(!1), /**  @type {Exports} */
+    return on(!1), /**  @type {Exports} */
     a;
   } catch (a) {
     if (a instanceof Error && a.message.split(`
 `).some((o) => o.startsWith("https://svelte.dev/e/")))
       throw a;
-    return a !== pr && console.warn("Failed to hydrate: ", a), t.recover === !1 && bu(), bs(), No(n), ln(!1), Ko(e, t);
+    return a !== pr && console.warn("Failed to hydrate: ", a), t.recover === !1 && $u(), bs(), No(n), on(!1), Ko(e, t);
   } finally {
-    ln(r), Fe(i);
+    on(r), Fe(i);
   }
 }
-const si = /* @__PURE__ */ new Map();
+const ai = /* @__PURE__ */ new Map();
 function jo(e, { target: t, anchor: n, props: r = {}, events: i, context: s, intro: a = !0 }) {
   bs();
   var o = /* @__PURE__ */ new Set(), l = (d) => {
@@ -2008,20 +2008,20 @@ function jo(e, { target: t, anchor: n, props: r = {}, events: i, context: s, int
       var p = d[h];
       if (!o.has(p)) {
         o.add(p);
-        var y = of(p);
+        var y = lf(p);
         for (const x of [t, document]) {
-          var E = si.get(x);
-          E === void 0 && (E = /* @__PURE__ */ new Map(), si.set(x, E));
+          var E = ai.get(x);
+          E === void 0 && (E = /* @__PURE__ */ new Map(), ai.set(x, E));
           var _ = E.get(p);
           _ === void 0 ? (x.addEventListener(p, wa, { passive: y }), E.set(p, 1)) : E.set(p, _ + 1);
         }
       }
     }
   };
-  l(qi(Uo)), $s.add(l);
-  var u = void 0, f = Ku(() => {
-    var d = n ?? t.appendChild(rt());
-    return Iu(
+  l(Vi(Uo)), $s.add(l);
+  var u = void 0, f = ju(() => {
+    var d = n ?? t.appendChild(it());
+    return Fu(
       /** @type {TemplateNode} */
       d,
       {
@@ -2029,19 +2029,19 @@ function jo(e, { target: t, anchor: n, props: r = {}, events: i, context: s, int
         }
       },
       (h) => {
-        Yi({});
+        Bi({});
         var p = (
           /** @type {ComponentContext} */
-          it
+          st
         );
         if (s && (p.c = s), i && (r.$$events = i), Z && An(
           /** @type {TemplateNode} */
           h,
           null
-        ), u = e(h, r) || {}, Z && (te.nodes.end = W, W === null || W.nodeType !== Ar || /** @type {Comment} */
-        W.data !== Is))
-          throw zi(), pr;
-        Bi();
+        ), u = e(h, r) || {}, Z && (te.nodes.end = U, U === null || U.nodeType !== Ar || /** @type {Comment} */
+        U.data !== Is))
+          throw Hi(), pr;
+        Xi();
       }
     ), () => {
       var E;
@@ -2049,12 +2049,12 @@ function jo(e, { target: t, anchor: n, props: r = {}, events: i, context: s, int
         for (const _ of [t, document]) {
           var p = (
             /** @type {Map<string, number>} */
-            si.get(_)
+            ai.get(_)
           ), y = (
             /** @type {number} */
             p.get(h)
           );
-          --y == 0 ? (_.removeEventListener(h, wa), p.delete(h), p.size === 0 && si.delete(_)) : p.set(h, y);
+          --y == 0 ? (_.removeEventListener(h, wa), p.delete(h), p.size === 0 && ai.delete(_)) : p.set(h, y);
         }
       $s.delete(l), d !== n && ((E = d.parentNode) == null || E.removeChild(d));
     };
@@ -2062,21 +2062,21 @@ function jo(e, { target: t, anchor: n, props: r = {}, events: i, context: s, int
   return As.set(u, f), u;
 }
 let As = /* @__PURE__ */ new WeakMap();
-function uf(e, t) {
+function ff(e, t) {
   const n = As.get(e);
   return n ? (As.delete(e), n(t)) : Promise.resolve();
 }
-var yt, It, tt, Yn, Kr, jr, Fi;
-class ff {
+var wt, Ft, nt, Yn, Kr, jr, Li;
+class cf {
   /**
    * @param {TemplateNode} anchor
    * @param {boolean} transition
    */
   constructor(t, n = !0) {
     /** @type {TemplateNode} */
-    de(this, "anchor");
+    he(this, "anchor");
     /** @type {Map<Batch, Key>} */
-    H(this, yt, /* @__PURE__ */ new Map());
+    H(this, wt, /* @__PURE__ */ new Map());
     /**
      * Map of keys to effects that are currently rendered in the DOM.
      * These effects are visible and actively part of the document tree.
@@ -2091,13 +2091,13 @@ class ff {
      * Can result in the entries `true->Effect` and `false->Effect`
      * @type {Map<Key, Effect>}
      */
-    H(this, It, /* @__PURE__ */ new Map());
+    H(this, Ft, /* @__PURE__ */ new Map());
     /**
      * Similar to #onscreen with respect to the keys, but contains branches that are not yet
      * in the DOM, because their insertion is deferred.
      * @type {Map<Key, Branch>}
      */
-    H(this, tt, /* @__PURE__ */ new Map());
+    H(this, nt, /* @__PURE__ */ new Map());
     /**
      * Keys of effects that are currently outroing
      * @type {Set<Key>}
@@ -2113,32 +2113,32 @@ class ff {
         /** @type {Batch} */
         J
       );
-      if (g(this, yt).has(t)) {
+      if (g(this, wt).has(t)) {
         var n = (
           /** @type {Key} */
-          g(this, yt).get(t)
-        ), r = g(this, It).get(n);
+          g(this, wt).get(t)
+        ), r = g(this, Ft).get(n);
         if (r)
           Xs(r), g(this, Yn).delete(n);
         else {
-          var i = g(this, tt).get(n);
-          i && (g(this, It).set(n, i.effect), g(this, tt).delete(n), i.fragment.lastChild.remove(), this.anchor.before(i.fragment), r = i.effect);
+          var i = g(this, nt).get(n);
+          i && (g(this, Ft).set(n, i.effect), g(this, nt).delete(n), i.fragment.lastChild.remove(), this.anchor.before(i.fragment), r = i.effect);
         }
-        for (const [s, a] of g(this, yt)) {
-          if (g(this, yt).delete(s), s === t)
+        for (const [s, a] of g(this, wt)) {
+          if (g(this, wt).delete(s), s === t)
             break;
-          const o = g(this, tt).get(a);
-          o && (Le(o.effect), g(this, tt).delete(a));
+          const o = g(this, nt).get(a);
+          o && (Le(o.effect), g(this, nt).delete(a));
         }
-        for (const [s, a] of g(this, It)) {
+        for (const [s, a] of g(this, Ft)) {
           if (s === n || g(this, Yn).has(s)) continue;
           const o = () => {
-            if (Array.from(g(this, yt).values()).includes(s)) {
+            if (Array.from(g(this, wt).values()).includes(s)) {
               var u = document.createDocumentFragment();
-              qo(a, u), u.append(rt()), g(this, tt).set(s, { effect: a, fragment: u });
+              qo(a, u), u.append(it()), g(this, nt).set(s, { effect: a, fragment: u });
             } else
               Le(a);
-            g(this, Yn).delete(s), g(this, It).delete(s);
+            g(this, Yn).delete(s), g(this, Ft).delete(s);
           };
           g(this, Kr) || !r ? (g(this, Yn).add(s), Xn(a, o, !1)) : o();
         }
@@ -2147,11 +2147,11 @@ class ff {
     /**
      * @param {Batch} batch
      */
-    H(this, Fi, (t) => {
-      g(this, yt).delete(t);
-      const n = Array.from(g(this, yt).values());
-      for (const [r, i] of g(this, tt))
-        n.includes(r) || (Le(i.effect), g(this, tt).delete(r));
+    H(this, Li, (t) => {
+      g(this, wt).delete(t);
+      const n = Array.from(g(this, wt).values());
+      for (const [r, i] of g(this, nt))
+        n.includes(r) || (Le(i.effect), g(this, nt).delete(r));
     });
     this.anchor = t, L(this, Kr, n);
   }
@@ -2165,31 +2165,31 @@ class ff {
       /** @type {Batch} */
       J
     ), i = ko();
-    if (n && !g(this, It).has(t) && !g(this, tt).has(t))
+    if (n && !g(this, Ft).has(t) && !g(this, nt).has(t))
       if (i) {
-        var s = document.createDocumentFragment(), a = rt();
-        s.append(a), g(this, tt).set(t, {
+        var s = document.createDocumentFragment(), a = it();
+        s.append(a), g(this, nt).set(t, {
           effect: dt(() => n(a)),
           fragment: s
         });
       } else
-        g(this, It).set(
+        g(this, Ft).set(
           t,
           dt(() => n(this.anchor))
         );
-    if (g(this, yt).set(r, t), i) {
-      for (const [o, l] of g(this, It))
+    if (g(this, wt).set(r, t), i) {
+      for (const [o, l] of g(this, Ft))
         o === t ? r.unskip_effect(l) : r.skip_effect(l);
-      for (const [o, l] of g(this, tt))
+      for (const [o, l] of g(this, nt))
         o === t ? r.unskip_effect(l.effect) : r.skip_effect(l.effect);
-      r.oncommit(g(this, jr)), r.ondiscard(g(this, Fi));
+      r.oncommit(g(this, jr)), r.ondiscard(g(this, Li));
     } else
-      Z && (this.anchor = W), g(this, jr).call(this);
+      Z && (this.anchor = U), g(this, jr).call(this);
   }
 }
-yt = new WeakMap(), It = new WeakMap(), tt = new WeakMap(), Yn = new WeakMap(), Kr = new WeakMap(), jr = new WeakMap(), Fi = new WeakMap();
-function cf(e) {
-  it === null && vu(), Ri(() => {
+wt = new WeakMap(), Ft = new WeakMap(), nt = new WeakMap(), Yn = new WeakMap(), Kr = new WeakMap(), jr = new WeakMap(), Li = new WeakMap();
+function hf(e) {
+  st === null && gu(), Si(() => {
     const t = Qr(e);
     if (typeof t == "function") return (
       /** @type {() => void} */
@@ -2198,15 +2198,15 @@ function cf(e) {
   });
 }
 function ir(e, t, n = !1) {
-  Z && Hi();
-  var r = new ff(e), i = n ? gr : 0;
+  Z && Yi();
+  var r = new cf(e), i = n ? gr : 0;
   function s(a, o) {
     if (Z) {
       const f = so(e);
       var l;
-      if (f === Os ? l = 0 : f === Li ? l = !1 : l = parseInt(f.substring(1)), a !== l) {
-        var u = Ti();
-        Fe(u), r.anchor = u, ln(!1), r.ensure(a, o), ln(!0);
+      if (f === Os ? l = 0 : f === qi ? l = !1 : l = parseInt(f.substring(1)), a !== l) {
+        var u = Ri();
+        Fe(u), r.anchor = u, on(!1), r.ensure(a, o), on(!0);
         return;
       }
     }
@@ -2219,10 +2219,10 @@ function ir(e, t, n = !1) {
     }), a || s(!1, null);
   }, i);
 }
-function vi(e, t) {
+function gi(e, t) {
   return t;
 }
-function hf(e, t, n) {
+function df(e, t, n) {
   for (var r = [], i = t.length, s, a = t.length, o = 0; o < i; o++) {
     let d = t[o];
     Xn(
@@ -2234,7 +2234,7 @@ function hf(e, t, n) {
               /** @type {Set<EachOutroGroup>} */
               e.outrogroups
             );
-            Es(qi(s.done)), h.delete(s), h.size === 0 && (e.outrogroups = null);
+            Es(Vi(s.done)), h.delete(s), h.size === 0 && (e.outrogroups = null);
           }
         } else
           a -= 1;
@@ -2266,22 +2266,22 @@ function Es(e, t = !0) {
     Le(e[n], t);
 }
 var ba;
-function gi(e, t, n, r, i, s = null) {
+function _i(e, t, n, r, i, s = null) {
   var a = e, o = /* @__PURE__ */ new Map(), l = (t & ja) !== 0;
   if (l) {
     var u = (
       /** @type {Element} */
       e
     );
-    a = Z ? Fe(/* @__PURE__ */ cn(u)) : u.appendChild(rt());
+    a = Z ? Fe(/* @__PURE__ */ fn(u)) : u.appendChild(it());
   }
-  Z && Hi();
+  Z && Yi();
   var f = null, d = /* @__PURE__ */ xo(() => {
     var x = n();
-    return Za(x) ? x : x == null ? [] : qi(x);
+    return Za(x) ? x : x == null ? [] : Vi(x);
   }), h, p = !0;
   function y() {
-    _.fallback = f, df(_, h, a, t, r), f !== null && (h.length === 0 ? (f.f & on) === 0 ? Xs(f) : (f.f ^= on, Mr(f, null, a)) : Xn(f, () => {
+    _.fallback = f, pf(_, h, a, t, r), f !== null && (h.length === 0 ? (f.f & an) === 0 ? Xs(f) : (f.f ^= an, Mr(f, null, a)) : Xn(f, () => {
       f = null;
     }));
   }
@@ -2291,29 +2291,29 @@ function gi(e, t, n, r, i, s = null) {
     var x = h.length;
     let D = !1;
     if (Z) {
-      var N = so(a) === Li;
-      N !== (x === 0) && (a = Ti(), Fe(a), ln(!1), D = !0);
+      var N = so(a) === qi;
+      N !== (x === 0) && (a = Ri(), Fe(a), on(!1), D = !0);
     }
     for (var O = /* @__PURE__ */ new Set(), I = (
       /** @type {Batch} */
       J
     ), K = ko(), V = 0; V < x; V += 1) {
-      Z && W.nodeType === Ar && /** @type {Comment} */
-      W.data === Is && (a = /** @type {Comment} */
-      W, D = !0, ln(!1));
-      var Q = h[V], B = r(Q, V), U = p ? null : o.get(B);
-      U ? (U.v && yr(U.v, Q), U.i && yr(U.i, V), K && I.unskip_effect(U.e)) : (U = pf(
+      Z && U.nodeType === Ar && /** @type {Comment} */
+      U.data === Is && (a = /** @type {Comment} */
+      U, D = !0, on(!1));
+      var Q = h[V], B = r(Q, V), G = p ? null : o.get(B);
+      G ? (G.v && yr(G.v, Q), G.i && yr(G.i, V), K && I.unskip_effect(G.e)) : (G = vf(
         o,
-        p ? a : ba ?? (ba = rt()),
+        p ? a : ba ?? (ba = it()),
         Q,
         B,
         V,
         i,
         t,
         n
-      ), p || (U.e.f |= on), o.set(B, U)), O.add(B);
+      ), p || (G.e.f |= an), o.set(B, G)), O.add(B);
     }
-    if (x === 0 && s && !f && (p ? f = dt(() => s(a)) : (f = dt(() => s(ba ?? (ba = rt()))), f.f |= on)), x > O.size && _u(), Z && x > 0 && Fe(Ti()), !p)
+    if (x === 0 && s && !f && (p ? f = dt(() => s(a)) : (f = dt(() => s(ba ?? (ba = it()))), f.f |= an)), x > O.size && mu(), Z && x > 0 && Fe(Ri()), !p)
       if (K) {
         for (const [fe, ie] of o)
           O.has(fe) || I.skip_effect(ie.e);
@@ -2321,36 +2321,36 @@ function gi(e, t, n, r, i, s = null) {
         });
       } else
         y();
-    D && ln(!0), A(d);
+    D && on(!0), A(d);
   }), _ = { effect: E, items: o, outrogroups: null, fallback: f };
-  p = !1, Z && (a = W);
+  p = !1, Z && (a = U);
 }
 function kr(e) {
-  for (; e !== null && (e.f & At) === 0; )
+  for (; e !== null && (e.f & Et) === 0; )
     e = e.next;
   return e;
 }
-function df(e, t, n, r, i) {
-  var U, fe, ie, M, z, Se, Ge, se, Pe;
-  var s = (r & Jl) !== 0, a = t.length, o = e.items, l = kr(e.effect.first), u, f = null, d, h = [], p = [], y, E, _, x;
+function pf(e, t, n, r, i) {
+  var G, fe, ie, M, z, Se, Ge, se, Pe;
+  var s = (r & Zl) !== 0, a = t.length, o = e.items, l = kr(e.effect.first), u, f = null, d, h = [], p = [], y, E, _, x;
   if (s)
     for (x = 0; x < a; x += 1)
       y = t[x], E = i(y, x), _ = /** @type {EachItem} */
-      o.get(E).e, (_.f & on) === 0 && ((fe = (U = _.nodes) == null ? void 0 : U.a) == null || fe.measure(), (d ?? (d = /* @__PURE__ */ new Set())).add(_));
+      o.get(E).e, (_.f & an) === 0 && ((fe = (G = _.nodes) == null ? void 0 : G.a) == null || fe.measure(), (d ?? (d = /* @__PURE__ */ new Set())).add(_));
   for (x = 0; x < a; x += 1) {
     if (y = t[x], E = i(y, x), _ = /** @type {EachItem} */
     o.get(E).e, e.outrogroups !== null)
-      for (const me of e.outrogroups)
-        me.pending.delete(_), me.done.delete(_);
-    if ((_.f & on) !== 0)
-      if (_.f ^= on, _ === l)
+      for (const ge of e.outrogroups)
+        ge.pending.delete(_), ge.done.delete(_);
+    if ((_.f & an) !== 0)
+      if (_.f ^= an, _ === l)
         Mr(_, null, n);
       else {
         var D = f ? f.next : l;
         _ === e.effect.last && (e.effect.last = _.prev), _.prev && (_.prev.next = _.next), _.next && (_.next.prev = _.prev), _n(e, f, _), _n(e, _, D), Mr(_, D, n), f = _, h = [], p = [], l = kr(f.next);
         continue;
       }
-    if ((_.f & nt) !== 0 && (Xs(_), s && ((M = (ie = _.nodes) == null ? void 0 : ie.a) == null || M.unfix(), (d ?? (d = /* @__PURE__ */ new Set())).delete(_))), _ !== l) {
+    if ((_.f & rt) !== 0 && (Xs(_), s && ((M = (ie = _.nodes) == null ? void 0 : ie.a) == null || M.unfix(), (d ?? (d = /* @__PURE__ */ new Set())).delete(_))), _ !== l) {
       if (u !== void 0 && u.has(_)) {
         if (h.length < p.length) {
           var N = p[0], O;
@@ -2370,20 +2370,20 @@ function df(e, t, n, r, i) {
       if (l === null)
         continue;
     }
-    (_.f & on) === 0 && h.push(_), f = _, l = kr(_.next);
+    (_.f & an) === 0 && h.push(_), f = _, l = kr(_.next);
   }
   if (e.outrogroups !== null) {
-    for (const me of e.outrogroups)
-      me.pending.size === 0 && (Es(qi(me.done)), (z = e.outrogroups) == null || z.delete(me));
+    for (const ge of e.outrogroups)
+      ge.pending.size === 0 && (Es(Vi(ge.done)), (z = e.outrogroups) == null || z.delete(ge));
     e.outrogroups.size === 0 && (e.outrogroups = null);
   }
   if (l !== null || u !== void 0) {
     var V = [];
     if (u !== void 0)
       for (_ of u)
-        (_.f & nt) === 0 && V.push(_);
+        (_.f & rt) === 0 && V.push(_);
     for (; l !== null; )
-      (l.f & nt) === 0 && l !== e.fallback && V.push(l), l = kr(l.next);
+      (l.f & rt) === 0 && l !== e.fallback && V.push(l), l = kr(l.next);
     var Q = V.length;
     if (Q > 0) {
       var B = (r & ja) !== 0 && a === 0 ? n : null;
@@ -2393,18 +2393,18 @@ function df(e, t, n, r, i) {
         for (x = 0; x < Q; x += 1)
           (Pe = (se = V[x].nodes) == null ? void 0 : se.a) == null || Pe.fix();
       }
-      hf(e, V, B);
+      df(e, V, B);
     }
   }
   s && bn(() => {
-    var me, ye;
+    var ge, _e;
     if (d !== void 0)
       for (_ of d)
-        (ye = (me = _.nodes) == null ? void 0 : me.a) == null || ye.apply();
+        (_e = (ge = _.nodes) == null ? void 0 : ge.a) == null || _e.apply();
   });
 }
-function pf(e, t, n, r, i, s, a, o) {
-  var l = (a & Kl) !== 0 ? (a & Zl) === 0 ? /* @__PURE__ */ Eo(n, !1, !1) : Kn(n) : null, u = (a & jl) !== 0 ? Kn(i) : null;
+function vf(e, t, n, r, i, s, a, o) {
+  var l = (a & jl) !== 0 ? (a & Ql) === 0 ? /* @__PURE__ */ Eo(n, !1, !1) : Kn(n) : null, u = (a & Jl) !== 0 ? Kn(i) : null;
   return {
     v: l,
     i: u,
@@ -2415,13 +2415,13 @@ function pf(e, t, n, r, i, s, a, o) {
 }
 function Mr(e, t, n) {
   if (e.nodes)
-    for (var r = e.nodes.start, i = e.nodes.end, s = t && (t.f & on) === 0 ? (
+    for (var r = e.nodes.start, i = e.nodes.end, s = t && (t.f & an) === 0 ? (
       /** @type {EffectNodes} */
       t.nodes.start
     ) : n; r !== null; ) {
       var a = (
         /** @type {TemplateNode} */
-        /* @__PURE__ */ zt(r)
+        /* @__PURE__ */ Ht(r)
       );
       if (s.before(r), r === i)
         return;
@@ -2452,7 +2452,7 @@ function Ws(e, t) {
 }
 const $a = [...` 	
 \r\f \v\uFEFF`];
-function vf(e, t, n) {
+function gf(e, t, n) {
   var r = e == null ? "" : "" + e;
   if (n) {
     for (var i in n)
@@ -2474,17 +2474,17 @@ function Aa(e, t = !1) {
   }
   return r;
 }
-function gf(e, t) {
+function _f(e, t) {
   if (t) {
     var n = "", r, i;
     return Array.isArray(t) ? (r = t[0], i = t[1]) : r = t, r && (n += Aa(r)), i && (n += Aa(i, !0)), n = n.trim(), n === "" ? null : n;
   }
   return String(e);
 }
-function ai(e, t, n, r, i, s) {
+function oi(e, t, n, r, i, s) {
   var a = e.__className;
   if (Z || a !== n || a === void 0) {
-    var o = vf(n, r, s);
+    var o = gf(n, r, s);
     (!Z || o !== e.getAttribute("class")) && (o == null ? e.removeAttribute("class") : e.className = o), e.__className = n;
   } else if (s && i !== s)
     for (var l in s) {
@@ -2502,33 +2502,33 @@ function os(e, t = {}, n, r) {
 function Ea(e, t, n, r) {
   var i = e.__style;
   if (Z || i !== t) {
-    var s = gf(t, r);
+    var s = _f(t, r);
     (!Z || s !== e.getAttribute("style")) && (s == null ? e.removeAttribute("style") : e.style.cssText = s), e.__style = t;
   } else r && (Array.isArray(r) ? (os(e, n == null ? void 0 : n[0], r[0]), os(e, n == null ? void 0 : n[1], r[1], "important")) : os(e, n, r));
   return r;
 }
-const _f = Symbol("is custom element"), mf = Symbol("is html"), yf = pu ? "link" : "LINK";
+const mf = Symbol("is custom element"), yf = Symbol("is html"), wf = vu ? "link" : "LINK";
 function Ta(e, t, n, r) {
-  var i = wf(e);
-  Z && (i[t] = e.getAttribute(t), t === "src" || t === "srcset" || t === "href" && e.nodeName === yf) || i[t] !== (i[t] = n) && (t === "loading" && (e[du] = n), n == null ? e.removeAttribute(t) : typeof n != "string" && xf(e).includes(t) ? e[t] = n : e.setAttribute(t, n));
+  var i = xf(e);
+  Z && (i[t] = e.getAttribute(t), t === "src" || t === "srcset" || t === "href" && e.nodeName === wf) || i[t] !== (i[t] = n) && (t === "loading" && (e[pu] = n), n == null ? e.removeAttribute(t) : typeof n != "string" && bf(e).includes(t) ? e[t] = n : e.setAttribute(t, n));
 }
-function wf(e) {
+function xf(e) {
   return (
     /** @type {Record<string | symbol, unknown>} **/
     // @ts-expect-error
     e.__attributes ?? (e.__attributes = {
-      [_f]: e.nodeName.includes("-"),
-      [mf]: e.namespaceURI === Ja
+      [mf]: e.nodeName.includes("-"),
+      [yf]: e.namespaceURI === Ja
     })
   );
 }
 var Ra = /* @__PURE__ */ new Map();
-function xf(e) {
+function bf(e) {
   var t = e.getAttribute("is") || e.nodeName, n = Ra.get(t);
   if (n) return n;
   Ra.set(t, n = []);
   for (var r, i = e, s = Element.prototype; s !== i; ) {
-    r = au(i);
+    r = ou(i);
     for (var a in r)
       r[a].set && n.push(a);
     i = Qa(i);
@@ -2538,7 +2538,7 @@ function xf(e) {
 function Sa(e, t) {
   return e === t || (e == null ? void 0 : e[Fr]) === t;
 }
-function _i(e = {}, t, n, r) {
+function mi(e = {}, t, n, r) {
   return Do(() => {
     var i, s;
     return Hs(() => {
@@ -2552,18 +2552,18 @@ function _i(e = {}, t, n, r) {
     };
   }), e;
 }
-let oi = !1;
-function bf(e) {
-  var t = oi;
+let li = !1;
+function $f(e) {
+  var t = li;
   try {
-    return oi = !1, [e(), oi];
+    return li = !1, [e(), li];
   } finally {
-    oi = t;
+    li = t;
   }
 }
 function ee(e, t, n, r) {
   var D;
-  var i = (n & tu) !== 0, s = (n & nu) !== 0, a = (
+  var i = (n & nu) !== 0, s = (n & ru) !== 0, a = (
     /** @type {V} */
     r
   ), o = !0, l = () => (o && (o = !1, a = s ? Qr(
@@ -2578,11 +2578,11 @@ function ee(e, t, n, r) {
     u = ((D = Bn(e, t)) == null ? void 0 : D.set) ?? (f && t in e ? (N) => e[t] = N : void 0);
   }
   var d, h = !1;
-  i ? [d, h] = bf(() => (
+  i ? [d, h] = $f(() => (
     /** @type {V} */
     e[t]
   )) : d = /** @type {V} */
-  e[t], d === void 0 && r !== void 0 && (d = l(), u && ($u(), u(d)));
+  e[t], d === void 0 && r !== void 0 && (d = l(), u && (Au(), u(d)));
   var p;
   if (p = () => {
     var N = (
@@ -2590,7 +2590,7 @@ function ee(e, t, n, r) {
       e[t]
     );
     return N === void 0 ? l() : (o = !0, N);
-  }, (n & eu) === 0)
+  }, (n & tu) === 0)
     return p;
   if (u) {
     var y = e.$$legacy;
@@ -2601,7 +2601,7 @@ function ee(e, t, n, r) {
       })
     );
   }
-  var E = !1, _ = ((n & Ql) !== 0 ? Wi : xo)(() => (E = !1, p()));
+  var E = !1, _ = ((n & eu) !== 0 ? Ui : xo)(() => (E = !1, p()));
   i && A(_);
   var x = (
     /** @type {Effect} */
@@ -2612,17 +2612,17 @@ function ee(e, t, n, r) {
     (function(N, O) {
       if (arguments.length > 0) {
         const I = O ? A(_) : i ? On(N) : N;
-        return pe(_, I), E = !0, a !== void 0 && (a = I), N;
+        return de(_, I), E = !0, a !== void 0 && (a = I), N;
       }
-      return En && E || (x.f & un) !== 0 ? _.v : A(_);
+      return En && E || (x.f & ln) !== 0 ? _.v : A(_);
     })
   );
 }
-function $f(e) {
-  return new Af(e);
+function Af(e) {
+  return new Ef(e);
 }
-var an, ht;
-class Af {
+var sn, ht;
+class Ef {
   /**
    * @param {ComponentConstructorOptions & {
    *  component: any;
@@ -2630,7 +2630,7 @@ class Af {
    */
   constructor(t) {
     /** @type {any} */
-    H(this, an);
+    H(this, sn);
     /** @type {Record<string, any>} */
     H(this, ht);
     var s;
@@ -2648,20 +2648,20 @@ class Af {
           return o === io ? !0 : (A(n.get(o) ?? r(o, Reflect.get(a, o))), Reflect.has(a, o));
         },
         set(a, o, l) {
-          return pe(n.get(o) ?? r(o, l), l), Reflect.set(a, o, l);
+          return de(n.get(o) ?? r(o, l), l), Reflect.set(a, o, l);
         }
       }
     );
-    L(this, ht, (t.hydrate ? lf : Ko)(t.component, {
+    L(this, ht, (t.hydrate ? uf : Ko)(t.component, {
       target: t.target,
       anchor: t.anchor,
       props: i,
       context: t.context,
       intro: t.intro ?? !1,
       recover: t.recover
-    })), (!((s = t == null ? void 0 : t.props) != null && s.$$host) || t.sync === !1) && j(), L(this, an, i.$$events);
+    })), (!((s = t == null ? void 0 : t.props) != null && s.$$host) || t.sync === !1) && j(), L(this, sn, i.$$events);
     for (const a of Object.keys(g(this, ht)))
-      a === "$set" || a === "$destroy" || a === "$on" || Ei(this, a, {
+      a === "$set" || a === "$destroy" || a === "$on" || Ti(this, a, {
         get() {
           return g(this, ht)[a];
         },
@@ -2675,7 +2675,7 @@ class Af {
     (a) => {
       Object.assign(i, a);
     }, g(this, ht).$destroy = () => {
-      uf(g(this, ht));
+      ff(g(this, ht));
     };
   }
   /** @param {Record<string, any>} props */
@@ -2688,10 +2688,10 @@ class Af {
    * @returns {any}
    */
   $on(t, n) {
-    g(this, an)[t] = g(this, an)[t] || [];
+    g(this, sn)[t] = g(this, sn)[t] || [];
     const r = (...i) => n.call(this, ...i);
-    return g(this, an)[t].push(r), () => {
-      g(this, an)[t] = g(this, an)[t].filter(
+    return g(this, sn)[t].push(r), () => {
+      g(this, sn)[t] = g(this, sn)[t].filter(
         /** @param {any} fn */
         (i) => i !== r
       );
@@ -2701,7 +2701,7 @@ class Af {
     g(this, ht).$destroy();
   }
 }
-an = new WeakMap(), ht = new WeakMap();
+sn = new WeakMap(), ht = new WeakMap();
 let Jo;
 typeof HTMLElement == "function" && (Jo = class extends HTMLElement {
   /**
@@ -2712,27 +2712,27 @@ typeof HTMLElement == "function" && (Jo = class extends HTMLElement {
   constructor(t, n, r) {
     super();
     /** The Svelte component constructor */
-    de(this, "$$ctor");
+    he(this, "$$ctor");
     /** Slots */
-    de(this, "$$s");
+    he(this, "$$s");
     /** @type {any} The Svelte component instance */
-    de(this, "$$c");
+    he(this, "$$c");
     /** Whether or not the custom element is connected */
-    de(this, "$$cn", !1);
+    he(this, "$$cn", !1);
     /** @type {Record<string, any>} Component props data */
-    de(this, "$$d", {});
+    he(this, "$$d", {});
     /** `true` if currently in the process of reflecting component props back to attributes */
-    de(this, "$$r", !1);
+    he(this, "$$r", !1);
     /** @type {Record<string, CustomElementPropDefinition>} Props definition (name, reflected, type etc) */
-    de(this, "$$p_d", {});
+    he(this, "$$p_d", {});
     /** @type {Record<string, EventListenerOrEventListenerObject[]>} Event listeners */
-    de(this, "$$l", {});
+    he(this, "$$l", {});
     /** @type {Map<EventListenerOrEventListenerObject, Function>} Event listener unsubscribe functions */
-    de(this, "$$l_u", /* @__PURE__ */ new Map());
+    he(this, "$$l_u", /* @__PURE__ */ new Map());
     /** @type {any} The managed render effect for reflecting attributes */
-    de(this, "$$me");
+    he(this, "$$me");
     /** @type {ShadowRoot | null} The ShadowRoot of the custom element */
-    de(this, "$$shadowRoot", null);
+    he(this, "$$shadowRoot", null);
     this.$$ctor = t, this.$$s = n, r && (this.$$shadowRoot = this.attachShadow(r));
   }
   /**
@@ -2769,16 +2769,16 @@ typeof HTMLElement == "function" && (Jo = class extends HTMLElement {
       var t = n;
       if (await Promise.resolve(), !this.$$cn || this.$$c)
         return;
-      const r = {}, i = Ef(this);
+      const r = {}, i = Tf(this);
       for (const s of this.$$s)
         s in i && (s === "default" && !this.$$d.children ? (this.$$d.children = n(s), r.default = !0) : r[s] = n(s));
       for (const s of this.attributes) {
         const a = this.$$g_p(s.name);
-        a in this.$$d || (this.$$d[a] = mi(a, s.value, this.$$p_d, "toProp"));
+        a in this.$$d || (this.$$d[a] = yi(a, s.value, this.$$p_d, "toProp"));
       }
       for (const s in this.$$p_d)
         !(s in this.$$d) && this[s] !== void 0 && (this.$$d[s] = this[s], delete this[s]);
-      this.$$c = $f({
+      this.$$c = Af({
         component: this.$$ctor,
         target: this.$$shadowRoot || this,
         props: {
@@ -2786,14 +2786,14 @@ typeof HTMLElement == "function" && (Jo = class extends HTMLElement {
           $$slots: r,
           $$host: this
         }
-      }), this.$$me = Gu(() => {
+      }), this.$$me = Ku(() => {
         Hs(() => {
           var s;
           this.$$r = !0;
-          for (const a of Ai(this.$$c)) {
+          for (const a of Ei(this.$$c)) {
             if (!((s = this.$$p_d[a]) != null && s.reflect)) continue;
             this.$$d[a] = this.$$c[a];
-            const o = mi(
+            const o = yi(
               a,
               this.$$d[a],
               this.$$p_d,
@@ -2821,7 +2821,7 @@ typeof HTMLElement == "function" && (Jo = class extends HTMLElement {
    */
   attributeChangedCallback(t, n, r) {
     var i;
-    this.$$r || (t = this.$$g_p(t), this.$$d[t] = mi(t, r, this.$$p_d, "toProp"), (i = this.$$c) == null || i.$set({ [t]: this.$$d[t] }));
+    this.$$r || (t = this.$$g_p(t), this.$$d[t] = yi(t, r, this.$$p_d, "toProp"), (i = this.$$c) == null || i.$set({ [t]: this.$$d[t] }));
   }
   disconnectedCallback() {
     this.$$cn = !1, Promise.resolve().then(() => {
@@ -2832,12 +2832,12 @@ typeof HTMLElement == "function" && (Jo = class extends HTMLElement {
    * @param {string} attribute_name
    */
   $$g_p(t) {
-    return Ai(this.$$p_d).find(
+    return Ei(this.$$p_d).find(
       (n) => this.$$p_d[n].attribute === t || !this.$$p_d[n].attribute && n.toLowerCase() === t
     ) || t;
   }
 });
-function mi(e, t, n, r) {
+function yi(e, t, n, r) {
   var s;
   const i = (s = n[e]) == null ? void 0 : s.type;
   if (t = i === "Boolean" && typeof t != "boolean" ? t != null : t, !r || !n[e])
@@ -2868,7 +2868,7 @@ function mi(e, t, n, r) {
         return t;
     }
 }
-function Ef(e) {
+function Tf(e) {
   const t = {};
   return e.childNodes.forEach((n) => {
     t[
@@ -2883,19 +2883,19 @@ function Us(e, t, n, r, i, s) {
       super(e, n, i), this.$$p_d = t;
     }
     static get observedAttributes() {
-      return Ai(t).map(
+      return Ei(t).map(
         (o) => (t[o].attribute || o).toLowerCase()
       );
     }
   };
-  return Ai(t).forEach((o) => {
-    Ei(a.prototype, o, {
+  return Ei(t).forEach((o) => {
+    Ti(a.prototype, o, {
       get() {
         return this.$$c && o in this.$$c ? this.$$c[o] : this.$$d[o];
       },
       set(l) {
         var d;
-        l = mi(o, l, t), this.$$d[o] = l;
+        l = yi(o, l, t), this.$$d[o] = l;
         var u = this.$$c;
         if (u) {
           var f = (d = Bn(u, o)) == null ? void 0 : d.get;
@@ -2904,7 +2904,7 @@ function Us(e, t, n, r, i, s) {
       }
     });
   }), r.forEach((o) => {
-    Ei(a.prototype, o, {
+    Ti(a.prototype, o, {
       get() {
         var l;
         return (l = this.$$c) == null ? void 0 : l[o];
@@ -2913,31 +2913,31 @@ function Us(e, t, n, r, i, s) {
   }), e.element = /** @type {any} */
   a, a;
 }
-var Tf = { value: () => {
+var Rf = { value: () => {
 } };
 function Zo() {
   for (var e = 0, t = arguments.length, n = {}, r; e < t; ++e) {
     if (!(r = arguments[e] + "") || r in n || /[\s.]/.test(r)) throw new Error("illegal type: " + r);
     n[r] = [];
   }
-  return new yi(n);
+  return new wi(n);
 }
-function yi(e) {
+function wi(e) {
   this._ = e;
 }
-function Rf(e, t) {
+function Sf(e, t) {
   return e.trim().split(/^|\s+/).map(function(n) {
     var r = "", i = n.indexOf(".");
     if (i >= 0 && (r = n.slice(i + 1), n = n.slice(0, i)), n && !t.hasOwnProperty(n)) throw new Error("unknown type: " + n);
     return { type: n, name: r };
   });
 }
-yi.prototype = Zo.prototype = {
-  constructor: yi,
+wi.prototype = Zo.prototype = {
+  constructor: wi,
   on: function(e, t) {
-    var n = this._, r = Rf(e + "", n), i, s = -1, a = r.length;
+    var n = this._, r = Sf(e + "", n), i, s = -1, a = r.length;
     if (arguments.length < 2) {
-      for (; ++s < a; ) if ((i = (e = r[s]).type) && (i = Sf(n[i], e.name))) return i;
+      for (; ++s < a; ) if ((i = (e = r[s]).type) && (i = Cf(n[i], e.name))) return i;
       return;
     }
     if (t != null && typeof t != "function") throw new Error("invalid callback: " + t);
@@ -2949,7 +2949,7 @@ yi.prototype = Zo.prototype = {
   copy: function() {
     var e = {}, t = this._;
     for (var n in t) e[n] = t[n].slice();
-    return new yi(e);
+    return new wi(e);
   },
   call: function(e, t) {
     if ((i = arguments.length - 2) > 0) for (var n = new Array(i), r = 0, i, s; r < i; ++r) n[r] = arguments[r + 2];
@@ -2961,7 +2961,7 @@ yi.prototype = Zo.prototype = {
     for (var r = this._[e], i = 0, s = r.length; i < s; ++i) r[i].value.apply(t, n);
   }
 };
-function Sf(e, t) {
+function Cf(e, t) {
   for (var n = 0, r = e.length, i; n < r; ++n)
     if ((i = e[n]).name === t)
       return i.value;
@@ -2969,7 +2969,7 @@ function Sf(e, t) {
 function Ca(e, t, n) {
   for (var r = 0, i = e.length; r < i; ++r)
     if (e[r].name === t) {
-      e[r] = Tf, e = e.slice(0, r).concat(e.slice(r + 1));
+      e[r] = Rf, e = e.slice(0, r).concat(e.slice(r + 1));
       break;
     }
   return n != null && e.push({ name: t, value: n }), e;
@@ -2982,61 +2982,61 @@ const Na = {
   xml: "http://www.w3.org/XML/1998/namespace",
   xmlns: "http://www.w3.org/2000/xmlns/"
 };
-function Gi(e) {
+function Ki(e) {
   var t = e += "", n = t.indexOf(":");
   return n >= 0 && (t = e.slice(0, n)) !== "xmlns" && (e = e.slice(n + 1)), Na.hasOwnProperty(t) ? { space: Na[t], local: e } : e;
 }
-function Cf(e) {
+function Nf(e) {
   return function() {
     var t = this.ownerDocument, n = this.namespaceURI;
     return n === Ts && t.documentElement.namespaceURI === Ts ? t.createElement(e) : t.createElementNS(n, e);
   };
 }
-function Nf(e) {
+function kf(e) {
   return function() {
     return this.ownerDocument.createElementNS(e.space, e.local);
   };
 }
 function Qo(e) {
-  var t = Gi(e);
-  return (t.local ? Nf : Cf)(t);
+  var t = Ki(e);
+  return (t.local ? kf : Nf)(t);
 }
-function kf() {
+function Pf() {
 }
 function Gs(e) {
-  return e == null ? kf : function() {
+  return e == null ? Pf : function() {
     return this.querySelector(e);
   };
 }
-function Pf(e) {
+function Mf(e) {
   typeof e != "function" && (e = Gs(e));
   for (var t = this._groups, n = t.length, r = new Array(n), i = 0; i < n; ++i)
     for (var s = t[i], a = s.length, o = r[i] = new Array(a), l, u, f = 0; f < a; ++f)
       (l = s[f]) && (u = e.call(l, l.__data__, f, s)) && ("__data__" in l && (u.__data__ = l.__data__), o[f] = u);
-  return new st(r, this._parents);
+  return new at(r, this._parents);
 }
-function Mf(e) {
+function Df(e) {
   return e == null ? [] : Array.isArray(e) ? e : Array.from(e);
 }
-function Df() {
+function Of() {
   return [];
 }
 function el(e) {
-  return e == null ? Df : function() {
+  return e == null ? Of : function() {
     return this.querySelectorAll(e);
   };
 }
-function Of(e) {
+function If(e) {
   return function() {
-    return Mf(e.apply(this, arguments));
+    return Df(e.apply(this, arguments));
   };
 }
-function If(e) {
-  typeof e == "function" ? e = Of(e) : e = el(e);
+function Ff(e) {
+  typeof e == "function" ? e = If(e) : e = el(e);
   for (var t = this._groups, n = t.length, r = [], i = [], s = 0; s < n; ++s)
     for (var a = t[s], o = a.length, l, u = 0; u < o; ++u)
       (l = a[u]) && (r.push(e.call(l, l.__data__, u, a)), i.push(l));
-  return new st(r, i);
+  return new at(r, i);
 }
 function tl(e) {
   return function() {
@@ -3048,48 +3048,48 @@ function nl(e) {
     return t.matches(e);
   };
 }
-var Ff = Array.prototype.find;
-function Lf(e) {
+var Lf = Array.prototype.find;
+function qf(e) {
   return function() {
-    return Ff.call(this.children, e);
+    return Lf.call(this.children, e);
   };
 }
-function qf() {
+function Vf() {
   return this.firstElementChild;
 }
-function Vf(e) {
-  return this.select(e == null ? qf : Lf(typeof e == "function" ? e : nl(e)));
+function zf(e) {
+  return this.select(e == null ? Vf : qf(typeof e == "function" ? e : nl(e)));
 }
-var zf = Array.prototype.filter;
-function Hf() {
+var Hf = Array.prototype.filter;
+function Yf() {
   return Array.from(this.children);
 }
-function Yf(e) {
+function Bf(e) {
   return function() {
-    return zf.call(this.children, e);
+    return Hf.call(this.children, e);
   };
 }
-function Bf(e) {
-  return this.selectAll(e == null ? Hf : Yf(typeof e == "function" ? e : nl(e)));
-}
 function Xf(e) {
+  return this.selectAll(e == null ? Yf : Bf(typeof e == "function" ? e : nl(e)));
+}
+function Wf(e) {
   typeof e != "function" && (e = tl(e));
   for (var t = this._groups, n = t.length, r = new Array(n), i = 0; i < n; ++i)
     for (var s = t[i], a = s.length, o = r[i] = [], l, u = 0; u < a; ++u)
       (l = s[u]) && e.call(l, l.__data__, u, s) && o.push(l);
-  return new st(r, this._parents);
+  return new at(r, this._parents);
 }
 function rl(e) {
   return new Array(e.length);
 }
-function Wf() {
-  return new st(this._enter || this._groups.map(rl), this._parents);
+function Uf() {
+  return new at(this._enter || this._groups.map(rl), this._parents);
 }
-function Si(e, t) {
+function Ci(e, t) {
   this.ownerDocument = e.ownerDocument, this.namespaceURI = e.namespaceURI, this._next = null, this._parent = e, this.__data__ = t;
 }
-Si.prototype = {
-  constructor: Si,
+Ci.prototype = {
+  constructor: Ci,
   appendChild: function(e) {
     return this._parent.insertBefore(e, this._next);
   },
@@ -3103,35 +3103,35 @@ Si.prototype = {
     return this._parent.querySelectorAll(e);
   }
 };
-function Uf(e) {
+function Gf(e) {
   return function() {
     return e;
   };
 }
-function Gf(e, t, n, r, i, s) {
+function Kf(e, t, n, r, i, s) {
   for (var a = 0, o, l = t.length, u = s.length; a < u; ++a)
-    (o = t[a]) ? (o.__data__ = s[a], r[a] = o) : n[a] = new Si(e, s[a]);
+    (o = t[a]) ? (o.__data__ = s[a], r[a] = o) : n[a] = new Ci(e, s[a]);
   for (; a < l; ++a)
     (o = t[a]) && (i[a] = o);
 }
-function Kf(e, t, n, r, i, s, a) {
+function jf(e, t, n, r, i, s, a) {
   var o, l, u = /* @__PURE__ */ new Map(), f = t.length, d = s.length, h = new Array(f), p;
   for (o = 0; o < f; ++o)
     (l = t[o]) && (h[o] = p = a.call(l, l.__data__, o, t) + "", u.has(p) ? i[o] = l : u.set(p, l));
   for (o = 0; o < d; ++o)
-    p = a.call(e, s[o], o, s) + "", (l = u.get(p)) ? (r[o] = l, l.__data__ = s[o], u.delete(p)) : n[o] = new Si(e, s[o]);
+    p = a.call(e, s[o], o, s) + "", (l = u.get(p)) ? (r[o] = l, l.__data__ = s[o], u.delete(p)) : n[o] = new Ci(e, s[o]);
   for (o = 0; o < f; ++o)
     (l = t[o]) && u.get(h[o]) === l && (i[o] = l);
 }
-function jf(e) {
+function Jf(e) {
   return e.__data__;
 }
-function Jf(e, t) {
-  if (!arguments.length) return Array.from(this, jf);
-  var n = t ? Kf : Gf, r = this._parents, i = this._groups;
-  typeof e != "function" && (e = Uf(e));
+function Zf(e, t) {
+  if (!arguments.length) return Array.from(this, Jf);
+  var n = t ? jf : Kf, r = this._parents, i = this._groups;
+  typeof e != "function" && (e = Gf(e));
   for (var s = i.length, a = new Array(s), o = new Array(s), l = new Array(s), u = 0; u < s; ++u) {
-    var f = r[u], d = i[u], h = d.length, p = Zf(e.call(f, f && f.__data__, u, r)), y = p.length, E = o[u] = new Array(y), _ = a[u] = new Array(y), x = l[u] = new Array(h);
+    var f = r[u], d = i[u], h = d.length, p = Qf(e.call(f, f && f.__data__, u, r)), y = p.length, E = o[u] = new Array(y), _ = a[u] = new Array(y), x = l[u] = new Array(h);
     n(f, d, E, _, x, p, t);
     for (var D = 0, N = 0, O, I; D < y; ++D)
       if (O = E[D]) {
@@ -3139,34 +3139,34 @@ function Jf(e, t) {
         O._next = I || null;
       }
   }
-  return a = new st(a, r), a._enter = o, a._exit = l, a;
+  return a = new at(a, r), a._enter = o, a._exit = l, a;
 }
-function Zf(e) {
+function Qf(e) {
   return typeof e == "object" && "length" in e ? e : Array.from(e);
 }
-function Qf() {
-  return new st(this._exit || this._groups.map(rl), this._parents);
+function ec() {
+  return new at(this._exit || this._groups.map(rl), this._parents);
 }
-function ec(e, t, n) {
+function tc(e, t, n) {
   var r = this.enter(), i = this, s = this.exit();
   return typeof e == "function" ? (r = e(r), r && (r = r.selection())) : r = r.append(e + ""), t != null && (i = t(i), i && (i = i.selection())), n == null ? s.remove() : n(s), r && i ? r.merge(i).order() : i;
 }
-function tc(e) {
+function nc(e) {
   for (var t = e.selection ? e.selection() : e, n = this._groups, r = t._groups, i = n.length, s = r.length, a = Math.min(i, s), o = new Array(i), l = 0; l < a; ++l)
     for (var u = n[l], f = r[l], d = u.length, h = o[l] = new Array(d), p, y = 0; y < d; ++y)
       (p = u[y] || f[y]) && (h[y] = p);
   for (; l < i; ++l)
     o[l] = n[l];
-  return new st(o, this._parents);
+  return new at(o, this._parents);
 }
-function nc() {
+function rc() {
   for (var e = this._groups, t = -1, n = e.length; ++t < n; )
     for (var r = e[t], i = r.length - 1, s = r[i], a; --i >= 0; )
       (a = r[i]) && (s && a.compareDocumentPosition(s) ^ 4 && s.parentNode.insertBefore(a, s), s = a);
   return this;
 }
-function rc(e) {
-  e || (e = ic);
+function ic(e) {
+  e || (e = sc);
   function t(d, h) {
     return d && h ? e(d.__data__, h.__data__) : !d - !h;
   }
@@ -3175,19 +3175,19 @@ function rc(e) {
       (u = a[f]) && (l[f] = u);
     l.sort(t);
   }
-  return new st(i, this._parents).order();
+  return new at(i, this._parents).order();
 }
-function ic(e, t) {
+function sc(e, t) {
   return e < t ? -1 : e > t ? 1 : e >= t ? 0 : NaN;
 }
-function sc() {
+function ac() {
   var e = arguments[0];
   return arguments[0] = this, e.apply(null, arguments), this;
 }
-function ac() {
+function oc() {
   return Array.from(this);
 }
-function oc() {
+function lc() {
   for (var e = this._groups, t = 0, n = e.length; t < n; ++t)
     for (var r = e[t], i = 0, s = r.length; i < s; ++i) {
       var a = r[i];
@@ -3195,103 +3195,103 @@ function oc() {
     }
   return null;
 }
-function lc() {
+function uc() {
   let e = 0;
   for (const t of this) ++e;
   return e;
 }
-function uc() {
+function fc() {
   return !this.node();
 }
-function fc(e) {
+function cc(e) {
   for (var t = this._groups, n = 0, r = t.length; n < r; ++n)
     for (var i = t[n], s = 0, a = i.length, o; s < a; ++s)
       (o = i[s]) && e.call(o, o.__data__, s, i);
   return this;
 }
-function cc(e) {
+function hc(e) {
   return function() {
     this.removeAttribute(e);
   };
 }
-function hc(e) {
+function dc(e) {
   return function() {
     this.removeAttributeNS(e.space, e.local);
   };
 }
-function dc(e, t) {
+function pc(e, t) {
   return function() {
     this.setAttribute(e, t);
   };
 }
-function pc(e, t) {
-  return function() {
-    this.setAttributeNS(e.space, e.local, t);
-  };
-}
 function vc(e, t) {
   return function() {
-    var n = t.apply(this, arguments);
-    n == null ? this.removeAttribute(e) : this.setAttribute(e, n);
+    this.setAttributeNS(e.space, e.local, t);
   };
 }
 function gc(e, t) {
   return function() {
     var n = t.apply(this, arguments);
-    n == null ? this.removeAttributeNS(e.space, e.local) : this.setAttributeNS(e.space, e.local, n);
+    n == null ? this.removeAttribute(e) : this.setAttribute(e, n);
   };
 }
 function _c(e, t) {
-  var n = Gi(e);
+  return function() {
+    var n = t.apply(this, arguments);
+    n == null ? this.removeAttributeNS(e.space, e.local) : this.setAttributeNS(e.space, e.local, n);
+  };
+}
+function mc(e, t) {
+  var n = Ki(e);
   if (arguments.length < 2) {
     var r = this.node();
     return n.local ? r.getAttributeNS(n.space, n.local) : r.getAttribute(n);
   }
-  return this.each((t == null ? n.local ? hc : cc : typeof t == "function" ? n.local ? gc : vc : n.local ? pc : dc)(n, t));
+  return this.each((t == null ? n.local ? dc : hc : typeof t == "function" ? n.local ? _c : gc : n.local ? vc : pc)(n, t));
 }
 function il(e) {
   return e.ownerDocument && e.ownerDocument.defaultView || e.document && e || e.defaultView;
 }
-function mc(e) {
+function yc(e) {
   return function() {
     this.style.removeProperty(e);
   };
 }
-function yc(e, t, n) {
+function wc(e, t, n) {
   return function() {
     this.style.setProperty(e, t, n);
   };
 }
-function wc(e, t, n) {
+function xc(e, t, n) {
   return function() {
     var r = t.apply(this, arguments);
     r == null ? this.style.removeProperty(e) : this.style.setProperty(e, r, n);
   };
 }
-function xc(e, t, n) {
-  return arguments.length > 1 ? this.each((t == null ? mc : typeof t == "function" ? wc : yc)(e, t, n ?? "")) : xr(this.node(), e);
+function bc(e, t, n) {
+  return arguments.length > 1 ? this.each((t == null ? yc : typeof t == "function" ? xc : wc)(e, t, n ?? "")) : xr(this.node(), e);
 }
 function xr(e, t) {
   return e.style.getPropertyValue(t) || il(e).getComputedStyle(e, null).getPropertyValue(t);
 }
-function bc(e) {
+function $c(e) {
   return function() {
     delete this[e];
   };
 }
-function $c(e, t) {
+function Ac(e, t) {
   return function() {
     this[e] = t;
   };
 }
-function Ac(e, t) {
+function Ec(e, t) {
   return function() {
     var n = t.apply(this, arguments);
     n == null ? delete this[e] : this[e] = n;
   };
 }
-function Ec(e, t) {
-  return arguments.length > 1 ? this.each((t == null ? bc : typeof t == "function" ? Ac : $c)(e, t)) : this.node()[e];
+function Tc(e, t) {
+  return arguments.length > 1 ? this.each((t == null ? $c : typeof t == "function" ? Ec : Ac)(e, t)) : this.node()[e];
 }
 function sl(e) {
   return e.trim().split(/^|\s+/);
@@ -3321,123 +3321,123 @@ function ol(e, t) {
 function ll(e, t) {
   for (var n = Ks(e), r = -1, i = t.length; ++r < i; ) n.remove(t[r]);
 }
-function Tc(e) {
+function Rc(e) {
   return function() {
     ol(this, e);
   };
 }
-function Rc(e) {
+function Sc(e) {
   return function() {
     ll(this, e);
   };
 }
-function Sc(e, t) {
+function Cc(e, t) {
   return function() {
     (t.apply(this, arguments) ? ol : ll)(this, e);
   };
 }
-function Cc(e, t) {
+function Nc(e, t) {
   var n = sl(e + "");
   if (arguments.length < 2) {
     for (var r = Ks(this.node()), i = -1, s = n.length; ++i < s; ) if (!r.contains(n[i])) return !1;
     return !0;
   }
-  return this.each((typeof t == "function" ? Sc : t ? Tc : Rc)(n, t));
+  return this.each((typeof t == "function" ? Cc : t ? Rc : Sc)(n, t));
 }
-function Nc() {
+function kc() {
   this.textContent = "";
 }
-function kc(e) {
+function Pc(e) {
   return function() {
     this.textContent = e;
   };
 }
-function Pc(e) {
+function Mc(e) {
   return function() {
     var t = e.apply(this, arguments);
     this.textContent = t ?? "";
   };
 }
-function Mc(e) {
-  return arguments.length ? this.each(e == null ? Nc : (typeof e == "function" ? Pc : kc)(e)) : this.node().textContent;
+function Dc(e) {
+  return arguments.length ? this.each(e == null ? kc : (typeof e == "function" ? Mc : Pc)(e)) : this.node().textContent;
 }
-function Dc() {
+function Oc() {
   this.innerHTML = "";
 }
-function Oc(e) {
+function Ic(e) {
   return function() {
     this.innerHTML = e;
   };
 }
-function Ic(e) {
+function Fc(e) {
   return function() {
     var t = e.apply(this, arguments);
     this.innerHTML = t ?? "";
   };
 }
-function Fc(e) {
-  return arguments.length ? this.each(e == null ? Dc : (typeof e == "function" ? Ic : Oc)(e)) : this.node().innerHTML;
-}
-function Lc() {
-  this.nextSibling && this.parentNode.appendChild(this);
+function Lc(e) {
+  return arguments.length ? this.each(e == null ? Oc : (typeof e == "function" ? Fc : Ic)(e)) : this.node().innerHTML;
 }
 function qc() {
-  return this.each(Lc);
+  this.nextSibling && this.parentNode.appendChild(this);
 }
 function Vc() {
-  this.previousSibling && this.parentNode.insertBefore(this, this.parentNode.firstChild);
+  return this.each(qc);
 }
 function zc() {
-  return this.each(Vc);
+  this.previousSibling && this.parentNode.insertBefore(this, this.parentNode.firstChild);
 }
-function Hc(e) {
+function Hc() {
+  return this.each(zc);
+}
+function Yc(e) {
   var t = typeof e == "function" ? e : Qo(e);
   return this.select(function() {
     return this.appendChild(t.apply(this, arguments));
   });
 }
-function Yc() {
+function Bc() {
   return null;
 }
-function Bc(e, t) {
-  var n = typeof e == "function" ? e : Qo(e), r = t == null ? Yc : typeof t == "function" ? t : Gs(t);
+function Xc(e, t) {
+  var n = typeof e == "function" ? e : Qo(e), r = t == null ? Bc : typeof t == "function" ? t : Gs(t);
   return this.select(function() {
     return this.insertBefore(n.apply(this, arguments), r.apply(this, arguments) || null);
   });
 }
-function Xc() {
+function Wc() {
   var e = this.parentNode;
   e && e.removeChild(this);
 }
-function Wc() {
-  return this.each(Xc);
-}
 function Uc() {
+  return this.each(Wc);
+}
+function Gc() {
   var e = this.cloneNode(!1), t = this.parentNode;
   return t ? t.insertBefore(e, this.nextSibling) : e;
 }
-function Gc() {
+function Kc() {
   var e = this.cloneNode(!0), t = this.parentNode;
   return t ? t.insertBefore(e, this.nextSibling) : e;
 }
-function Kc(e) {
-  return this.select(e ? Gc : Uc);
-}
 function jc(e) {
-  return arguments.length ? this.property("__data__", e) : this.node().__data__;
+  return this.select(e ? Kc : Gc);
 }
 function Jc(e) {
+  return arguments.length ? this.property("__data__", e) : this.node().__data__;
+}
+function Zc(e) {
   return function(t) {
     e.call(this, t, this.__data__);
   };
 }
-function Zc(e) {
+function Qc(e) {
   return e.trim().split(/^|\s+/).map(function(t) {
     var n = "", r = t.indexOf(".");
     return r >= 0 && (n = t.slice(r + 1), t = t.slice(0, r)), { type: t, name: n };
   });
 }
-function Qc(e) {
+function eh(e) {
   return function() {
     var t = this.__on;
     if (t) {
@@ -3447,9 +3447,9 @@ function Qc(e) {
     }
   };
 }
-function eh(e, t, n) {
+function th(e, t, n) {
   return function() {
-    var r = this.__on, i, s = Jc(t);
+    var r = this.__on, i, s = Zc(t);
     if (r) {
       for (var a = 0, o = r.length; a < o; ++a)
         if ((i = r[a]).type === e.type && i.name === e.name) {
@@ -3460,8 +3460,8 @@ function eh(e, t, n) {
     this.addEventListener(e.type, s, n), i = { type: e.type, name: e.name, value: t, listener: s, options: n }, r ? r.push(i) : this.__on = [i];
   };
 }
-function th(e, t, n) {
-  var r = Zc(e + ""), i, s = r.length, a;
+function nh(e, t, n) {
+  var r = Qc(e + ""), i, s = r.length, a;
   if (arguments.length < 2) {
     var o = this.node().__on;
     if (o) {
@@ -3472,81 +3472,81 @@ function th(e, t, n) {
     }
     return;
   }
-  for (o = t ? eh : Qc, i = 0; i < s; ++i) this.each(o(r[i], t, n));
+  for (o = t ? th : eh, i = 0; i < s; ++i) this.each(o(r[i], t, n));
   return this;
 }
 function ul(e, t, n) {
   var r = il(e), i = r.CustomEvent;
   typeof i == "function" ? i = new i(t, n) : (i = r.document.createEvent("Event"), n ? (i.initEvent(t, n.bubbles, n.cancelable), i.detail = n.detail) : i.initEvent(t, !1, !1)), e.dispatchEvent(i);
 }
-function nh(e, t) {
+function rh(e, t) {
   return function() {
     return ul(this, e, t);
   };
 }
-function rh(e, t) {
+function ih(e, t) {
   return function() {
     return ul(this, e, t.apply(this, arguments));
   };
 }
-function ih(e, t) {
-  return this.each((typeof t == "function" ? rh : nh)(e, t));
+function sh(e, t) {
+  return this.each((typeof t == "function" ? ih : rh)(e, t));
 }
-function* sh() {
+function* ah() {
   for (var e = this._groups, t = 0, n = e.length; t < n; ++t)
     for (var r = e[t], i = 0, s = r.length, a; i < s; ++i)
       (a = r[i]) && (yield a);
 }
 var fl = [null];
-function st(e, t) {
+function at(e, t) {
   this._groups = e, this._parents = t;
 }
 function Er() {
-  return new st([[document.documentElement]], fl);
+  return new at([[document.documentElement]], fl);
 }
-function ah() {
+function oh() {
   return this;
 }
-st.prototype = Er.prototype = {
-  constructor: st,
-  select: Pf,
-  selectAll: If,
-  selectChild: Vf,
-  selectChildren: Bf,
-  filter: Xf,
-  data: Jf,
-  enter: Wf,
-  exit: Qf,
-  join: ec,
-  merge: tc,
-  selection: ah,
-  order: nc,
-  sort: rc,
-  call: sc,
-  nodes: ac,
-  node: oc,
-  size: lc,
-  empty: uc,
-  each: fc,
-  attr: _c,
-  style: xc,
-  property: Ec,
-  classed: Cc,
-  text: Mc,
-  html: Fc,
-  raise: qc,
-  lower: zc,
-  append: Hc,
-  insert: Bc,
-  remove: Wc,
-  clone: Kc,
-  datum: jc,
-  on: th,
-  dispatch: ih,
-  [Symbol.iterator]: sh
+at.prototype = Er.prototype = {
+  constructor: at,
+  select: Mf,
+  selectAll: Ff,
+  selectChild: zf,
+  selectChildren: Xf,
+  filter: Wf,
+  data: Zf,
+  enter: Uf,
+  exit: ec,
+  join: tc,
+  merge: nc,
+  selection: oh,
+  order: rc,
+  sort: ic,
+  call: ac,
+  nodes: oc,
+  node: lc,
+  size: uc,
+  empty: fc,
+  each: cc,
+  attr: mc,
+  style: bc,
+  property: Tc,
+  classed: Nc,
+  text: Dc,
+  html: Lc,
+  raise: Vc,
+  lower: Hc,
+  append: Yc,
+  insert: Xc,
+  remove: Uc,
+  clone: jc,
+  datum: Jc,
+  on: nh,
+  dispatch: sh,
+  [Symbol.iterator]: ah
 };
 function ue(e) {
-  return typeof e == "string" ? new st([[document.querySelector(e)]], [document.documentElement]) : new st([[e]], fl);
+  return typeof e == "string" ? new at([[document.querySelector(e)]], [document.documentElement]) : new at([[e]], fl);
 }
 function js(e, t, n) {
   e.prototype = t.prototype = n, n.constructor = e;
@@ -3558,7 +3558,7 @@ function cl(e, t) {
 }
 function ei() {
 }
-var Hr = 0.7, Ci = 1 / Hr, ar = "\\s*([+-]?\\d+)\\s*", Yr = "\\s*([+-]?(?:\\d*\\.)?\\d+(?:[eE][+-]?\\d+)?)\\s*", Lt = "\\s*([+-]?(?:\\d*\\.)?\\d+(?:[eE][+-]?\\d+)?)%\\s*", oh = /^#([0-9a-f]{3,8})$/, lh = new RegExp(`^rgb\\(${ar},${ar},${ar}\\)$`), uh = new RegExp(`^rgb\\(${Lt},${Lt},${Lt}\\)$`), fh = new RegExp(`^rgba\\(${ar},${ar},${ar},${Yr}\\)$`), ch = new RegExp(`^rgba\\(${Lt},${Lt},${Lt},${Yr}\\)$`), hh = new RegExp(`^hsl\\(${Yr},${Lt},${Lt}\\)$`), dh = new RegExp(`^hsla\\(${Yr},${Lt},${Lt},${Yr}\\)$`), ka = {
+var Hr = 0.7, Ni = 1 / Hr, ar = "\\s*([+-]?\\d+)\\s*", Yr = "\\s*([+-]?(?:\\d*\\.)?\\d+(?:[eE][+-]?\\d+)?)\\s*", qt = "\\s*([+-]?(?:\\d*\\.)?\\d+(?:[eE][+-]?\\d+)?)%\\s*", lh = /^#([0-9a-f]{3,8})$/, uh = new RegExp(`^rgb\\(${ar},${ar},${ar}\\)$`), fh = new RegExp(`^rgb\\(${qt},${qt},${qt}\\)$`), ch = new RegExp(`^rgba\\(${ar},${ar},${ar},${Yr}\\)$`), hh = new RegExp(`^rgba\\(${qt},${qt},${qt},${Yr}\\)$`), dh = new RegExp(`^hsl\\(${Yr},${qt},${qt}\\)$`), ph = new RegExp(`^hsla\\(${Yr},${qt},${qt},${Yr}\\)$`), ka = {
   aliceblue: 15792383,
   antiquewhite: 16444375,
   aqua: 65535,
@@ -3718,18 +3718,18 @@ js(ei, jn, {
   hex: Pa,
   // Deprecated! Use color.formatHex.
   formatHex: Pa,
-  formatHex8: ph,
-  formatHsl: vh,
+  formatHex8: vh,
+  formatHsl: gh,
   formatRgb: Ma,
   toString: Ma
 });
 function Pa() {
   return this.rgb().formatHex();
 }
-function ph() {
+function vh() {
   return this.rgb().formatHex8();
 }
-function vh() {
+function gh() {
   return hl(this).formatHsl();
 }
 function Ma() {
@@ -3737,26 +3737,26 @@ function Ma() {
 }
 function jn(e) {
   var t, n;
-  return e = (e + "").trim().toLowerCase(), (t = oh.exec(e)) ? (n = t[1].length, t = parseInt(t[1], 16), n === 6 ? Da(t) : n === 3 ? new Ue(t >> 8 & 15 | t >> 4 & 240, t >> 4 & 15 | t & 240, (t & 15) << 4 | t & 15, 1) : n === 8 ? li(t >> 24 & 255, t >> 16 & 255, t >> 8 & 255, (t & 255) / 255) : n === 4 ? li(t >> 12 & 15 | t >> 8 & 240, t >> 8 & 15 | t >> 4 & 240, t >> 4 & 15 | t & 240, ((t & 15) << 4 | t & 15) / 255) : null) : (t = lh.exec(e)) ? new Ue(t[1], t[2], t[3], 1) : (t = uh.exec(e)) ? new Ue(t[1] * 255 / 100, t[2] * 255 / 100, t[3] * 255 / 100, 1) : (t = fh.exec(e)) ? li(t[1], t[2], t[3], t[4]) : (t = ch.exec(e)) ? li(t[1] * 255 / 100, t[2] * 255 / 100, t[3] * 255 / 100, t[4]) : (t = hh.exec(e)) ? Fa(t[1], t[2] / 100, t[3] / 100, 1) : (t = dh.exec(e)) ? Fa(t[1], t[2] / 100, t[3] / 100, t[4]) : ka.hasOwnProperty(e) ? Da(ka[e]) : e === "transparent" ? new Ue(NaN, NaN, NaN, 0) : null;
+  return e = (e + "").trim().toLowerCase(), (t = lh.exec(e)) ? (n = t[1].length, t = parseInt(t[1], 16), n === 6 ? Da(t) : n === 3 ? new Ue(t >> 8 & 15 | t >> 4 & 240, t >> 4 & 15 | t & 240, (t & 15) << 4 | t & 15, 1) : n === 8 ? ui(t >> 24 & 255, t >> 16 & 255, t >> 8 & 255, (t & 255) / 255) : n === 4 ? ui(t >> 12 & 15 | t >> 8 & 240, t >> 8 & 15 | t >> 4 & 240, t >> 4 & 15 | t & 240, ((t & 15) << 4 | t & 15) / 255) : null) : (t = uh.exec(e)) ? new Ue(t[1], t[2], t[3], 1) : (t = fh.exec(e)) ? new Ue(t[1] * 255 / 100, t[2] * 255 / 100, t[3] * 255 / 100, 1) : (t = ch.exec(e)) ? ui(t[1], t[2], t[3], t[4]) : (t = hh.exec(e)) ? ui(t[1] * 255 / 100, t[2] * 255 / 100, t[3] * 255 / 100, t[4]) : (t = dh.exec(e)) ? Fa(t[1], t[2] / 100, t[3] / 100, 1) : (t = ph.exec(e)) ? Fa(t[1], t[2] / 100, t[3] / 100, t[4]) : ka.hasOwnProperty(e) ? Da(ka[e]) : e === "transparent" ? new Ue(NaN, NaN, NaN, 0) : null;
 }
 function Da(e) {
   return new Ue(e >> 16 & 255, e >> 8 & 255, e & 255, 1);
 }
-function li(e, t, n, r) {
+function ui(e, t, n, r) {
   return r <= 0 && (e = t = n = NaN), new Ue(e, t, n, r);
 }
-function gh(e) {
+function _h(e) {
   return e instanceof ei || (e = jn(e)), e ? (e = e.rgb(), new Ue(e.r, e.g, e.b, e.opacity)) : new Ue();
 }
 function Rs(e, t, n, r) {
-  return arguments.length === 1 ? gh(e) : new Ue(e, t, n, r ?? 1);
+  return arguments.length === 1 ? _h(e) : new Ue(e, t, n, r ?? 1);
 }
 function Ue(e, t, n, r) {
   this.r = +e, this.g = +t, this.b = +n, this.opacity = +r;
 }
 js(Ue, Rs, cl(ei, {
   brighter(e) {
-    return e = e == null ? Ci : Math.pow(Ci, e), new Ue(this.r * e, this.g * e, this.b * e, this.opacity);
+    return e = e == null ? Ni : Math.pow(Ni, e), new Ue(this.r * e, this.g * e, this.b * e, this.opacity);
   },
   darker(e) {
     return e = e == null ? Hr : Math.pow(Hr, e), new Ue(this.r * e, this.g * e, this.b * e, this.opacity);
@@ -3765,7 +3765,7 @@ js(Ue, Rs, cl(ei, {
     return this;
   },
   clamp() {
-    return new Ue(Un(this.r), Un(this.g), Un(this.b), Ni(this.opacity));
+    return new Ue(Un(this.r), Un(this.g), Un(this.b), ki(this.opacity));
   },
   displayable() {
     return -0.5 <= this.r && this.r < 255.5 && -0.5 <= this.g && this.g < 255.5 && -0.5 <= this.b && this.b < 255.5 && 0 <= this.opacity && this.opacity <= 1;
@@ -3773,21 +3773,21 @@ js(Ue, Rs, cl(ei, {
   hex: Oa,
   // Deprecated! Use color.formatHex.
   formatHex: Oa,
-  formatHex8: _h,
+  formatHex8: mh,
   formatRgb: Ia,
   toString: Ia
 }));
 function Oa() {
   return `#${Fn(this.r)}${Fn(this.g)}${Fn(this.b)}`;
 }
-function _h() {
+function mh() {
   return `#${Fn(this.r)}${Fn(this.g)}${Fn(this.b)}${Fn((isNaN(this.opacity) ? 1 : this.opacity) * 255)}`;
 }
 function Ia() {
-  const e = Ni(this.opacity);
+  const e = ki(this.opacity);
   return `${e === 1 ? "rgb(" : "rgba("}${Un(this.r)}, ${Un(this.g)}, ${Un(this.b)}${e === 1 ? ")" : `, ${e})`}`;
 }
-function Ni(e) {
+function ki(e) {
   return isNaN(e) ? 1 : Math.max(0, Math.min(1, e));
 }
 function Un(e) {
@@ -3797,28 +3797,28 @@ function Fn(e) {
   return e = Un(e), (e < 16 ? "0" : "") + e.toString(16);
 }
 function Fa(e, t, n, r) {
-  return r <= 0 ? e = t = n = NaN : n <= 0 || n >= 1 ? e = t = NaN : t <= 0 && (e = NaN), new wt(e, t, n, r);
+  return r <= 0 ? e = t = n = NaN : n <= 0 || n >= 1 ? e = t = NaN : t <= 0 && (e = NaN), new xt(e, t, n, r);
 }
 function hl(e) {
-  if (e instanceof wt) return new wt(e.h, e.s, e.l, e.opacity);
-  if (e instanceof ei || (e = jn(e)), !e) return new wt();
-  if (e instanceof wt) return e;
+  if (e instanceof xt) return new xt(e.h, e.s, e.l, e.opacity);
+  if (e instanceof ei || (e = jn(e)), !e) return new xt();
+  if (e instanceof xt) return e;
   e = e.rgb();
   var t = e.r / 255, n = e.g / 255, r = e.b / 255, i = Math.min(t, n, r), s = Math.max(t, n, r), a = NaN, o = s - i, l = (s + i) / 2;
-  return o ? (t === s ? a = (n - r) / o + (n < r) * 6 : n === s ? a = (r - t) / o + 2 : a = (t - n) / o + 4, o /= l < 0.5 ? s + i : 2 - s - i, a *= 60) : o = l > 0 && l < 1 ? 0 : a, new wt(a, o, l, e.opacity);
+  return o ? (t === s ? a = (n - r) / o + (n < r) * 6 : n === s ? a = (r - t) / o + 2 : a = (t - n) / o + 4, o /= l < 0.5 ? s + i : 2 - s - i, a *= 60) : o = l > 0 && l < 1 ? 0 : a, new xt(a, o, l, e.opacity);
 }
-function mh(e, t, n, r) {
-  return arguments.length === 1 ? hl(e) : new wt(e, t, n, r ?? 1);
+function yh(e, t, n, r) {
+  return arguments.length === 1 ? hl(e) : new xt(e, t, n, r ?? 1);
 }
-function wt(e, t, n, r) {
+function xt(e, t, n, r) {
   this.h = +e, this.s = +t, this.l = +n, this.opacity = +r;
 }
-js(wt, mh, cl(ei, {
+js(xt, yh, cl(ei, {
   brighter(e) {
-    return e = e == null ? Ci : Math.pow(Ci, e), new wt(this.h, this.s, this.l * e, this.opacity);
+    return e = e == null ? Ni : Math.pow(Ni, e), new xt(this.h, this.s, this.l * e, this.opacity);
   },
   darker(e) {
-    return e = e == null ? Hr : Math.pow(Hr, e), new wt(this.h, this.s, this.l * e, this.opacity);
+    return e = e == null ? Hr : Math.pow(Hr, e), new xt(this.h, this.s, this.l * e, this.opacity);
   },
   rgb() {
     var e = this.h % 360 + (this.h < 0) * 360, t = isNaN(e) || isNaN(this.s) ? 0 : this.s, n = this.l, r = n + (n < 0.5 ? n : 1 - n) * t, i = 2 * n - r;
@@ -3830,47 +3830,47 @@ js(wt, mh, cl(ei, {
     );
   },
   clamp() {
-    return new wt(La(this.h), ui(this.s), ui(this.l), Ni(this.opacity));
+    return new xt(La(this.h), fi(this.s), fi(this.l), ki(this.opacity));
   },
   displayable() {
     return (0 <= this.s && this.s <= 1 || isNaN(this.s)) && 0 <= this.l && this.l <= 1 && 0 <= this.opacity && this.opacity <= 1;
   },
   formatHsl() {
-    const e = Ni(this.opacity);
-    return `${e === 1 ? "hsl(" : "hsla("}${La(this.h)}, ${ui(this.s) * 100}%, ${ui(this.l) * 100}%${e === 1 ? ")" : `, ${e})`}`;
+    const e = ki(this.opacity);
+    return `${e === 1 ? "hsl(" : "hsla("}${La(this.h)}, ${fi(this.s) * 100}%, ${fi(this.l) * 100}%${e === 1 ? ")" : `, ${e})`}`;
   }
 }));
 function La(e) {
   return e = (e || 0) % 360, e < 0 ? e + 360 : e;
 }
-function ui(e) {
+function fi(e) {
   return Math.max(0, Math.min(1, e || 0));
 }
 function ls(e, t, n) {
   return (e < 60 ? t + (n - t) * e / 60 : e < 180 ? n : e < 240 ? t + (n - t) * (240 - e) / 60 : t) * 255;
 }
 const Js = (e) => () => e;
-function yh(e, t) {
+function wh(e, t) {
   return function(n) {
     return e + n * t;
   };
 }
-function wh(e, t, n) {
+function xh(e, t, n) {
   return e = Math.pow(e, n), t = Math.pow(t, n) - e, n = 1 / n, function(r) {
     return Math.pow(e + r * t, n);
   };
 }
-function xh(e) {
+function bh(e) {
   return (e = +e) == 1 ? dl : function(t, n) {
-    return n - t ? wh(t, n, e) : Js(isNaN(t) ? n : t);
+    return n - t ? xh(t, n, e) : Js(isNaN(t) ? n : t);
   };
 }
 function dl(e, t) {
   var n = t - e;
-  return n ? yh(e, n) : Js(isNaN(e) ? t : e);
+  return n ? wh(e, n) : Js(isNaN(e) ? t : e);
 }
-const ki = (function e(t) {
-  var n = xh(t);
+const Pi = (function e(t) {
+  var n = bh(t);
   function r(i, s) {
     var a = n((i = Rs(i)).r, (s = Rs(s)).r), o = n(i.g, s.g), l = n(i.b, s.b), u = dl(i.opacity, s.opacity);
     return function(f) {
@@ -3879,7 +3879,7 @@ const ki = (function e(t) {
   }
   return r.gamma = e, r;
 })(1);
-function bh(e, t) {
+function $h(e, t) {
   t || (t = []);
   var n = e ? Math.min(t.length, e.length) : 0, r = t.slice(), i;
   return function(s) {
@@ -3887,46 +3887,46 @@ function bh(e, t) {
     return r;
   };
 }
-function $h(e) {
+function Ah(e) {
   return ArrayBuffer.isView(e) && !(e instanceof DataView);
 }
-function Ah(e, t) {
+function Eh(e, t) {
   var n = t ? t.length : 0, r = e ? Math.min(n, e.length) : 0, i = new Array(r), s = new Array(n), a;
-  for (a = 0; a < r; ++a) i[a] = Qt(e[a], t[a]);
+  for (a = 0; a < r; ++a) i[a] = Zt(e[a], t[a]);
   for (; a < n; ++a) s[a] = t[a];
   return function(o) {
     for (a = 0; a < r; ++a) s[a] = i[a](o);
     return s;
   };
 }
-function Eh(e, t) {
+function Th(e, t) {
   var n = /* @__PURE__ */ new Date();
   return e = +e, t = +t, function(r) {
     return n.setTime(e * (1 - r) + t * r), n;
   };
 }
-function Ft(e, t) {
+function Lt(e, t) {
   return e = +e, t = +t, function(n) {
     return e * (1 - n) + t * n;
   };
 }
-function Th(e, t) {
+function Rh(e, t) {
   var n = {}, r = {}, i;
   (e === null || typeof e != "object") && (e = {}), (t === null || typeof t != "object") && (t = {});
   for (i in t)
-    i in e ? n[i] = Qt(e[i], t[i]) : r[i] = t[i];
+    i in e ? n[i] = Zt(e[i], t[i]) : r[i] = t[i];
   return function(s) {
     for (i in n) r[i] = n[i](s);
     return r;
   };
 }
 var Ss = /[-+]?(?:\d+\.?\d*|\.?\d+)(?:[eE][-+]?\d+)?/g, us = new RegExp(Ss.source, "g");
-function Rh(e) {
+function Sh(e) {
   return function() {
     return e;
   };
 }
-function Sh(e) {
+function Ch(e) {
   return function(t) {
     return e(t) + "";
   };
@@ -3934,15 +3934,15 @@ function Sh(e) {
 function pl(e, t) {
   var n = Ss.lastIndex = us.lastIndex = 0, r, i, s, a = -1, o = [], l = [];
   for (e = e + "", t = t + ""; (r = Ss.exec(e)) && (i = us.exec(t)); )
-    (s = i.index) > n && (s = t.slice(n, s), o[a] ? o[a] += s : o[++a] = s), (r = r[0]) === (i = i[0]) ? o[a] ? o[a] += i : o[++a] = i : (o[++a] = null, l.push({ i: a, x: Ft(r, i) })), n = us.lastIndex;
-  return n < t.length && (s = t.slice(n), o[a] ? o[a] += s : o[++a] = s), o.length < 2 ? l[0] ? Sh(l[0].x) : Rh(t) : (t = l.length, function(u) {
+    (s = i.index) > n && (s = t.slice(n, s), o[a] ? o[a] += s : o[++a] = s), (r = r[0]) === (i = i[0]) ? o[a] ? o[a] += i : o[++a] = i : (o[++a] = null, l.push({ i: a, x: Lt(r, i) })), n = us.lastIndex;
+  return n < t.length && (s = t.slice(n), o[a] ? o[a] += s : o[++a] = s), o.length < 2 ? l[0] ? Ch(l[0].x) : Sh(t) : (t = l.length, function(u) {
     for (var f = 0, d; f < t; ++f) o[(d = l[f]).i] = d.x(u);
     return o.join("");
   });
 }
-function Qt(e, t) {
+function Zt(e, t) {
   var n = typeof t, r;
-  return t == null || n === "boolean" ? Js(t) : (n === "number" ? Ft : n === "string" ? (r = jn(t)) ? (t = r, ki) : pl : t instanceof jn ? ki : t instanceof Date ? Eh : $h(t) ? bh : Array.isArray(t) ? Ah : typeof t.valueOf != "function" && typeof t.toString != "function" || isNaN(t) ? Th : Ft)(e, t);
+  return t == null || n === "boolean" ? Js(t) : (n === "number" ? Lt : n === "string" ? (r = jn(t)) ? (t = r, Pi) : pl : t instanceof jn ? Pi : t instanceof Date ? Th : Ah(t) ? $h : Array.isArray(t) ? Eh : typeof t.valueOf != "function" && typeof t.toString != "function" || isNaN(t) ? Rh : Lt)(e, t);
 }
 var qa = 180 / Math.PI, Cs = {
   translateX: 0,
@@ -3963,13 +3963,13 @@ function vl(e, t, n, r, i, s) {
     scaleY: o
   };
 }
-var fi;
-function Ch(e) {
+var ci;
+function Nh(e) {
   const t = new (typeof DOMMatrix == "function" ? DOMMatrix : WebKitCSSMatrix)(e + "");
   return t.isIdentity ? Cs : vl(t.a, t.b, t.c, t.d, t.e, t.f);
 }
-function Nh(e) {
-  return e == null || (fi || (fi = document.createElementNS("http://www.w3.org/2000/svg", "g")), fi.setAttribute("transform", e), !(e = fi.transform.baseVal.consolidate())) ? Cs : (e = e.matrix, vl(e.a, e.b, e.c, e.d, e.e, e.f));
+function kh(e) {
+  return e == null || (ci || (ci = document.createElementNS("http://www.w3.org/2000/svg", "g")), ci.setAttribute("transform", e), !(e = ci.transform.baseVal.consolidate())) ? Cs : (e = e.matrix, vl(e.a, e.b, e.c, e.d, e.e, e.f));
 }
 function gl(e, t, n, r) {
   function i(u) {
@@ -3978,19 +3978,19 @@ function gl(e, t, n, r) {
   function s(u, f, d, h, p, y) {
     if (u !== d || f !== h) {
       var E = p.push("translate(", null, t, null, n);
-      y.push({ i: E - 4, x: Ft(u, d) }, { i: E - 2, x: Ft(f, h) });
+      y.push({ i: E - 4, x: Lt(u, d) }, { i: E - 2, x: Lt(f, h) });
     } else (d || h) && p.push("translate(" + d + t + h + n);
   }
   function a(u, f, d, h) {
-    u !== f ? (u - f > 180 ? f += 360 : f - u > 180 && (u += 360), h.push({ i: d.push(i(d) + "rotate(", null, r) - 2, x: Ft(u, f) })) : f && d.push(i(d) + "rotate(" + f + r);
+    u !== f ? (u - f > 180 ? f += 360 : f - u > 180 && (u += 360), h.push({ i: d.push(i(d) + "rotate(", null, r) - 2, x: Lt(u, f) })) : f && d.push(i(d) + "rotate(" + f + r);
   }
   function o(u, f, d, h) {
-    u !== f ? h.push({ i: d.push(i(d) + "skewX(", null, r) - 2, x: Ft(u, f) }) : f && d.push(i(d) + "skewX(" + f + r);
+    u !== f ? h.push({ i: d.push(i(d) + "skewX(", null, r) - 2, x: Lt(u, f) }) : f && d.push(i(d) + "skewX(" + f + r);
   }
   function l(u, f, d, h, p, y) {
     if (u !== d || f !== h) {
       var E = p.push(i(p) + "scale(", null, ",", null, ")");
-      y.push({ i: E - 4, x: Ft(u, d) }, { i: E - 2, x: Ft(f, h) });
+      y.push({ i: E - 4, x: Lt(u, d) }, { i: E - 2, x: Lt(f, h) });
     } else (d !== 1 || h !== 1) && p.push(i(p) + "scale(" + d + "," + h + ")");
   }
   return function(u, f) {
@@ -4001,81 +4001,81 @@ function gl(e, t, n, r) {
     };
   };
 }
-var kh = gl(Ch, "px, ", "px)", "deg)"), Ph = gl(Nh, ", ", ")", ")"), br = 0, Dr = 0, Pr = 0, _l = 1e3, Pi, Or, Mi = 0, Jn = 0, Ki = 0, Br = typeof performance == "object" && performance.now ? performance : Date, ml = typeof window == "object" && window.requestAnimationFrame ? window.requestAnimationFrame.bind(window) : function(e) {
+var Ph = gl(Nh, "px, ", "px)", "deg)"), Mh = gl(kh, ", ", ")", ")"), br = 0, Dr = 0, Pr = 0, _l = 1e3, Mi, Or, Di = 0, Jn = 0, ji = 0, Br = typeof performance == "object" && performance.now ? performance : Date, ml = typeof window == "object" && window.requestAnimationFrame ? window.requestAnimationFrame.bind(window) : function(e) {
   setTimeout(e, 17);
 };
 function Zs() {
-  return Jn || (ml(Mh), Jn = Br.now() + Ki);
+  return Jn || (ml(Dh), Jn = Br.now() + ji);
 }
-function Mh() {
+function Dh() {
   Jn = 0;
 }
-function Di() {
+function Oi() {
   this._call = this._time = this._next = null;
 }
-Di.prototype = yl.prototype = {
-  constructor: Di,
+Oi.prototype = yl.prototype = {
+  constructor: Oi,
   restart: function(e, t, n) {
     if (typeof e != "function") throw new TypeError("callback is not a function");
-    n = (n == null ? Zs() : +n) + (t == null ? 0 : +t), !this._next && Or !== this && (Or ? Or._next = this : Pi = this, Or = this), this._call = e, this._time = n, Ns();
+    n = (n == null ? Zs() : +n) + (t == null ? 0 : +t), !this._next && Or !== this && (Or ? Or._next = this : Mi = this, Or = this), this._call = e, this._time = n, Ns();
   },
   stop: function() {
     this._call && (this._call = null, this._time = 1 / 0, Ns());
   }
 };
 function yl(e, t, n) {
-  var r = new Di();
+  var r = new Oi();
   return r.restart(e, t, n), r;
 }
-function Dh() {
+function Oh() {
   Zs(), ++br;
-  for (var e = Pi, t; e; )
+  for (var e = Mi, t; e; )
     (t = Jn - e._time) >= 0 && e._call.call(void 0, t), e = e._next;
   --br;
 }
 function Va() {
-  Jn = (Mi = Br.now()) + Ki, br = Dr = 0;
+  Jn = (Di = Br.now()) + ji, br = Dr = 0;
   try {
-    Dh();
+    Oh();
   } finally {
-    br = 0, Ih(), Jn = 0;
+    br = 0, Fh(), Jn = 0;
   }
 }
-function Oh() {
-  var e = Br.now(), t = e - Mi;
-  t > _l && (Ki -= t, Mi = e);
-}
 function Ih() {
-  for (var e, t = Pi, n, r = 1 / 0; t; )
-    t._call ? (r > t._time && (r = t._time), e = t, t = t._next) : (n = t._next, t._next = null, t = e ? e._next = n : Pi = n);
+  var e = Br.now(), t = e - Di;
+  t > _l && (ji -= t, Di = e);
+}
+function Fh() {
+  for (var e, t = Mi, n, r = 1 / 0; t; )
+    t._call ? (r > t._time && (r = t._time), e = t, t = t._next) : (n = t._next, t._next = null, t = e ? e._next = n : Mi = n);
   Or = e, Ns(r);
 }
 function Ns(e) {
   if (!br) {
     Dr && (Dr = clearTimeout(Dr));
     var t = e - Jn;
-    t > 24 ? (e < 1 / 0 && (Dr = setTimeout(Va, e - Br.now() - Ki)), Pr && (Pr = clearInterval(Pr))) : (Pr || (Mi = Br.now(), Pr = setInterval(Oh, _l)), br = 1, ml(Va));
+    t > 24 ? (e < 1 / 0 && (Dr = setTimeout(Va, e - Br.now() - ji)), Pr && (Pr = clearInterval(Pr))) : (Pr || (Di = Br.now(), Pr = setInterval(Ih, _l)), br = 1, ml(Va));
   }
 }
 function za(e, t, n) {
-  var r = new Di();
+  var r = new Oi();
   return t = t == null ? 0 : +t, r.restart((i) => {
     r.stop(), e(i + t);
   }, t, n), r;
 }
-var Fh = Zo("start", "end", "cancel", "interrupt"), Lh = [], wl = 0, Ha = 1, ks = 2, wi = 3, Ya = 4, Ps = 5, xi = 6;
-function ji(e, t, n, r, i, s) {
+var Lh = Zo("start", "end", "cancel", "interrupt"), qh = [], wl = 0, Ha = 1, ks = 2, xi = 3, Ya = 4, Ps = 5, bi = 6;
+function Ji(e, t, n, r, i, s) {
   var a = e.__transition;
   if (!a) e.__transition = {};
   else if (n in a) return;
-  qh(e, n, {
+  Vh(e, n, {
     name: t,
     index: r,
     // For context during callback.
     group: i,
     // For context during callback.
-    on: Fh,
-    tween: Lh,
+    on: Lh,
+    tween: qh,
     time: s.time,
     delay: s.delay,
     duration: s.duration,
@@ -4085,21 +4085,21 @@ function ji(e, t, n, r, i, s) {
   });
 }
 function Qs(e, t) {
-  var n = Et(e, t);
+  var n = Tt(e, t);
   if (n.state > wl) throw new Error("too late; already scheduled");
   return n;
 }
-function Bt(e, t) {
-  var n = Et(e, t);
-  if (n.state > wi) throw new Error("too late; already running");
+function Xt(e, t) {
+  var n = Tt(e, t);
+  if (n.state > xi) throw new Error("too late; already running");
   return n;
 }
-function Et(e, t) {
+function Tt(e, t) {
   var n = e.__transition;
   if (!n || !(n = n[t])) throw new Error("transition not found");
   return n;
 }
-function qh(e, t, n) {
+function Vh(e, t, n) {
   var r = e.__transition, i;
   r[t] = n, n.timer = yl(s, 0, n.time);
   function s(u) {
@@ -4110,13 +4110,13 @@ function qh(e, t, n) {
     if (n.state !== Ha) return l();
     for (f in r)
       if (p = r[f], p.name === n.name) {
-        if (p.state === wi) return za(a);
-        p.state === Ya ? (p.state = xi, p.timer.stop(), p.on.call("interrupt", e, e.__data__, p.index, p.group), delete r[f]) : +f < t && (p.state = xi, p.timer.stop(), p.on.call("cancel", e, e.__data__, p.index, p.group), delete r[f]);
+        if (p.state === xi) return za(a);
+        p.state === Ya ? (p.state = bi, p.timer.stop(), p.on.call("interrupt", e, e.__data__, p.index, p.group), delete r[f]) : +f < t && (p.state = bi, p.timer.stop(), p.on.call("cancel", e, e.__data__, p.index, p.group), delete r[f]);
       }
     if (za(function() {
-      n.state === wi && (n.state = Ya, n.timer.restart(o, n.delay, n.time), o(u));
+      n.state === xi && (n.state = Ya, n.timer.restart(o, n.delay, n.time), o(u));
     }), n.state = ks, n.on.call("start", e, e.__data__, n.index, n.group), n.state === ks) {
-      for (n.state = wi, i = new Array(h = n.tween.length), f = 0, d = -1; f < h; ++f)
+      for (n.state = xi, i = new Array(h = n.tween.length), f = 0, d = -1; f < h; ++f)
         (p = n.tween[f].value.call(e, e.__data__, n.index, n.group)) && (i[++d] = p);
       i.length = d + 1;
     }
@@ -4127,12 +4127,12 @@ function qh(e, t, n) {
     n.state === Ps && (n.on.call("end", e, e.__data__, n.index, n.group), l());
   }
   function l() {
-    n.state = xi, n.timer.stop(), delete r[t];
+    n.state = bi, n.timer.stop(), delete r[t];
     for (var u in r) return;
     delete e.__transition;
   }
 }
-function Vh(e, t) {
+function zh(e, t) {
   var n = e.__transition, r, i, s = !0, a;
   if (n) {
     t = t == null ? null : t + "";
@@ -4141,20 +4141,20 @@ function Vh(e, t) {
         s = !1;
         continue;
       }
-      i = r.state > ks && r.state < Ps, r.state = xi, r.timer.stop(), r.on.call(i ? "interrupt" : "cancel", e, e.__data__, r.index, r.group), delete n[a];
+      i = r.state > ks && r.state < Ps, r.state = bi, r.timer.stop(), r.on.call(i ? "interrupt" : "cancel", e, e.__data__, r.index, r.group), delete n[a];
     }
     s && delete e.__transition;
   }
 }
-function zh(e) {
+function Hh(e) {
   return this.each(function() {
-    Vh(this, e);
+    zh(this, e);
   });
 }
-function Hh(e, t) {
+function Yh(e, t) {
   var n, r;
   return function() {
-    var i = Bt(this, e), s = i.tween;
+    var i = Xt(this, e), s = i.tween;
     if (s !== n) {
       r = n = s;
       for (var a = 0, o = r.length; a < o; ++a)
@@ -4166,11 +4166,11 @@ function Hh(e, t) {
     i.tween = r;
   };
 }
-function Yh(e, t, n) {
+function Bh(e, t, n) {
   var r, i;
   if (typeof n != "function") throw new Error();
   return function() {
-    var s = Bt(this, e), a = s.tween;
+    var s = Xt(this, e), a = s.tween;
     if (a !== r) {
       i = (r = a).slice();
       for (var o = { name: t, value: n }, l = 0, u = i.length; l < u; ++l)
@@ -4183,82 +4183,90 @@ function Yh(e, t, n) {
     s.tween = i;
   };
 }
-function Bh(e, t) {
+function Xh(e, t) {
   var n = this._id;
   if (e += "", arguments.length < 2) {
-    for (var r = Et(this.node(), n).tween, i = 0, s = r.length, a; i < s; ++i)
+    for (var r = Tt(this.node(), n).tween, i = 0, s = r.length, a; i < s; ++i)
       if ((a = r[i]).name === e)
         return a.value;
     return null;
   }
-  return this.each((t == null ? Hh : Yh)(n, e, t));
+  return this.each((t == null ? Yh : Bh)(n, e, t));
 }
 function ea(e, t, n) {
   var r = e._id;
   return e.each(function() {
-    var i = Bt(this, r);
+    var i = Xt(this, r);
     (i.value || (i.value = {}))[t] = n.apply(this, arguments);
   }), function(i) {
-    return Et(i, r).value[t];
+    return Tt(i, r).value[t];
   };
 }
 function xl(e, t) {
   var n;
-  return (typeof t == "number" ? Ft : t instanceof jn ? ki : (n = jn(t)) ? (t = n, ki) : pl)(e, t);
+  return (typeof t == "number" ? Lt : t instanceof jn ? Pi : (n = jn(t)) ? (t = n, Pi) : pl)(e, t);
 }
-function Xh(e) {
+function Wh(e) {
   return function() {
     this.removeAttribute(e);
   };
 }
-function Wh(e) {
+function Uh(e) {
   return function() {
     this.removeAttributeNS(e.space, e.local);
   };
 }
-function Uh(e, t, n) {
+function Gh(e, t, n) {
   var r, i = n + "", s;
   return function() {
     var a = this.getAttribute(e);
     return a === i ? null : a === r ? s : s = t(r = a, n);
   };
 }
-function Gh(e, t, n) {
+function Kh(e, t, n) {
   var r, i = n + "", s;
   return function() {
     var a = this.getAttributeNS(e.space, e.local);
     return a === i ? null : a === r ? s : s = t(r = a, n);
   };
 }
-function Kh(e, t, n) {
+function jh(e, t, n) {
   var r, i, s;
   return function() {
     var a, o = n(this), l;
     return o == null ? void this.removeAttribute(e) : (a = this.getAttribute(e), l = o + "", a === l ? null : a === r && l === i ? s : (i = l, s = t(r = a, o)));
   };
 }
-function jh(e, t, n) {
+function Jh(e, t, n) {
   var r, i, s;
   return function() {
     var a, o = n(this), l;
     return o == null ? void this.removeAttributeNS(e.space, e.local) : (a = this.getAttributeNS(e.space, e.local), l = o + "", a === l ? null : a === r && l === i ? s : (i = l, s = t(r = a, o)));
   };
 }
-function Jh(e, t) {
-  var n = Gi(e), r = n === "transform" ? Ph : xl;
-  return this.attrTween(e, typeof t == "function" ? (n.local ? jh : Kh)(n, r, ea(this, "attr." + e, t)) : t == null ? (n.local ? Wh : Xh)(n) : (n.local ? Gh : Uh)(n, r, t));
-}
 function Zh(e, t) {
+  var n = Ki(e), r = n === "transform" ? Mh : xl;
+  return this.attrTween(e, typeof t == "function" ? (n.local ? Jh : jh)(n, r, ea(this, "attr." + e, t)) : t == null ? (n.local ? Uh : Wh)(n) : (n.local ? Kh : Gh)(n, r, t));
+}
+function Qh(e, t) {
   return function(n) {
     this.setAttribute(e, t.call(this, n));
   };
 }
-function Qh(e, t) {
+function ed(e, t) {
   return function(n) {
     this.setAttributeNS(e.space, e.local, t.call(this, n));
   };
 }
-function ed(e, t) {
+function td(e, t) {
+  var n, r;
+  function i() {
+    var s = t.apply(this, arguments);
+    return s !== r && (n = (r = s) && ed(e, s)), n;
+  }
+  return i._value = t, i;
+}
+function nd(e, t) {
   var n, r;
   function i() {
     var s = t.apply(this, arguments);
@@ -4266,139 +4274,131 @@ function ed(e, t) {
   }
   return i._value = t, i;
 }
-function td(e, t) {
-  var n, r;
-  function i() {
-    var s = t.apply(this, arguments);
-    return s !== r && (n = (r = s) && Zh(e, s)), n;
-  }
-  return i._value = t, i;
-}
-function nd(e, t) {
+function rd(e, t) {
   var n = "attr." + e;
   if (arguments.length < 2) return (n = this.tween(n)) && n._value;
   if (t == null) return this.tween(n, null);
   if (typeof t != "function") throw new Error();
-  var r = Gi(e);
-  return this.tween(n, (r.local ? ed : td)(r, t));
+  var r = Ki(e);
+  return this.tween(n, (r.local ? td : nd)(r, t));
 }
-function rd(e, t) {
+function id(e, t) {
   return function() {
     Qs(this, e).delay = +t.apply(this, arguments);
   };
 }
-function id(e, t) {
+function sd(e, t) {
   return t = +t, function() {
     Qs(this, e).delay = t;
   };
 }
-function sd(e) {
+function ad(e) {
   var t = this._id;
-  return arguments.length ? this.each((typeof e == "function" ? rd : id)(t, e)) : Et(this.node(), t).delay;
-}
-function ad(e, t) {
-  return function() {
-    Bt(this, e).duration = +t.apply(this, arguments);
-  };
+  return arguments.length ? this.each((typeof e == "function" ? id : sd)(t, e)) : Tt(this.node(), t).delay;
 }
 function od(e, t) {
-  return t = +t, function() {
-    Bt(this, e).duration = t;
+  return function() {
+    Xt(this, e).duration = +t.apply(this, arguments);
   };
 }
-function ld(e) {
-  var t = this._id;
-  return arguments.length ? this.each((typeof e == "function" ? ad : od)(t, e)) : Et(this.node(), t).duration;
+function ld(e, t) {
+  return t = +t, function() {
+    Xt(this, e).duration = t;
+  };
 }
-function ud(e, t) {
+function ud(e) {
+  var t = this._id;
+  return arguments.length ? this.each((typeof e == "function" ? od : ld)(t, e)) : Tt(this.node(), t).duration;
+}
+function fd(e, t) {
   if (typeof t != "function") throw new Error();
   return function() {
-    Bt(this, e).ease = t;
+    Xt(this, e).ease = t;
   };
 }
-function fd(e) {
+function cd(e) {
   var t = this._id;
-  return arguments.length ? this.each(ud(t, e)) : Et(this.node(), t).ease;
+  return arguments.length ? this.each(fd(t, e)) : Tt(this.node(), t).ease;
 }
-function cd(e, t) {
+function hd(e, t) {
   return function() {
     var n = t.apply(this, arguments);
     if (typeof n != "function") throw new Error();
-    Bt(this, e).ease = n;
+    Xt(this, e).ease = n;
   };
 }
-function hd(e) {
-  if (typeof e != "function") throw new Error();
-  return this.each(cd(this._id, e));
-}
 function dd(e) {
+  if (typeof e != "function") throw new Error();
+  return this.each(hd(this._id, e));
+}
+function pd(e) {
   typeof e != "function" && (e = tl(e));
   for (var t = this._groups, n = t.length, r = new Array(n), i = 0; i < n; ++i)
     for (var s = t[i], a = s.length, o = r[i] = [], l, u = 0; u < a; ++u)
       (l = s[u]) && e.call(l, l.__data__, u, s) && o.push(l);
-  return new hn(r, this._parents, this._name, this._id);
+  return new cn(r, this._parents, this._name, this._id);
 }
-function pd(e) {
+function vd(e) {
   if (e._id !== this._id) throw new Error();
   for (var t = this._groups, n = e._groups, r = t.length, i = n.length, s = Math.min(r, i), a = new Array(r), o = 0; o < s; ++o)
     for (var l = t[o], u = n[o], f = l.length, d = a[o] = new Array(f), h, p = 0; p < f; ++p)
       (h = l[p] || u[p]) && (d[p] = h);
   for (; o < r; ++o)
     a[o] = t[o];
-  return new hn(a, this._parents, this._name, this._id);
+  return new cn(a, this._parents, this._name, this._id);
 }
-function vd(e) {
+function gd(e) {
   return (e + "").trim().split(/^|\s+/).every(function(t) {
     var n = t.indexOf(".");
     return n >= 0 && (t = t.slice(0, n)), !t || t === "start";
   });
 }
-function gd(e, t, n) {
-  var r, i, s = vd(t) ? Qs : Bt;
+function _d(e, t, n) {
+  var r, i, s = gd(t) ? Qs : Xt;
   return function() {
     var a = s(this, e), o = a.on;
     o !== r && (i = (r = o).copy()).on(t, n), a.on = i;
   };
 }
-function _d(e, t) {
+function md(e, t) {
   var n = this._id;
-  return arguments.length < 2 ? Et(this.node(), n).on.on(e) : this.each(gd(n, e, t));
+  return arguments.length < 2 ? Tt(this.node(), n).on.on(e) : this.each(_d(n, e, t));
 }
-function md(e) {
+function yd(e) {
   return function() {
     var t = this.parentNode;
     for (var n in this.__transition) if (+n !== e) return;
     t && t.removeChild(this);
   };
 }
-function yd() {
-  return this.on("end.remove", md(this._id));
+function wd() {
+  return this.on("end.remove", yd(this._id));
 }
-function wd(e) {
+function xd(e) {
   var t = this._name, n = this._id;
   typeof e != "function" && (e = Gs(e));
   for (var r = this._groups, i = r.length, s = new Array(i), a = 0; a < i; ++a)
     for (var o = r[a], l = o.length, u = s[a] = new Array(l), f, d, h = 0; h < l; ++h)
-      (f = o[h]) && (d = e.call(f, f.__data__, h, o)) && ("__data__" in f && (d.__data__ = f.__data__), u[h] = d, ji(u[h], t, n, h, u, Et(f, n)));
-  return new hn(s, this._parents, t, n);
+      (f = o[h]) && (d = e.call(f, f.__data__, h, o)) && ("__data__" in f && (d.__data__ = f.__data__), u[h] = d, Ji(u[h], t, n, h, u, Tt(f, n)));
+  return new cn(s, this._parents, t, n);
 }
-function xd(e) {
+function bd(e) {
   var t = this._name, n = this._id;
   typeof e != "function" && (e = el(e));
   for (var r = this._groups, i = r.length, s = [], a = [], o = 0; o < i; ++o)
     for (var l = r[o], u = l.length, f, d = 0; d < u; ++d)
       if (f = l[d]) {
-        for (var h = e.call(f, f.__data__, d, l), p, y = Et(f, n), E = 0, _ = h.length; E < _; ++E)
-          (p = h[E]) && ji(p, t, n, E, h, y);
+        for (var h = e.call(f, f.__data__, d, l), p, y = Tt(f, n), E = 0, _ = h.length; E < _; ++E)
+          (p = h[E]) && Ji(p, t, n, E, h, y);
         s.push(h), a.push(f);
       }
-  return new hn(s, a, t, n);
+  return new cn(s, a, t, n);
 }
-var bd = Er.prototype.constructor;
-function $d() {
-  return new bd(this._groups, this._parents);
+var $d = Er.prototype.constructor;
+function Ad() {
+  return new $d(this._groups, this._parents);
 }
-function Ad(e, t) {
+function Ed(e, t) {
   var n, r, i;
   return function() {
     var s = xr(this, e), a = (this.style.removeProperty(e), xr(this, e));
@@ -4410,187 +4410,187 @@ function bl(e) {
     this.style.removeProperty(e);
   };
 }
-function Ed(e, t, n) {
+function Td(e, t, n) {
   var r, i = n + "", s;
   return function() {
     var a = xr(this, e);
     return a === i ? null : a === r ? s : s = t(r = a, n);
   };
 }
-function Td(e, t, n) {
+function Rd(e, t, n) {
   var r, i, s;
   return function() {
     var a = xr(this, e), o = n(this), l = o + "";
     return o == null && (l = o = (this.style.removeProperty(e), xr(this, e))), a === l ? null : a === r && l === i ? s : (i = l, s = t(r = a, o));
   };
 }
-function Rd(e, t) {
+function Sd(e, t) {
   var n, r, i, s = "style." + t, a = "end." + s, o;
   return function() {
-    var l = Bt(this, e), u = l.on, f = l.value[s] == null ? o || (o = bl(t)) : void 0;
+    var l = Xt(this, e), u = l.on, f = l.value[s] == null ? o || (o = bl(t)) : void 0;
     (u !== n || i !== f) && (r = (n = u).copy()).on(a, i = f), l.on = r;
   };
 }
-function Sd(e, t, n) {
-  var r = (e += "") == "transform" ? kh : xl;
-  return t == null ? this.styleTween(e, Ad(e, r)).on("end.style." + e, bl(e)) : typeof t == "function" ? this.styleTween(e, Td(e, r, ea(this, "style." + e, t))).each(Rd(this._id, e)) : this.styleTween(e, Ed(e, r, t), n).on("end.style." + e, null);
-}
 function Cd(e, t, n) {
+  var r = (e += "") == "transform" ? Ph : xl;
+  return t == null ? this.styleTween(e, Ed(e, r)).on("end.style." + e, bl(e)) : typeof t == "function" ? this.styleTween(e, Rd(e, r, ea(this, "style." + e, t))).each(Sd(this._id, e)) : this.styleTween(e, Td(e, r, t), n).on("end.style." + e, null);
+}
+function Nd(e, t, n) {
   return function(r) {
     this.style.setProperty(e, t.call(this, r), n);
   };
 }
-function Nd(e, t, n) {
+function kd(e, t, n) {
   var r, i;
   function s() {
     var a = t.apply(this, arguments);
-    return a !== i && (r = (i = a) && Cd(e, a, n)), r;
+    return a !== i && (r = (i = a) && Nd(e, a, n)), r;
   }
   return s._value = t, s;
 }
-function kd(e, t, n) {
+function Pd(e, t, n) {
   var r = "style." + (e += "");
   if (arguments.length < 2) return (r = this.tween(r)) && r._value;
   if (t == null) return this.tween(r, null);
   if (typeof t != "function") throw new Error();
-  return this.tween(r, Nd(e, t, n ?? ""));
+  return this.tween(r, kd(e, t, n ?? ""));
 }
-function Pd(e) {
+function Md(e) {
   return function() {
     this.textContent = e;
   };
 }
-function Md(e) {
+function Dd(e) {
   return function() {
     var t = e(this);
     this.textContent = t ?? "";
   };
 }
-function Dd(e) {
-  return this.tween("text", typeof e == "function" ? Md(ea(this, "text", e)) : Pd(e == null ? "" : e + ""));
-}
 function Od(e) {
+  return this.tween("text", typeof e == "function" ? Dd(ea(this, "text", e)) : Md(e == null ? "" : e + ""));
+}
+function Id(e) {
   return function(t) {
     this.textContent = e.call(this, t);
   };
 }
-function Id(e) {
+function Fd(e) {
   var t, n;
   function r() {
     var i = e.apply(this, arguments);
-    return i !== n && (t = (n = i) && Od(i)), t;
+    return i !== n && (t = (n = i) && Id(i)), t;
   }
   return r._value = e, r;
 }
-function Fd(e) {
+function Ld(e) {
   var t = "text";
   if (arguments.length < 1) return (t = this.tween(t)) && t._value;
   if (e == null) return this.tween(t, null);
   if (typeof e != "function") throw new Error();
-  return this.tween(t, Id(e));
+  return this.tween(t, Fd(e));
 }
-function Ld() {
+function qd() {
   for (var e = this._name, t = this._id, n = $l(), r = this._groups, i = r.length, s = 0; s < i; ++s)
     for (var a = r[s], o = a.length, l, u = 0; u < o; ++u)
       if (l = a[u]) {
-        var f = Et(l, t);
-        ji(l, e, n, u, a, {
+        var f = Tt(l, t);
+        Ji(l, e, n, u, a, {
           time: f.time + f.delay + f.duration,
           delay: 0,
           duration: f.duration,
           ease: f.ease
         });
       }
-  return new hn(r, this._parents, e, n);
+  return new cn(r, this._parents, e, n);
 }
-function qd() {
+function Vd() {
   var e, t, n = this, r = n._id, i = n.size();
   return new Promise(function(s, a) {
     var o = { value: a }, l = { value: function() {
       --i === 0 && s();
     } };
     n.each(function() {
-      var u = Bt(this, r), f = u.on;
+      var u = Xt(this, r), f = u.on;
       f !== e && (t = (e = f).copy(), t._.cancel.push(o), t._.interrupt.push(o), t._.end.push(l)), u.on = t;
     }), i === 0 && s();
   });
 }
-var Vd = 0;
-function hn(e, t, n, r) {
+var zd = 0;
+function cn(e, t, n, r) {
   this._groups = e, this._parents = t, this._name = n, this._id = r;
 }
-function bi(e) {
+function $i(e) {
   return Er().transition(e);
 }
 function $l() {
-  return ++Vd;
+  return ++zd;
 }
-var Zt = Er.prototype;
-hn.prototype = bi.prototype = {
-  constructor: hn,
-  select: wd,
-  selectAll: xd,
-  selectChild: Zt.selectChild,
-  selectChildren: Zt.selectChildren,
-  filter: dd,
-  merge: pd,
-  selection: $d,
-  transition: Ld,
-  call: Zt.call,
-  nodes: Zt.nodes,
-  node: Zt.node,
-  size: Zt.size,
-  empty: Zt.empty,
-  each: Zt.each,
-  on: _d,
-  attr: Jh,
-  attrTween: nd,
-  style: Sd,
-  styleTween: kd,
-  text: Dd,
-  textTween: Fd,
-  remove: yd,
-  tween: Bh,
-  delay: sd,
-  duration: ld,
-  ease: fd,
-  easeVarying: hd,
-  end: qd,
-  [Symbol.iterator]: Zt[Symbol.iterator]
+var Jt = Er.prototype;
+cn.prototype = $i.prototype = {
+  constructor: cn,
+  select: xd,
+  selectAll: bd,
+  selectChild: Jt.selectChild,
+  selectChildren: Jt.selectChildren,
+  filter: pd,
+  merge: vd,
+  selection: Ad,
+  transition: qd,
+  call: Jt.call,
+  nodes: Jt.nodes,
+  node: Jt.node,
+  size: Jt.size,
+  empty: Jt.empty,
+  each: Jt.each,
+  on: md,
+  attr: Zh,
+  attrTween: rd,
+  style: Cd,
+  styleTween: Pd,
+  text: Od,
+  textTween: Ld,
+  remove: wd,
+  tween: Xh,
+  delay: ad,
+  duration: ud,
+  ease: cd,
+  easeVarying: dd,
+  end: Vd,
+  [Symbol.iterator]: Jt[Symbol.iterator]
 };
-function zd(e) {
+function Hd(e) {
   return ((e *= 2) <= 1 ? e * e * e : (e -= 2) * e * e + 2) / 2;
 }
-var Hd = {
+var Yd = {
   time: null,
   // Set on use.
   delay: 0,
   duration: 250,
-  ease: zd
+  ease: Hd
 };
-function Yd(e, t) {
+function Bd(e, t) {
   for (var n; !(n = e.__transition) || !(n = n[t]); )
     if (!(e = e.parentNode))
       throw new Error(`transition ${t} not found`);
   return n;
 }
-function Bd(e) {
+function Xd(e) {
   var t, n;
-  e instanceof hn ? (t = e._id, e = e._name) : (t = $l(), (n = Hd).time = Zs(), e = e == null ? null : e + "");
+  e instanceof cn ? (t = e._id, e = e._name) : (t = $l(), (n = Yd).time = Zs(), e = e == null ? null : e + "");
   for (var r = this._groups, i = r.length, s = 0; s < i; ++s)
     for (var a = r[s], o = a.length, l, u = 0; u < o; ++u)
-      (l = a[u]) && ji(l, e, t, u, a, n || Yd(l, t));
-  return new hn(r, this._parents, e, t);
+      (l = a[u]) && Ji(l, e, t, u, a, n || Bd(l, t));
+  return new cn(r, this._parents, e, t);
 }
-Er.prototype.interrupt = zh;
-Er.prototype.transition = Bd;
-const Ms = Math.PI, Ds = 2 * Ms, Pn = 1e-6, Xd = Ds - Pn;
+Er.prototype.interrupt = Hh;
+Er.prototype.transition = Xd;
+const Ms = Math.PI, Ds = 2 * Ms, Pn = 1e-6, Wd = Ds - Pn;
 function Al(e) {
   this._ += e[0];
   for (let t = 1, n = e.length; t < n; ++t)
     this._ += arguments[t] + e[t];
 }
-function Wd(e) {
+function Ud(e) {
   let t = Math.floor(e);
   if (!(t >= 0)) throw new Error(`invalid digits: ${e}`);
   if (t > 15) return Al;
@@ -4601,10 +4601,10 @@ function Wd(e) {
       this._ += Math.round(arguments[i] * n) / n + r[i];
   };
 }
-class Ud {
+class Gd {
   constructor(t) {
     this._x0 = this._y0 = // start of current subpath
-    this._x1 = this._y1 = null, this._ = "", this._append = t == null ? Al : Wd(t);
+    this._x1 = this._y1 = null, this._ = "", this._append = t == null ? Al : Ud(t);
   }
   moveTo(t, n) {
     this._append`M${this._x0 = this._x1 = +t},${this._y0 = this._y1 = +n}`;
@@ -4636,7 +4636,7 @@ class Ud {
   arc(t, n, r, i, s, a) {
     if (t = +t, n = +n, r = +r, a = !!a, r < 0) throw new Error(`negative radius: ${r}`);
     let o = r * Math.cos(i), l = r * Math.sin(i), u = t + o, f = n + l, d = 1 ^ a, h = a ? i - s : s - i;
-    this._x1 === null ? this._append`M${u},${f}` : (Math.abs(this._x1 - u) > Pn || Math.abs(this._y1 - f) > Pn) && this._append`L${u},${f}`, r && (h < 0 && (h = h % Ds + Ds), h > Xd ? this._append`A${r},${r},0,1,${d},${t - o},${n - l}A${r},${r},0,1,${d},${this._x1 = u},${this._y1 = f}` : h > Pn && this._append`A${r},${r},0,${+(h >= Ms)},${d},${this._x1 = t + r * Math.cos(s)},${this._y1 = n + r * Math.sin(s)}`);
+    this._x1 === null ? this._append`M${u},${f}` : (Math.abs(this._x1 - u) > Pn || Math.abs(this._y1 - f) > Pn) && this._append`L${u},${f}`, r && (h < 0 && (h = h % Ds + Ds), h > Wd ? this._append`A${r},${r},0,1,${d},${t - o},${n - l}A${r},${r},0,1,${d},${this._x1 = u},${this._y1 = f}` : h > Pn && this._append`A${r},${r},0,${+(h >= Ms)},${d},${this._x1 = t + r * Math.cos(s)},${this._y1 = n + r * Math.sin(s)}`);
   }
   rect(t, n, r, i) {
     this._append`M${this._x0 = this._x1 = +t},${this._y0 = this._y1 = +n}h${r = +r}v${+i}h${-r}Z`;
@@ -4645,24 +4645,24 @@ class Ud {
     return this._;
   }
 }
-function Gd(e) {
+function Kd(e) {
   for (var t = e.length / 6 | 0, n = new Array(t), r = 0; r < t; ) n[r] = "#" + e.slice(r * 6, ++r * 6);
   return n;
 }
-const Kd = Gd("1f77b4ff7f0e2ca02cd627289467bd8c564be377c27f7f7fbcbd2217becf");
+const jd = Kd("1f77b4ff7f0e2ca02cd627289467bd8c564be377c27f7f7fbcbd2217becf");
 function Ie(e) {
   return function() {
     return e;
   };
 }
-const Ba = Math.abs, ke = Math.atan2, kn = Math.cos, jd = Math.max, fs = Math.min, Pt = Math.sin, sr = Math.sqrt, ze = 1e-12, Xr = Math.PI, Oi = Xr / 2, $i = 2 * Xr;
-function Jd(e) {
+const Ba = Math.abs, ke = Math.atan2, kn = Math.cos, Jd = Math.max, fs = Math.min, Mt = Math.sin, sr = Math.sqrt, ze = 1e-12, Xr = Math.PI, Ii = Xr / 2, Ai = 2 * Xr;
+function Zd(e) {
   return e > 1 ? 0 : e < -1 ? Xr : Math.acos(e);
 }
 function Xa(e) {
-  return e >= 1 ? Oi : e <= -1 ? -Oi : Math.asin(e);
+  return e >= 1 ? Ii : e <= -1 ? -Ii : Math.asin(e);
 }
-function Zd(e) {
+function Qd(e) {
   let t = 3;
   return e.digits = function(n) {
     if (!arguments.length) return t;
@@ -4674,31 +4674,31 @@ function Zd(e) {
       t = r;
     }
     return e;
-  }, () => new Ud(t);
-}
-function Qd(e) {
-  return e.innerRadius;
+  }, () => new Gd(t);
 }
 function ep(e) {
-  return e.outerRadius;
+  return e.innerRadius;
 }
 function tp(e) {
-  return e.startAngle;
+  return e.outerRadius;
 }
 function np(e) {
-  return e.endAngle;
+  return e.startAngle;
 }
 function rp(e) {
+  return e.endAngle;
+}
+function ip(e) {
   return e && e.padAngle;
 }
-function ip(e, t, n, r, i, s, a, o) {
+function sp(e, t, n, r, i, s, a, o) {
   var l = n - e, u = r - t, f = a - i, d = o - s, h = d * l - f * u;
   if (!(h * h < ze))
     return h = (f * (t - s) - d * (e - i)) / h, [e + h * l, t + h * u];
 }
-function ci(e, t, n, r, i, s, a) {
-  var o = e - n, l = t - r, u = (a ? s : -s) / sr(o * o + l * l), f = u * l, d = -u * o, h = e + f, p = t + d, y = n + f, E = r + d, _ = (h + y) / 2, x = (p + E) / 2, D = y - h, N = E - p, O = D * D + N * N, I = i - s, K = h * E - y * p, V = (N < 0 ? -1 : 1) * sr(jd(0, I * I * O - K * K)), Q = (K * N - D * V) / O, B = (-K * D - N * V) / O, U = (K * N + D * V) / O, fe = (-K * D + N * V) / O, ie = Q - _, M = B - x, z = U - _, Se = fe - x;
-  return ie * ie + M * M > z * z + Se * Se && (Q = U, B = fe), {
+function hi(e, t, n, r, i, s, a) {
+  var o = e - n, l = t - r, u = (a ? s : -s) / sr(o * o + l * l), f = u * l, d = -u * o, h = e + f, p = t + d, y = n + f, E = r + d, _ = (h + y) / 2, x = (p + E) / 2, D = y - h, N = E - p, O = D * D + N * N, I = i - s, K = h * E - y * p, V = (N < 0 ? -1 : 1) * sr(Jd(0, I * I * O - K * K)), Q = (K * N - D * V) / O, B = (-K * D - N * V) / O, G = (K * N + D * V) / O, fe = (-K * D + N * V) / O, ie = Q - _, M = B - x, z = G - _, Se = fe - x;
+  return ie * ie + M * M > z * z + Se * Se && (Q = G, B = fe), {
     cx: Q,
     cy: B,
     x01: -f,
@@ -4707,36 +4707,36 @@ function ci(e, t, n, r, i, s, a) {
     y11: B * (i / I - 1)
   };
 }
-function _t() {
-  var e = Qd, t = ep, n = Ie(0), r = null, i = tp, s = np, a = rp, o = null, l = Zd(u);
+function mt() {
+  var e = ep, t = tp, n = Ie(0), r = null, i = np, s = rp, a = ip, o = null, l = Qd(u);
   function u() {
-    var f, d, h = +e.apply(this, arguments), p = +t.apply(this, arguments), y = i.apply(this, arguments) - Oi, E = s.apply(this, arguments) - Oi, _ = Ba(E - y), x = E > y;
+    var f, d, h = +e.apply(this, arguments), p = +t.apply(this, arguments), y = i.apply(this, arguments) - Ii, E = s.apply(this, arguments) - Ii, _ = Ba(E - y), x = E > y;
     if (o || (o = f = l()), p < h && (d = p, p = h, h = d), !(p > ze)) o.moveTo(0, 0);
-    else if (_ > $i - ze)
-      o.moveTo(p * kn(y), p * Pt(y)), o.arc(0, 0, p, y, E, !x), h > ze && (o.moveTo(h * kn(E), h * Pt(E)), o.arc(0, 0, h, E, y, x));
+    else if (_ > Ai - ze)
+      o.moveTo(p * kn(y), p * Mt(y)), o.arc(0, 0, p, y, E, !x), h > ze && (o.moveTo(h * kn(E), h * Mt(E)), o.arc(0, 0, h, E, y, x));
     else {
-      var D = y, N = E, O = y, I = E, K = _, V = _, Q = a.apply(this, arguments) / 2, B = Q > ze && (r ? +r.apply(this, arguments) : sr(h * h + p * p)), U = fs(Ba(p - h) / 2, +n.apply(this, arguments)), fe = U, ie = U, M, z;
+      var D = y, N = E, O = y, I = E, K = _, V = _, Q = a.apply(this, arguments) / 2, B = Q > ze && (r ? +r.apply(this, arguments) : sr(h * h + p * p)), G = fs(Ba(p - h) / 2, +n.apply(this, arguments)), fe = G, ie = G, M, z;
       if (B > ze) {
-        var Se = Xa(B / h * Pt(Q)), Ge = Xa(B / p * Pt(Q));
+        var Se = Xa(B / h * Mt(Q)), Ge = Xa(B / p * Mt(Q));
         (K -= Se * 2) > ze ? (Se *= x ? 1 : -1, O += Se, I -= Se) : (K = 0, O = I = (y + E) / 2), (V -= Ge * 2) > ze ? (Ge *= x ? 1 : -1, D += Ge, N -= Ge) : (V = 0, D = N = (y + E) / 2);
       }
-      var se = p * kn(D), Pe = p * Pt(D), me = h * kn(I), ye = h * Pt(I);
-      if (U > ze) {
-        var at = p * kn(N), Ce = p * Pt(N), Tt = h * kn(O), Rt = h * Pt(O), Y;
+      var se = p * kn(D), Pe = p * Mt(D), ge = h * kn(I), _e = h * Mt(I);
+      if (G > ze) {
+        var ot = p * kn(N), Ce = p * Mt(N), Rt = h * kn(O), St = h * Mt(O), Y;
         if (_ < Xr)
-          if (Y = ip(se, Pe, Tt, Rt, at, Ce, me, ye)) {
-            var Me = se - Y[0], Xt = Pe - Y[1], ae = at - Y[0], Wt = Ce - Y[1], Rn = 1 / Pt(Jd((Me * ae + Xt * Wt) / (sr(Me * Me + Xt * Xt) * sr(ae * ae + Wt * Wt))) / 2), Ut = sr(Y[0] * Y[0] + Y[1] * Y[1]);
-            fe = fs(U, (h - Ut) / (Rn - 1)), ie = fs(U, (p - Ut) / (Rn + 1));
+          if (Y = sp(se, Pe, Rt, St, ot, Ce, ge, _e)) {
+            var Me = se - Y[0], Wt = Pe - Y[1], ae = ot - Y[0], Ut = Ce - Y[1], Rn = 1 / Mt(Zd((Me * ae + Wt * Ut) / (sr(Me * Me + Wt * Wt) * sr(ae * ae + Ut * Ut))) / 2), Gt = sr(Y[0] * Y[0] + Y[1] * Y[1]);
+            fe = fs(G, (h - Gt) / (Rn - 1)), ie = fs(G, (p - Gt) / (Rn + 1));
           } else
             fe = ie = 0;
       }
-      V > ze ? ie > ze ? (M = ci(Tt, Rt, se, Pe, p, ie, x), z = ci(at, Ce, me, ye, p, ie, x), o.moveTo(M.cx + M.x01, M.cy + M.y01), ie < U ? o.arc(M.cx, M.cy, ie, ke(M.y01, M.x01), ke(z.y01, z.x01), !x) : (o.arc(M.cx, M.cy, ie, ke(M.y01, M.x01), ke(M.y11, M.x11), !x), o.arc(0, 0, p, ke(M.cy + M.y11, M.cx + M.x11), ke(z.cy + z.y11, z.cx + z.x11), !x), o.arc(z.cx, z.cy, ie, ke(z.y11, z.x11), ke(z.y01, z.x01), !x))) : (o.moveTo(se, Pe), o.arc(0, 0, p, D, N, !x)) : o.moveTo(se, Pe), !(h > ze) || !(K > ze) ? o.lineTo(me, ye) : fe > ze ? (M = ci(me, ye, at, Ce, h, -fe, x), z = ci(se, Pe, Tt, Rt, h, -fe, x), o.lineTo(M.cx + M.x01, M.cy + M.y01), fe < U ? o.arc(M.cx, M.cy, fe, ke(M.y01, M.x01), ke(z.y01, z.x01), !x) : (o.arc(M.cx, M.cy, fe, ke(M.y01, M.x01), ke(M.y11, M.x11), !x), o.arc(0, 0, h, ke(M.cy + M.y11, M.cx + M.x11), ke(z.cy + z.y11, z.cx + z.x11), x), o.arc(z.cx, z.cy, fe, ke(z.y11, z.x11), ke(z.y01, z.x01), !x))) : o.arc(0, 0, h, I, O, x);
+      V > ze ? ie > ze ? (M = hi(Rt, St, se, Pe, p, ie, x), z = hi(ot, Ce, ge, _e, p, ie, x), o.moveTo(M.cx + M.x01, M.cy + M.y01), ie < G ? o.arc(M.cx, M.cy, ie, ke(M.y01, M.x01), ke(z.y01, z.x01), !x) : (o.arc(M.cx, M.cy, ie, ke(M.y01, M.x01), ke(M.y11, M.x11), !x), o.arc(0, 0, p, ke(M.cy + M.y11, M.cx + M.x11), ke(z.cy + z.y11, z.cx + z.x11), !x), o.arc(z.cx, z.cy, ie, ke(z.y11, z.x11), ke(z.y01, z.x01), !x))) : (o.moveTo(se, Pe), o.arc(0, 0, p, D, N, !x)) : o.moveTo(se, Pe), !(h > ze) || !(K > ze) ? o.lineTo(ge, _e) : fe > ze ? (M = hi(ge, _e, ot, Ce, h, -fe, x), z = hi(se, Pe, Rt, St, h, -fe, x), o.lineTo(M.cx + M.x01, M.cy + M.y01), fe < G ? o.arc(M.cx, M.cy, fe, ke(M.y01, M.x01), ke(z.y01, z.x01), !x) : (o.arc(M.cx, M.cy, fe, ke(M.y01, M.x01), ke(M.y11, M.x11), !x), o.arc(0, 0, h, ke(M.cy + M.y11, M.cx + M.x11), ke(z.cy + z.y11, z.cx + z.x11), x), o.arc(z.cx, z.cy, fe, ke(z.y11, z.x11), ke(z.y01, z.x01), !x))) : o.arc(0, 0, h, I, O, x);
     }
     if (o.closePath(), f) return o = null, f + "" || null;
   }
   return u.centroid = function() {
     var f = (+e.apply(this, arguments) + +t.apply(this, arguments)) / 2, d = (+i.apply(this, arguments) + +s.apply(this, arguments)) / 2 - Xr / 2;
-    return [kn(d) * f, Pt(d) * f];
+    return [kn(d) * f, Mt(d) * f];
   }, u.innerRadius = function(f) {
     return arguments.length ? (e = typeof f == "function" ? f : Ie(+f), u) : e;
   }, u.outerRadius = function(f) {
@@ -4755,19 +4755,19 @@ function _t() {
     return arguments.length ? (o = f ?? null, u) : o;
   }, u;
 }
-function sp(e) {
+function ap(e) {
   return typeof e == "object" && "length" in e ? e : Array.from(e);
 }
-function ap(e, t) {
+function op(e, t) {
   return t < e ? -1 : t > e ? 1 : t >= e ? 0 : NaN;
 }
-function op(e) {
+function lp(e) {
   return e;
 }
 function cs() {
-  var e = op, t = ap, n = null, r = Ie(0), i = Ie($i), s = Ie(0);
+  var e = lp, t = op, n = null, r = Ie(0), i = Ie(Ai), s = Ie(0);
   function a(o) {
-    var l, u = (o = sp(o)).length, f, d, h = 0, p = new Array(u), y = new Array(u), E = +r.apply(this, arguments), _ = Math.min($i, Math.max(-$i, i.apply(this, arguments) - E)), x, D = Math.min(Math.abs(_) / u, s.apply(this, arguments)), N = D * (_ < 0 ? -1 : 1), O;
+    var l, u = (o = ap(o)).length, f, d, h = 0, p = new Array(u), y = new Array(u), E = +r.apply(this, arguments), _ = Math.min(Ai, Math.max(-Ai, i.apply(this, arguments) - E)), x, D = Math.min(Math.abs(_) / u, s.apply(this, arguments)), N = D * (_ < 0 ? -1 : 1), O;
     for (l = 0; l < u; ++l)
       (O = y[p[l] = l] = +e(o[l], l, o)) > 0 && (h += O);
     for (t != null ? p.sort(function(I, K) {
@@ -4839,8 +4839,8 @@ Ir.prototype = {
   }
 };
 Ir.prototype;
-var lp = /* @__PURE__ */ sf('<svg class="pie-chart-svg svelte-80ulj4"><defs><filter id="text-top-filter"><feBlend mode="normal" in="SourceGraphic" in2="BackgroundImage"></feBlend></filter><pattern id="cross-hatch" width="7" height="7" patternUnits="userSpaceOnUse"><rect width="7" height="7" fill="transparent"></rect><circle cx="1.75" cy="1.75" r="1.5" fill="lightgray"></circle><circle cx="5.25" cy="5.25" r="1.5" fill="lightgray"></circle></pattern></defs></svg>');
-const up = {
+var up = /* @__PURE__ */ af('<svg class="pie-chart-svg svelte-80ulj4"><defs><filter id="text-top-filter"><feBlend mode="normal" in="SourceGraphic" in2="BackgroundImage"></feBlend></filter><pattern id="cross-hatch" width="7" height="7" patternUnits="userSpaceOnUse"><rect width="7" height="7" fill="transparent"></rect><circle cx="1.75" cy="1.75" r="1.5" fill="lightgray"></circle><circle cx="5.25" cy="5.25" r="1.5" fill="lightgray"></circle></pattern></defs></svg>');
+const fp = {
   hash: "svelte-80ulj4",
   code: `.pie-chart-svg.svelte-80ulj4 {width:100%;height:100%;max-width:700px;max-height:60vh;aspect-ratio:1 / 1; /* For a perfect circle, use 1:1 ratio */margin:0 auto;display:block;}
 
@@ -4848,28 +4848,28 @@ const up = {
 }`
 };
 function El(e, t) {
-  Yi(t, !0), Ws(e, up);
+  Bi(t, !0), Ws(e, fp);
   let n = ee(t, "jsonData", 7), r = ee(t, "currentRound", 7, 1), i = ee(t, "mouseEventType", 15), s = ee(t, "mouseData", 15), a = ee(t, "mouseX", 15), o = ee(t, "mouseY", 15), l = ee(t, "requestRoundChange", 7, (c) => {
   }), u = ee(t, "requestSkipToRound", 7, (c) => {
   }), f = ee(t, "candidateColors", 23, () => []), d = ee(t, "excludeFinalWinnerAndEliminatedCandidate", 7, !1), h = ee(t, "firstRoundDeterminesPercentages", 7, !1), p = ee(t, "showVotes", 7, !0), y = ee(t, "showPercent", 7, !0), E = ee(t, "randomizeOrder", 7, !1), _ = ee(t, "displayPhase", 15, 0);
   function x(c) {
     return c.isTransfer ? `${c.label}__transfer` : c.transferIndex != null ? `${c.label}__${c.transferIndex}` : c.label;
   }
-  const D = 800, N = 800, O = Math.min(D, N) * 0.3, I = D / 2, K = N / 2, V = "Pie", Q = "PieOutline", B = "Donut", U = "TextLayer", fe = "url(#cross-hatch)", ie = 1.15, M = 750, z = 800, Se = "white", Ge = 1, se = "#ff00ff", Pe = 3;
-  function me(c) {
+  const D = 800, N = 800, O = Math.min(D, N) * 0.3, I = D / 2, K = N / 2, V = "Pie", Q = "PieOutline", B = "Donut", G = "TextLayer", fe = "url(#cross-hatch)", ie = 1.15, M = 750, z = 800, Se = "white", Ge = 1, se = "#ff00ff", Pe = 3;
+  function ge(c) {
     return "hatch-" + c.replace(/[^a-zA-Z0-9]/g, "-");
   }
-  let ye = [], at = [], Ce = [], Tt = null, Rt = 0, Y = 0;
-  const Me = {}, Xt = "No Further Rankings";
+  let _e = [], ot = [], Ce = [], Rt = null, St = 0, Y = 0;
+  const Me = {}, Wt = "No Further Rankings";
   let ae = /* @__PURE__ */ xe(null);
-  function Wt() {
+  function Ut() {
     const c = ue(A(ae));
-    c.select("#" + V).remove(), c.select("#" + Q).remove(), c.select("#" + B).remove(), c.select("#" + U).remove();
+    c.select("#" + V).remove(), c.select("#" + Q).remove(), c.select("#" + B).remove(), c.select("#" + G).remove();
   }
   function Rn(c) {
     l() && ($e = c, l()(c));
   }
-  function Ut(c) {
+  function Gt(c) {
     var m;
     if (!((m = n()) != null && m.results) || c < 1 || c > n().results.length) return !1;
     const v = n().results[c - 1].tallyResults;
@@ -4877,23 +4877,23 @@ function El(e, t) {
   }
   function Tr(c) {
     for (let v = c; v < n().results.length; v++)
-      if (Ut(v)) return v;
+      if (Gt(v)) return v;
     return n().results.length;
   }
   function Sn(c) {
-    Wt(), Ce = Ji(c), ye = sa(c, V, Ce, I, K, 0, Ke()), sa(c, Q, Ce, I, K, 0, Ke(), !1, !1, !0), Cr();
+    Ut(), Ce = Zi(c), _e = sa(c, V, Ce, I, K, 0, Ke()), sa(c, Q, Ce, I, K, 0, Ke(), !1, !1, !0), Cr();
   }
-  cf(() => {
-    vn(), setTimeout(
+  hf(() => {
+    tr(), setTimeout(
       () => {
         Sn(r());
       },
       0
     );
   });
-  function Ji(c) {
-    const v = qe(c);
-    return Rt = Qi(1), v;
+  function Zi(c) {
+    const v = kt(c);
+    return St = es(1), v;
   }
   function Ke() {
     return O;
@@ -4901,7 +4901,7 @@ function El(e, t) {
   function Rr() {
     return Ke() * 1.41;
   }
-  function pn(c) {
+  function dn(c) {
     let v = 0;
     for (let m = 1; m < c; m++) {
       const $ = n().results[m - 1].tallyResults;
@@ -4916,24 +4916,24 @@ function El(e, t) {
     return v;
   }
   function Qn(c, v) {
-    if (c === "exhausted") return pn(v);
+    if (c === "exhausted") return dn(v);
     {
       const m = n().results[v - 1].tally;
       return Number(m[c]);
     }
   }
-  function Zi(c, v) {
+  function Qi(c, v) {
     return Qn(c, v).toLocaleString("en-US");
   }
   function ti(c, v) {
-    const m = h() ? Rt : G(v);
+    const m = h() ? St : le(v);
     return (Qn(c, v) / m).toLocaleString("en-US", { style: "percent", minimumFractionDigits: 1 });
   }
   function er(c, v) {
-    const m = Zi(c, v), $ = w(c) && !h(), b = y() && !$;
+    const m = Qi(c, v), $ = w(c) && !h(), b = y() && !$;
     return p() && b ? m + " (" + ti(c, v) + ")" : b ? ti(c, v) : m;
   }
-  function Qi(c) {
+  function es(c) {
     const v = n().results[c - 1].tally;
     let m = 0;
     for (let [$, b] of Object.entries(v))
@@ -4943,14 +4943,17 @@ function El(e, t) {
   function w(c) {
     return c === "exhausted" || c === "Inactive Ballots";
   }
-  function G(c) {
+  function X(c) {
+    return c.toLowerCase() === "residual surplus";
+  }
+  function le(c) {
     const v = n().results[c - 1].tally;
     let m = 0;
     for (let [$, b] of Object.entries(v))
-      w($) || (m += Number(b));
+      !w($) && !X($) && (m += Number(b));
     return m;
   }
-  function oe(c, v) {
+  function me(c, v) {
     if (!c || c < 1 || c > n().results.length)
       return console.warn("In chosenCandidates: round ${round} is out of range."), [];
     if (d() && c === n().results.length)
@@ -4962,15 +4965,15 @@ function El(e, t) {
     }
     return $;
   }
-  function he(c) {
-    return oe(c, "eliminated");
+  function ce(c) {
+    return me(c, "eliminated");
   }
-  function ge(c) {
+  function oe(c) {
     let v = [];
-    for (let m = 1; m <= c; m++) v = v.concat(oe(m, "elected"));
+    for (let m = 1; m <= c; m++) v = v.concat(me(m, "elected"));
     return [...new Set(v)];
   }
-  function le(c, v) {
+  function qe(c, v) {
     const m = n().results[v - 1].tallyResults;
     let $ = 0;
     const b = m.findIndex((T) => (T == null ? void 0 : T.elected) && c == T.elected);
@@ -4982,10 +4985,10 @@ function El(e, t) {
       return 0;
     return $;
   }
-  function De(c, v) {
-    c.some((m) => w(m.label)) || c.push({ label: "exhausted", value: pn(v) });
+  function Ct(c, v) {
+    c.some((m) => w(m.label)) || c.push({ label: "exhausted", value: dn(v) });
   }
-  function Gt(c) {
+  function Nt(c) {
     let v = c | 0;
     return () => {
       v = v + 1831565813 | 0;
@@ -4993,46 +4996,46 @@ function El(e, t) {
       return m = m + Math.imul(m ^ m >>> 7, 61 | m) ^ m, ((m ^ m >>> 14) >>> 0) / 4294967296;
     };
   }
-  function St(c) {
+  function Cn(c) {
     let v = 5381;
     for (let m = 0; m < c.length; m++)
       v = (v << 5) + v + c.charCodeAt(m) | 0;
     return v;
   }
-  function Cn(c) {
+  function pn(c) {
     var b;
     if (c.length <= 3) return c;
-    const v = St(((b = n().config) == null ? void 0 : b.contest) ?? ""), m = Gt(v), $ = [...c];
+    const v = Cn(((b = n().config) == null ? void 0 : b.contest) ?? ""), m = Nt(v), $ = [...c];
     for (let T = $.length - 1; T > 0; T--) {
       const P = Math.floor(m() * (T + 1));
       [$[T], $[P]] = [$[P], $[T]];
     }
     return $;
   }
-  function Kt() {
-    const c = Object.keys(n().results[0].tally), v = c.filter((b) => !w(b)), m = c.filter((b) => w(b));
-    return [...E() ? Cn(v) : v, ...m];
+  function De() {
+    const c = Object.keys(n().results[0].tally).filter((b) => !X(b)), v = c.filter((b) => !w(b)), m = c.filter((b) => w(b));
+    return [...E() ? pn(v) : v, ...m];
   }
-  function qe(c) {
+  function kt(c) {
     const v = n().results[c - 1].tally, m = [];
-    for (const $ of Kt())
+    for (const $ of De())
       $ in v && m.push({ label: $, value: Number(v[$]) });
-    return De(m, c), m;
+    return Ct(m, c), m;
   }
-  function Ct(c) {
+  function lt(c) {
     const v = n().results[c - 1].tally, m = [];
-    for (const $ of Kt())
+    for (const $ of De())
       m.push({ label: $, value: Number(v[$] ?? 0) });
-    return De(m, c), m;
+    return Ct(m, c), m;
   }
-  function ot(c, v) {
+  function vn(c, v) {
     const m = [];
     for (const $ of c) {
       if ($.label === "exhausted" || $.isTransfer) {
         m.push($);
         continue;
       }
-      const b = le($.label, v);
+      const b = qe($.label, v);
       b > 0 ? (m.push({
         label: $.label,
         value: b,
@@ -5041,49 +5044,49 @@ function El(e, t) {
     }
     return m;
   }
-  function vn() {
+  function tr() {
     const c = ue(A(ae)).select("defs").select("#cross-hatch");
     let v = 0;
     for (let [m, $] of Object.entries(n().results[0].tally)) {
-      !f() || f().length === 0 ? v < 10 ? Me[m] = Kd[v] : Me[m] = "#" + Math.floor(Math.random() * 16777215).toString(16).padStart(6, "0") : Me[m] = f()[v % f().length], v++;
+      !f() || f().length === 0 ? v < 10 ? Me[m] = jd[v] : Me[m] = "#" + Math.floor(Math.random() * 16777215).toString(16).padStart(6, "0") : Me[m] = f()[v % f().length], v++;
       {
         const b = c.clone(!0);
-        b.attr("id", me(m)).select("rect").attr("fill", Me[m]), b.selectAll("circle").attr("fill", "#383838");
+        b.attr("id", ge(m)).select("rect").attr("fill", Me[m]), b.selectAll("circle").attr("fill", "#383838");
       }
     }
     Me.exhausted = fe, Me["Inactive Ballots"] = fe;
   }
-  function tr() {
+  function nr() {
     ue(A(ae)).select("#" + B).remove();
   }
-  function jt(c, v) {
-    const m = bi("global").duration(z);
+  function Kt(c, v) {
+    const m = $i("global").duration(z);
     v && m.on("end", v);
-    const $ = ot(Ce, c), T = cs().sort(null).value((P) => P.value)($);
-    ua(c, V, T, 0, Ke()), ua(c, Q, T, 0, Ke(), !0), Ce = $, ye = T, tr(), Pl(c), ql(), zl(0, Ke()), Cr();
+    const $ = vn(Ce, c), T = cs().sort(null).value((P) => P.value)($);
+    ua(c, V, T, 0, Ke()), ua(c, Q, T, 0, Ke(), !0), Ce = $, _e = T, nr(), Ml(c), Vl(), Hl(0, Ke()), Cr();
   }
-  function Nt(c, v) {
-    const m = bi("global").duration(z);
-    v && m.on("end", v), Ml(c);
+  function je(c, v) {
+    const m = $i("global").duration(z);
+    v && m.on("end", v), Dl(c);
   }
   function Ve(c, v) {
-    const m = bi("global").duration(z);
-    v && m.on("end", v), Nl(c), kl(Ke(), Rr());
+    const m = $i("global").duration(z);
+    v && m.on("end", v), kl(c), Pl(Ke(), Rr());
   }
-  let ce = !1, lt = [];
-  function je() {
-    Cr(), ce = !1, gn();
+  let ye = !1, _t = [];
+  function Je() {
+    Cr(), ye = !1, gn();
   }
   function gn() {
-    if (lt.length === 0) {
-      $e !== r() && (r() === $e + 1 && $e > 0 && r() <= n().results.length ? ($e = r(), nr(r())) : r() >= 1 && r() <= n().results.length && ($e = r(), _(0), Sn(r())));
+    if (_t.length === 0) {
+      $e !== r() && (r() === $e + 1 && $e > 0 && r() <= n().results.length ? ($e = r(), Pt(r())) : r() >= 1 && r() <= n().results.length && ($e = r(), _(0), Sn(r())));
       return;
     }
-    const c = lt.shift();
+    const c = _t.shift();
     switch (c.type) {
       case "round": {
         const v = c.round;
-        v === $e + 1 && $e > 0 && v <= n().results.length ? ($e = v, nr(v)) : (v !== $e && v >= 1 && v <= n().results.length && ($e = v, _(0), Sn(v)), gn());
+        v === $e + 1 && $e > 0 && v <= n().results.length ? ($e = v, Pt(v)) : (v !== $e && v >= 1 && v <= n().results.length && ($e = v, _(0), Sn(v)), gn());
         break;
       }
       case "step":
@@ -5091,66 +5094,66 @@ function El(e, t) {
         break;
     }
   }
-  function nr(c) {
+  function Pt(c) {
     if (c <= 1 || c > n().results.length) {
       gn();
       return;
     }
-    ce = !0, Y = c, _(0), jt(Y - 1, () => {
-      _(1), Nt(Y - 1, () => {
+    ye = !0, Y = c, _(0), Kt(Y - 1, () => {
+      _(1), je(Y - 1, () => {
         _(2), Ve(Y, () => {
-          _(0), je();
+          _(0), Je();
         });
       });
     });
   }
-  function Jt() {
-    ce || (ce = !0, Y = r(), kt());
+  function jt() {
+    ye || (ye = !0, Y = r(), ni());
   }
-  function kt() {
+  function ni() {
     if (_(
       0
       // if in the middle of "one small step" animation, reset to 0.
-    ), lt.length > 0) {
-      je();
+    ), _t.length > 0) {
+      Je();
       return;
     }
-    const c = Y < n().results.length - 1 ? kt : () => {
-      _(0), je();
+    const c = Y < n().results.length - 1 ? ni : () => {
+      _(0), Je();
     };
-    jt(Y, () => {
-      _(1), Nt(Y, () => {
+    Kt(Y, () => {
+      _(1), je(Y, () => {
         _(2), Y++, Rn(Y), Ve(Y, c);
       });
     });
   }
-  Ri(() => {
-    Rl();
+  Si(() => {
+    Sl();
   });
-  function es() {
-    if (!Tt) return;
-    ue(A(ae)).select("#" + U).remove();
-    const c = Tt;
+  function Rl() {
+    if (!Rt) return;
+    ue(A(ae)).select("#" + G).remove();
+    const c = Rt;
     ts(c.round, c.pieInfo, c.x, c.y, c.outerRadius, c.eliminated);
   }
   let na = !1;
-  Ri(() => {
+  Si(() => {
     if (h(), p(), y(), !na) {
       na = !0;
       return;
     }
-    ce || Qr(() => es());
+    ye || Qr(() => Rl());
   });
   let $e = 0;
-  function Rl() {
+  function Sl() {
     if ($e != r()) {
-      if (ce) {
-        lt.push({ type: "round", round: r() });
+      if (ye) {
+        _t.push({ type: "round", round: r() });
         return;
       }
       if ($e == r() - 1 && $e > 0)
-        if (Ut($e))
-          Cl();
+        if (Gt($e))
+          Nl();
         else {
           const c = Tr(r());
           if (u()) {
@@ -5159,20 +5162,20 @@ function El(e, t) {
           }
         }
       else
-        Sl(r());
+        Cl(r());
       $e = r();
     }
   }
-  function Sl(c) {
-    if (ce) {
-      lt.push({ type: "round", round: c });
+  function Cl(c) {
+    if (ye) {
+      _t.push({ type: "round", round: c });
       return;
     }
     _(0), Sn(c);
   }
-  function Cl() {
-    if (ce) {
-      lt.push({ type: "round", round: r() });
+  function Nl() {
+    if (ye) {
+      _t.push({ type: "round", round: r() });
       return;
     }
     if (r() <= 1) {
@@ -5180,49 +5183,49 @@ function El(e, t) {
       return;
     }
     if (Y = r(), Y > n().results.length) {
-      Cr(), ce = !1;
+      Cr(), ye = !1;
       return;
     }
-    ce = !0, _() === 0 ? jt(Y - 1, () => {
-      _(1), Nt(Y - 1, () => {
+    ye = !0, _() === 0 ? Kt(Y - 1, () => {
+      _(1), je(Y - 1, () => {
         _(2), Ve(Y, () => {
-          _(0), je();
+          _(0), Je();
         });
       });
-    }) : _() === 1 ? Nt(Y - 1, () => {
+    }) : _() === 1 ? je(Y - 1, () => {
       _(2), Ve(Y, () => {
-        _(0), je();
+        _(0), Je();
       });
     }) : _() === 2 && Ve(Y, () => {
-      _(0), je();
+      _(0), Je();
     });
   }
   function ra() {
     if (r() > n().results.length) {
-      Cr(), ce = !1;
+      Cr(), ye = !1;
       return;
     }
-    if (ce) {
-      lt.push({ type: "step" });
+    if (ye) {
+      _t.push({ type: "step" });
       return;
     }
-    ce = !0, Y = r(), _() === 0 ? jt(Y, () => {
-      _(1), je();
-    }) : _() === 1 ? Nt(Y, () => {
-      _(2), je();
+    ye = !0, Y = r(), _() === 0 ? Kt(Y, () => {
+      _(1), Je();
+    }) : _() === 1 ? je(Y, () => {
+      _(2), Je();
     }) : _() === 2 ? (Y++, Rn(Y), Ve(Y, () => {
-      _(0), je();
-    })) : (ce = !1, console.warn("displayPhase out of range at ", _()));
+      _(0), Je();
+    })) : (ye = !1, console.warn("displayPhase out of range at ", _()));
   }
-  function Nl(c) {
-    const v = Ct(c), m = new Set(Ce.filter((b) => b.isTransfer).map((b) => b.label)), $ = [];
+  function kl(c) {
+    const v = lt(c), m = new Set(Ce.filter((b) => b.isTransfer).map((b) => b.label)), $ = [];
     for (const b of v)
       m.has(b.label) && $.push({ label: b.label, value: 0, isTransfer: !0 }), $.push(b);
-    Ce = v, ye = oa(c, V, $, 0, Ke(), !0), oa(c, Q, $, 0, Ke(), !1, !0);
+    Ce = v, _e = oa(c, V, $, 0, Ke(), !0), oa(c, Q, $, 0, Ke(), !1, !0);
   }
-  function kl(c, v) {
+  function Pl(c, v) {
     const m = ue(A(ae)).select("#" + B), b = ue(A(ae)).select("#" + V), T = {};
-    for (const C of ye) {
+    for (const C of _e) {
       const k = C.data.label;
       if (C.data.isTransfer) continue;
       const R = b.select("#" + CSS.escape(x(C.data)));
@@ -5236,36 +5239,36 @@ function El(e, t) {
     const P = m.selectAll(".slice");
     let q = P.size();
     function F() {
-      q--, q === 0 && Vl();
+      q--, q === 0 && zl();
     }
     P.select("path").transition("global").duration(M).attrTween("d", function(C) {
       const k = C.startAngle, R = C.endAngle, S = R - k, Ne = T[C.data.label];
-      let ne, Je;
+      let ne, Ze;
       if (Ne) {
-        const rr = (Ne.oldStart + Ne.oldEnd) / 2, Xl = (Ne.newStart + Ne.newEnd) / 2, Wl = k - rr;
-        ne = Xl + Wl, Je = ne + S;
+        const rr = (Ne.oldStart + Ne.oldEnd) / 2, Wl = (Ne.newStart + Ne.newEnd) / 2, Ul = k - rr;
+        ne = Wl + Ul, Ze = ne + S;
       } else
-        ne = k, Je = R;
-      const re = Qt(k, ne), ut = Qt(R, Je), ri = Qt(v, c), Nr = _t();
+        ne = k, Ze = R;
+      const re = Zt(k, ne), ut = Zt(R, Ze), ii = Zt(v, c), Nr = mt();
       return function(rr) {
-        return Nr.innerRadius(Math.min(ri(rr), c) - 1).outerRadius(ri(rr)).startAngle(re(rr)).endAngle(ut(rr)), Nr(C);
+        return Nr.innerRadius(Math.min(ii(rr), c) - 1).outerRadius(ii(rr)).startAngle(re(rr)).endAngle(ut(rr)), Nr(C);
       };
     }).on("end", (C) => F());
   }
-  function Pl(c) {
-    const v = Ol(c, ye);
-    at = aa(c, B, v, I, K, Ke(), Rr(), !1, !0);
+  function Ml(c) {
+    const v = Il(c, _e);
+    ot = aa(c, B, v, I, K, Ke(), Rr(), !1, !0);
     const m = ue(A(ae));
     m.select("#" + V).raise(), m.select("#" + Q).raise();
   }
-  function Ml(c) {
-    const v = Fl(c, at, ye);
-    at = fa(c, B, v, Ke(), Rr(), !1);
+  function Dl(c) {
+    const v = Ll(c, ot, _e);
+    ot = fa(c, B, v, Ke(), Rr(), !1);
   }
   function Sr(c) {
     return Me[c.data.label];
   }
-  function Dl(c) {
+  function Ol(c) {
     const v = {}, m = n().results[c - 1].tallyResults;
     for (let $ = 0; $ < m.length; $++) {
       let b = m[$].eliminated;
@@ -5283,8 +5286,8 @@ function El(e, t) {
     }
     return v;
   }
-  function Ol(c, v) {
-    const m = [], $ = Rt, b = n().results[c - 1].tallyResults;
+  function Il(c, v) {
+    const m = [], $ = St, b = n().results[c - 1].tallyResults;
     for (let T = 0; T < b.length; T++) {
       let P = b[T].eliminated;
       if (P === void 0 && (P = b[T].elected), P === void 0) {
@@ -5319,23 +5322,23 @@ function El(e, t) {
             padAngle: 0
           };
         else {
-          if (k == "residual surplus")
+          if (X(k))
             continue;
           console.warn("makeDonutInfo: unrecognized name in transfers ", k);
           continue;
         }
-        const Je = Number(R) / $ * 2 * Math.PI;
-        S.startAngle = C, C = S.endAngle = C + Je, S.index = T, S.data.transferIndex = T, m.push(S);
+        const Ze = Number(R) / $ * 2 * Math.PI;
+        S.startAngle = C, C = S.endAngle = C + Ze, S.index = T, S.data.transferIndex = T, m.push(S);
       }
     }
     return m;
   }
-  function Il(c, v, m) {
+  function Fl(c, v, m) {
     const $ = {};
     for (let [b, T] of Object.entries(c)) {
       const P = m.find((C) => b == C.data.label);
       if (P === void 0) {
-        b !== "residual surplus" && console.warn("getTransferStartAngles: mainPieObj not found for ", b);
+        X(b) || console.warn("getTransferStartAngles: mainPieObj not found for ", b);
         continue;
       }
       const q = (P.startAngle + P.endAngle) / 2, F = c[P.data.label] / v * 2 * Math.PI;
@@ -5343,8 +5346,8 @@ function El(e, t) {
     }
     return $;
   }
-  function Fl(c, v, m) {
-    const $ = [], b = Rt, T = Dl(c), P = Il(T, b, m);
+  function Ll(c, v, m) {
+    const $ = [], b = St, T = Ol(c), P = Fl(T, b, m);
     for (let [q, F] of v.entries()) {
       const C = structuredClone(F), k = F.endAngle - F.startAngle, R = m.find((S) => F.data.label === S.data.label && !S.data.isTransfer);
       if (R) {
@@ -5361,11 +5364,11 @@ function El(e, t) {
     return $;
   }
   function ia(c, v, m, $) {
-    const b = _t().innerRadius(m * ie).outerRadius(m * ie), T = v.filter((k) => !k.data.isTransfer && k.data.value > 0), P = [], q = $.append("g").attr("opacity", 0);
+    const b = mt().innerRadius(m * ie).outerRadius(m * ie), T = v.filter((k) => !k.data.isTransfer && k.data.value > 0), P = [], q = $.append("g").attr("opacity", 0);
     for (const k of T) {
-      const R = k.data.label === "exhausted" ? Xt : k.data.label, S = b.centroid(k), Ne = ni(k.startAngle, k.endAngle), ne = er(k.data.label, c), Je = q.append("text").attr("transform", `translate(${S})`).attr("text-anchor", Ne).text(R);
-      Je.append("tspan").attr("x", 0).attr("dy", "1.2em").text(ne);
-      const re = Je.node().getBBox();
+      const R = k.data.label === "exhausted" ? Wt : k.data.label, S = b.centroid(k), Ne = ri(k.startAngle, k.endAngle), ne = er(k.data.label, c), Ze = q.append("text").attr("transform", `translate(${S})`).attr("text-anchor", Ne).text(R);
+      Ze.append("tspan").attr("x", 0).attr("dy", "1.2em").text(ne);
+      const re = Ze.node().getBBox();
       P.push({
         label: k.data.label,
         value: k.data.value,
@@ -5379,7 +5382,7 @@ function El(e, t) {
     return C;
   }
   function ts(c, v, m, $, b, T) {
-    Tt = {
+    Rt = {
       round: c,
       pieInfo: v,
       x: m,
@@ -5387,20 +5390,20 @@ function El(e, t) {
       outerRadius: b,
       eliminated: T
     };
-    const q = ue(A(ae)).append("g").attr("id", U).attr("transform", `translate(${m}, ${$})`), F = _t().innerRadius(b * ie).outerRadius(b * ie), C = ia(c, v, b, q);
+    const q = ue(A(ae)).append("g").attr("id", G).attr("transform", `translate(${m}, ${$})`), F = mt().innerRadius(b * ie).outerRadius(b * ie), C = ia(c, v, b, q);
     q.selectAll("text").data(v).enter().each(function(k) {
       !k.data.isTransfer && C.has(k.data.label) && ue(this).append("g").attr("id", (R) => x(R.data)).classed("eliminated", (R) => T.includes(R.data.label) || R.data.isTransfer === !0).each(function(R, S) {
-        R.data.label === "exhausted" && ue(this).on("mouseenter", (Ne, ne) => Hl(Ne)).on("mouseleave", (Ne, ne) => Yl());
-      }).append("text").attr("transform", (R) => `translate(${F.centroid(R)})`).attr("text-anchor", (R) => ni(R.startAngle, R.endAngle)).text((R) => R.data.label === "exhausted" ? Xt : R.data.label).append("tspan").attr("x", 0).attr("dy", "1.2em").text((R) => er(R.data.label, c));
+        R.data.label === "exhausted" && ue(this).on("mouseenter", (Ne, ne) => Yl(Ne)).on("mouseleave", (Ne, ne) => Bl());
+      }).append("text").attr("transform", (R) => `translate(${F.centroid(R)})`).attr("text-anchor", (R) => ri(R.startAngle, R.endAngle)).text((R) => R.data.label === "exhausted" ? Wt : R.data.label).append("tspan").attr("x", 0).attr("dy", "1.2em").text((R) => er(R.data.label, c));
     });
   }
-  function Ll(c, v, m, $) {
-    const T = ue(A(ae)).select("#" + U), P = ia(c, v, m, T);
+  function ql(c, v, m, $) {
+    const T = ue(A(ae)).select("#" + G), P = ia(c, v, m, T);
     T.selectAll("g").each(function(S) {
       S && S.data && !S.data.isTransfer && !P.has(S.data.label) && ue(this).remove();
     });
-    const q = T.selectAll("tspan"), F = T.selectAll("g").data(v, (S) => x(S.data)).classed("eliminated", (S) => $.includes(S.data.label) || S.data.isTransfer === !0), C = _t().innerRadius(m * ie).outerRadius(m * ie + 1);
-    q.transition("global").duration(M).attr("transform", (S) => `translate(${C.centroid(S)})`).attr("text-anchor", (S) => ni(S.startAngle, S.endAngle)), F.select("text").transition("global").duration(M).attr("transform", (S) => `translate(${C.centroid(S)})`).attr("text-anchor", (S) => ni(S.startAngle, S.endAngle)).on("end", (S) => R());
+    const q = T.selectAll("tspan"), F = T.selectAll("g").data(v, (S) => x(S.data)).classed("eliminated", (S) => $.includes(S.data.label) || S.data.isTransfer === !0), C = mt().innerRadius(m * ie).outerRadius(m * ie + 1);
+    q.transition("global").duration(M).attr("transform", (S) => `translate(${C.centroid(S)})`).attr("text-anchor", (S) => ri(S.startAngle, S.endAngle)), F.select("text").transition("global").duration(M).attr("transform", (S) => `translate(${C.centroid(S)})`).attr("text-anchor", (S) => ri(S.startAngle, S.endAngle)).on("end", (S) => R());
     let k = F.size();
     function R(S) {
       k--, k === 0 && (T.remove(), ts(c, v, I, K, m, $));
@@ -5414,41 +5417,41 @@ function El(e, t) {
     ue(A(ae)).select("#" + Q).selectAll(".elected").select("path").style("stroke", se).style("stroke-width", `${Pe}px`);
   }
   function aa(c, v, m, $, b, T, P, q, F, C = !1) {
-    const k = he(c), R = ge(c), ne = ue(A(ae)).attr("viewBox", `0 0 ${D} ${N}`).attr("preserveAspectRatio", "xMidYMid meet").classed("pie-chart-svg", !0).append("g").attr("id", v).attr("transform", `translate(${$}, ${b})`).selectAll(".slice").data(m).enter().append("g").attr("class", "slice").classed("eliminated", (re) => k.includes(re.data.label) || re.data.isTransfer === !0).classed("elected", (re) => R.includes(re.data.label) && !re.data.isTransfer).attr("id", (re) => x(re.data));
+    const k = ce(c), R = oe(c), ne = ue(A(ae)).attr("viewBox", `0 0 ${D} ${N}`).attr("preserveAspectRatio", "xMidYMid meet").classed("pie-chart-svg", !0).append("g").attr("id", v).attr("transform", `translate(${$}, ${b})`).selectAll(".slice").data(m).enter().append("g").attr("class", "slice").classed("eliminated", (re) => k.includes(re.data.label) || re.data.isTransfer === !0).classed("elected", (re) => R.includes(re.data.label) && !re.data.isTransfer).attr("id", (re) => x(re.data));
     C ? ne.style("pointer-events", "none") : ne.on("mouseenter", (re, ut) => rs(re, ut)).on("mouseleave", (re, ut) => is(re, ut));
-    const Je = _t().outerRadius(P).innerRadius(T);
+    const Ze = mt().outerRadius(P).innerRadius(T);
     if (F) {
-      const re = _t().outerRadius(T + 1).innerRadius(T);
-      ne.append("path").attr("d", re).attr("stroke", C ? "none" : T === 0 ? Se : "none").attr("stroke-width", C ? 0 : T === 0 ? Ge : 0).attr("fill", C ? "none" : (ut) => Sr(ut)).transition("global").duration(M).attr("d", (ut) => Je(ut)).on("end", (ut) => {
+      const re = mt().outerRadius(T + 1).innerRadius(T);
+      ne.append("path").attr("d", re).attr("stroke", C ? "none" : T === 0 ? Se : "none").attr("stroke-width", C ? 0 : T === 0 ? Ge : 0).attr("fill", C ? "none" : (ut) => Sr(ut)).transition("global").duration(M).attr("d", (ut) => Ze(ut)).on("end", (ut) => {
         C || ns();
       });
     } else
-      ne.append("path").attr("d", (re) => Je(re)).attr("fill", C ? "none" : (re) => Sr(re)).attr("stroke", C ? "none" : Se).attr("stroke-width", C ? 0 : Ge), C || ns();
+      ne.append("path").attr("d", (re) => Ze(re)).attr("fill", C ? "none" : (re) => Sr(re)).attr("stroke", C ? "none" : Se).attr("stroke-width", C ? 0 : Ge), C || ns();
     return q && !C && ts(c, m, $, b, P, k), m;
   }
-  function ql() {
-    const m = ue(A(ae)).select("#" + U).selectAll(".eliminated");
+  function Vl() {
+    const m = ue(A(ae)).select("#" + G).selectAll(".eliminated");
     m.size() > 0 && m.classed("finished", !0);
   }
-  function Vl() {
-    const m = ue(A(ae)).select("#" + U).selectAll(".finished");
+  function zl() {
+    const m = ue(A(ae)).select("#" + G).selectAll(".finished");
     m.size() > 0 && m.remove();
   }
-  function zl(c, v) {
-    const b = ue(A(ae)).select("#" + V).selectAll(".eliminated"), T = _t().innerRadius(c), P = _t().outerRadius(v);
+  function Hl(c, v) {
+    const b = ue(A(ae)).select("#" + V).selectAll(".eliminated"), T = mt().innerRadius(c), P = mt().outerRadius(v);
     b.classed("finished", !0).select("path").attr("stroke", "none").transition("global").duration(M).attrTween("d", function(q) {
-      const F = Qt(v, c);
+      const F = Zt(v, c);
       return function(C) {
         return P.innerRadius(F(C)), P(q);
       };
-    }).attr("fill", (q) => `url(#${me(q.data.label)})`), b.clone(!0).classed("finished", !0).select("path").transition("global").duration(M).attrTween("d", function(q) {
-      const F = Qt(v, c);
+    }).attr("fill", (q) => `url(#${ge(q.data.label)})`), b.clone(!0).classed("finished", !0).select("path").transition("global").duration(M).attrTween("d", function(q) {
+      const F = Zt(v, c);
       return function(C) {
         return T.outerRadius(F(C)), T(q);
       };
     }).attr("fill", (q) => Sr(q));
   }
-  function ni(c, v) {
+  function ri(c, v) {
     const m = (c + v) / 2;
     return m > Math.PI * 11 / 6 || m < Math.PI * 1 / 6 || m > Math.PI * 5 / 6 && m < Math.PI * 7 / 6 ? "middle" : m < Math.PI ? "start" : "end";
   }
@@ -5456,24 +5459,24 @@ function El(e, t) {
     ue(A(
       ae
       // force redisplay of text labels
-    )).select("#" + U).raise().append("g").remove();
+    )).select("#" + G).raise().append("g").remove();
   }
   function oa(c, v, m, $, b, T, P = !1) {
     const F = cs().sort(null).value((C) => C.value)(m);
     return fa(c, v, F, $, b, T, P), F;
   }
   function la(c, v, m, $, b = !1) {
-    const T = he(c), P = ge(c), C = ue(A(ae)).select("#" + v).selectAll(".slice").data(m, (R) => x(R.data));
+    const T = ce(c), P = oe(c), C = ue(A(ae)).select("#" + v).selectAll(".slice").data(m, (R) => x(R.data));
     C.exit().remove();
     const k = C.enter().append("g").attr("class", "slice").attr("id", (R) => x(R.data)).classed("eliminated", !0);
     return b ? k.style("pointer-events", "none") : k.on("mouseenter", (R, S) => rs(R, S)).on("mouseleave", (R, S) => is(R, S)), k.append("path").attr("d", (R) => $(R)).attr("fill", b ? "none" : (R) => Sr(R)).attr("stroke", b ? "none" : Se).attr("stroke-width", b ? 0 : Ge), C.classed("eliminated", (R) => T.includes(R.data.label)).classed("elected", (R) => P.includes(R.data.label)), b || C.on("mouseenter", (R, S) => rs(R, S)).on("mouseleave", (R, S) => is(R, S)), C;
   }
   function ua(c, v, m, $, b, T = !1) {
-    const P = _t().outerRadius(b).innerRadius($);
+    const P = mt().outerRadius(b).innerRadius($);
     la(c, v, m, P, T).select("path").attr("d", (F) => P(F)).attr("fill", T ? "none" : (F) => Sr(F));
   }
   function fa(c, v, m, $, b, T, P = !1) {
-    const q = _t().outerRadius(b).innerRadius($).startAngle((ne) => ne.startAngle).endAngle((ne) => ne.endAngle), F = _t().outerRadius(b).innerRadius($);
+    const q = mt().outerRadius(b).innerRadius($).startAngle((ne) => ne.startAngle).endAngle((ne) => ne.endAngle), F = mt().outerRadius(b).innerRadius($);
     ue(A(ae)).select("#" + v).selectAll(".slice").attr("prevStart", (ne) => ne.startAngle).attr("prevEnd", (ne) => ne.endAngle);
     const R = la(c, v, m, F, P);
     let S = R.size();
@@ -5481,11 +5484,11 @@ function El(e, t) {
       S--, S <= 0 && (P || ns());
     }
     return R.select("path").transition("global").duration(M).attrTween("d", function(ne) {
-      const Je = Number(ue(this.parentNode).attr("prevStart")), re = Number(ue(this.parentNode).attr("prevEnd")), ut = Qt(Je, ne.startAngle), ri = Qt(re, ne.endAngle);
-      return (Nr) => (q.startAngle(ut(Nr)).endAngle(ri(Nr)), q(ne));
+      const Ze = Number(ue(this.parentNode).attr("prevStart")), re = Number(ue(this.parentNode).attr("prevEnd")), ut = Zt(Ze, ne.startAngle), ii = Zt(re, ne.endAngle);
+      return (Nr) => (q.startAngle(ut(Nr)).endAngle(ii(Nr)), q(ne));
     }).on("end", function(ne) {
       ne.startAngle === ne.endAngle && ue(this).attr("stroke", "none"), Ne();
-    }), T && !P && Ll(c, m, b, he(c)), m;
+    }), T && !P && ql(c, m, b, ce(c)), m;
   }
   function rs(c, v) {
     s(v.data.label), i("enter"), a(c.clientX), o(c.clientY);
@@ -5493,19 +5496,19 @@ function El(e, t) {
   function is(c, v) {
     s(v.data.label), i("leave");
   }
-  function Hl(c, v) {
+  function Yl(c, v) {
     i("show-exhausted"), a(c.clientX), o(c.clientY);
   }
-  function Yl(c, v) {
+  function Bl(c, v) {
     i("hide-exhausted");
   }
-  var Bl = {
+  var Xl = {
     pieColors: Me,
-    exhaustedLabel: Xt,
-    countExhaustedVotes: pn,
-    getEliminatedCandidates: he,
-    getElectedCandidates: ge,
-    runFullAnimationFn: Jt,
+    exhaustedLabel: Wt,
+    countExhaustedVotes: dn,
+    getEliminatedCandidates: ce,
+    getElectedCandidates: oe,
+    runFullAnimationFn: jt,
     animateOnePhaseFn: ra,
     get jsonData() {
       return n();
@@ -5599,8 +5602,8 @@ function El(e, t) {
     set displayPhase(c = 0) {
       _(c), j();
     }
-  }, ca = lp();
-  return _i(ca, (c) => pe(ae, c), () => A(ae)), Be(e, ca), Bi(Bl);
+  }, ca = up();
+  return mi(ca, (c) => de(ae, c), () => A(ae)), Be(e, ca), Xi(Xl);
 }
 Us(
   El,
@@ -5633,13 +5636,13 @@ Us(
   ],
   { mode: "open" }
 );
-var fp = /* @__PURE__ */ Yt("<div></div>"), cp = /* @__PURE__ */ Yt('<!> <div class="step svelte-1l4eyw0"><div></div> <span> </span></div>', 1), hp = /* @__PURE__ */ Yt('<div role="button" aria-label="Advance animation phase"></div>');
-const dp = {
+var cp = /* @__PURE__ */ Bt("<div></div>"), hp = /* @__PURE__ */ Bt('<!> <div class="step svelte-1l4eyw0"><div></div> <span> </span></div>', 1), dp = /* @__PURE__ */ Bt('<div role="button" aria-label="Advance animation phase"></div>');
+const pp = {
   hash: "svelte-1l4eyw0",
   code: ".stepper.svelte-1l4eyw0 {display:inline-flex;align-items:center;cursor:pointer;user-select:none;padding:4px 8px;border-radius:4px;}.stepper.svelte-1l4eyw0:hover:not(.disabled) {background-color:#f0f0f0;}.stepper.disabled.svelte-1l4eyw0 {cursor:default;opacity:0.4;}.step.svelte-1l4eyw0 {display:flex;align-items:center;gap:4px;}.dot.svelte-1l4eyw0 {width:10px;height:10px;border-radius:50%;border:2px solid #ccc;background:white;transition:background-color 0.3s, border-color 0.3s;}.dot.active.svelte-1l4eyw0 {background:#4747ff;border-color:#4747ff;}.dot.completed.svelte-1l4eyw0 {background:#8888ff;border-color:#8888ff;}.label.svelte-1l4eyw0 {font-size:0.75rem;color:#888;transition:color 0.3s, font-weight 0.3s;}.label.active.svelte-1l4eyw0 {color:#4747ff;font-weight:bold;}.label.completed.svelte-1l4eyw0 {color:#8888ff;}.connector.svelte-1l4eyw0 {width:20px;height:2px;background:#ccc;margin:0 4px;transition:background-color 0.3s;}.connector.completed.svelte-1l4eyw0 {background:#8888ff;}"
 };
 function Tl(e, t) {
-  Yi(t, !0), Ws(e, dp);
+  Bi(t, !0), Ws(e, pp);
   let n = ee(t, "labels", 23, () => ["Eliminate", "Transfer", "Consolidate"]), r = ee(t, "currentStep", 7, 0), i = ee(t, "disabled", 7, !1), s = ee(t, "onAdvance", 7, () => {
   });
   function a() {
@@ -5674,42 +5677,42 @@ function Tl(e, t) {
     }) {
       s(d), j();
     }
-  }, u = hp();
+  }, u = dp();
   let f;
-  return u.__click = a, u.__keydown = o, gi(u, 21, n, vi, (d, h, p) => {
-    var y = cp(), E = mn(y);
+  return u.__click = a, u.__keydown = o, _i(u, 21, n, gi, (d, h, p) => {
+    var y = hp(), E = mn(y);
     {
       var _ = (V) => {
-        var Q = fp();
+        var Q = cp();
         let B;
-        en(() => B = ai(Q, 1, "connector svelte-1l4eyw0", null, B, { completed: !i() && p <= r() })), Be(V, Q);
+        Qt(() => B = oi(Q, 1, "connector svelte-1l4eyw0", null, B, { completed: !i() && p <= r() })), Be(V, Q);
       };
       ir(E, (V) => {
         p > 0 && V(_);
       });
     }
-    var x = Ze(E, 2), D = He(x);
+    var x = Qe(E, 2), D = He(x);
     let N;
-    var O = Ze(D, 2);
+    var O = Qe(D, 2);
     let I;
     var K = He(O, !0);
-    Oe(O), Oe(x), en(() => {
-      N = ai(D, 1, "dot svelte-1l4eyw0", null, N, {
+    Oe(O), Oe(x), Qt(() => {
+      N = oi(D, 1, "dot svelte-1l4eyw0", null, N, {
         active: !i() && p === r(),
         completed: !i() && p < r()
-      }), I = ai(O, 1, "label svelte-1l4eyw0", null, I, {
+      }), I = oi(O, 1, "label svelte-1l4eyw0", null, I, {
         active: !i() && p === r(),
         completed: !i() && p < r()
       }), yn(K, A(h));
     }), Be(d, y);
-  }), Oe(u), en(() => {
-    f = ai(u, 1, "stepper svelte-1l4eyw0", null, f, { disabled: i() }), Ta(u, "tabindex", i() ? -1 : 0), Ta(u, "aria-disabled", i());
-  }), Be(e, u), Bi(l);
+  }), Oe(u), Qt(() => {
+    f = oi(u, 1, "stepper svelte-1l4eyw0", null, f, { disabled: i() }), Ta(u, "tabindex", i() ? -1 : 0), Ta(u, "aria-disabled", i());
+  }), Be(e, u), Xi(l);
 }
-tf(["click", "keydown"]);
+nf(["click", "keydown"]);
 Us(Tl, { labels: {}, currentStep: {}, disabled: {}, onAdvance: {} }, [], [], { mode: "open" });
-var pp = /* @__PURE__ */ Yt("<span> </span> <!>", 1), vp = /* @__PURE__ */ Yt("About to eliminate: <!>", 1), gp = /* @__PURE__ */ Yt("<span> </span> <!>", 1), _p = /* @__PURE__ */ Yt(" <!>", 1), mp = /* @__PURE__ */ Yt('<h3 class="svelte-1r6y5gl"> </h3> <h4 class="svelte-1r6y5gl"><!> <!></h4>', 1), yp = /* @__PURE__ */ Yt("<span> </span> <br/>", 1), wp = /* @__PURE__ */ Yt('<div class="animation-button-container svelte-1r6y5gl"><!></div> <div class="common-header svelte-1r6y5gl"></div> <div class="page-container svelte-1r6y5gl"><div class="visualizations-container svelte-1r6y5gl"><div class="pie-chart-container svelte-1r6y5gl"><!></div></div> <!></div> <div class="tooltip svelte-1r6y5gl"><h3 class="svelte-1r6y5gl"> </h3> <!></div> <div class="tooltip svelte-1r6y5gl"> <br/> these ballots have already been eliminated.</div>', 1);
-const xp = {
+var vp = /* @__PURE__ */ Bt("<span> </span> <!>", 1), gp = /* @__PURE__ */ Bt("About to eliminate: <!>", 1), _p = /* @__PURE__ */ Bt("<span> </span> <!>", 1), mp = /* @__PURE__ */ Bt(" <!>", 1), yp = /* @__PURE__ */ Bt('<h3 class="svelte-1r6y5gl"> </h3> <h4 class="svelte-1r6y5gl"><!> <!></h4>', 1), wp = /* @__PURE__ */ Bt("<span> </span> <br/>", 1), xp = /* @__PURE__ */ Bt('<div class="animation-button-container svelte-1r6y5gl"><!></div> <div class="common-header svelte-1r6y5gl"></div> <div class="page-container svelte-1r6y5gl"><div class="visualizations-container svelte-1r6y5gl"><div class="pie-chart-container svelte-1r6y5gl"><!></div></div> <!></div> <div class="tooltip svelte-1r6y5gl"><h3 class="svelte-1r6y5gl"> </h3> <!></div> <div class="tooltip svelte-1r6y5gl"> <br/> these ballots have already been eliminated.</div>', 1);
+const bp = {
   hash: "svelte-1r6y5gl",
   code: `.page-container.svelte-1r6y5gl {width:95%;max-width:1800px;margin:0 auto;padding:0 20px;box-sizing:border-box;display:flex;flex-direction:column;align-items:center;}.common-header.svelte-1r6y5gl {width:100%;margin-bottom:1rem;text-align:center;}.tooltip.svelte-1r6y5gl {position:fixed;width:max-content;max-width:calc(100vw - 24px);text-align:left;padding:.5rem;background:#FFFFFF;color:#313639;border:1px solid #313639;border-radius:8px;pointer-events:none;font-size:0.8rem;font-weight:normal;opacity:0;z-index:100;}.tooltip.svelte-1r6y5gl h3:where(.svelte-1r6y5gl) {text-align:center;}.animation-button-container.svelte-1r6y5gl {display:flex;justify-content:center;gap:10px;margin:0.5rem;}.pie-chart-container.svelte-1r6y5gl {width:100%;min-width:auto;flex-grow:0;margin:0 auto;margin-top:-3vh;}.visualizations-container.svelte-1r6y5gl {display:flex;justify-content:space-between;width:100%;padding:0 20px;gap:20px;}
 
@@ -5724,8 +5727,8 @@ const xp = {
   
 }`
 };
-function bp(e, t) {
-  Yi(t, !0), Ws(e, xp);
+function $p(e, t) {
+  Bi(t, !0), Ws(e, bp);
   const n = 0.85;
   let r = ee(t, "electionSummary", 7), i = ee(t, "currentRound", 7, 1), s = ee(t, "requestRoundChange", 7, (w) => {
   }), a = ee(t, "requestSkipToRound", 7, (w) => {
@@ -5748,36 +5751,36 @@ function bp(e, t) {
       infinitive: "to take the lead"
     }
   };
-  let _ = /* @__PURE__ */ Nn(() => E[l()] ?? E.won), x = /* @__PURE__ */ xe(null), D = /* @__PURE__ */ xe(null), N = /* @__PURE__ */ xe(""), O = /* @__PURE__ */ xe(On([])), I = /* @__PURE__ */ xe(""), K = /* @__PURE__ */ xe(""), V = /* @__PURE__ */ xe(0), Q = /* @__PURE__ */ xe(0), B = /* @__PURE__ */ Nn(() => U(r()));
-  function U(w) {
+  let _ = /* @__PURE__ */ Nn(() => E[l()] ?? E.won), x = /* @__PURE__ */ xe(null), D = /* @__PURE__ */ xe(null), N = /* @__PURE__ */ xe(""), O = /* @__PURE__ */ xe(On([])), I = /* @__PURE__ */ xe(""), K = /* @__PURE__ */ xe(""), V = /* @__PURE__ */ xe(0), Q = /* @__PURE__ */ xe(0), B = /* @__PURE__ */ Nn(() => G(r()));
+  function G(w) {
     if (typeof w == "string")
       try {
         w = JSON.parse(w);
-      } catch (G) {
-        return console.error("Failed to parse JSON string:", G), {};
+      } catch (X) {
+        return console.error("Failed to parse JSON string:", X), {};
       }
     return w || {};
   }
   function fe(w) {
     s() ? s()(w) : console.warn("onRoundChange in PieChart: requestRoundChange is null");
   }
-  function ie(w, G, oe) {
-    w.style.left = G + "px", w.style.top = oe + 20 + "px", w.style.transform = "none", requestAnimationFrame(() => {
-      const le = w.getBoundingClientRect();
-      let De = G, Gt = oe + 20;
-      De + le.width > window.innerWidth - 12 && (De = window.innerWidth - le.width - 12), De < 12 && (De = 12), Gt + le.height > window.innerHeight - 12 && (Gt = oe - le.height - 12), w.style.left = De + "px", w.style.top = Gt + "px";
+  function ie(w, X, le) {
+    w.style.left = X + "px", w.style.top = le + 20 + "px", w.style.transform = "none", requestAnimationFrame(() => {
+      const oe = w.getBoundingClientRect();
+      let qe = X, Ct = le + 20;
+      qe + oe.width > window.innerWidth - 12 && (qe = window.innerWidth - oe.width - 12), qe < 12 && (qe = 12), Ct + oe.height > window.innerHeight - 12 && (Ct = le - oe.height - 12), w.style.left = qe + "px", w.style.top = Ct + "px";
     });
   }
   function M() {
     switch (A(I)) {
       case "enter":
         ((w) => {
-          var G = cu(w, 2);
-          pe(O, G[0], !0), pe(N, G[1], !0);
+          var X = hu(w, 2);
+          de(O, X[0], !0), de(N, X[1], !0);
         })(Se(A(K), i())), A(x) && (ie(A(x), A(V) || 0, A(Q) || 0), A(x).style.opacity = String(n));
         break;
       case "leave":
-        A(x) && (A(x).style.opacity = "0"), pe(O, [], !0), pe(N, "");
+        A(x) && (A(x).style.opacity = "0"), de(O, [], !0), de(N, "");
         break;
       case "show-exhausted":
         A(D) && (ie(A(D), A(V) || 0, A(Q) || 0), A(D).style.opacity = String(n));
@@ -5792,63 +5795,63 @@ function bp(e, t) {
         break;
     }
   }
-  Ri(() => M());
-  function z(w, G) {
-    return w === 1 ? G ? "vote was" : "vote will be" : G ? "votes were" : "votes will be";
+  Si(() => M());
+  function z(w, X) {
+    return w === 1 ? X ? "vote was" : "vote will be" : X ? "votes were" : "votes will be";
   }
-  function Se(w, G) {
-    const oe = [], he = w === "exhausted" ? Y() : w;
-    let ge;
-    w === "exhausted" ? ge = Tt(1) : ge = A(B).results[0].tally[w], oe.push(`${he} started with ${ge} votes.`);
-    for (let le = 1; le <= G; le++) {
-      le === G && (w === "exhausted" ? ge = Tt(G) : ge = A(B).results[G - 1].tally[w], oe.push(`${he} has ${ge} votes at round ${G}.`));
-      const De = A(B).results[le - 1].tallyResults, Gt = ye(le);
-      for (let St = 0; St < De.length; St++) {
-        const Cn = De[St].transfers, Kt = De[St].eliminated, qe = De[St].elected;
-        if (!Gt) {
-          if (Kt)
-            Kt === w && oe.push(`${he} will be eliminated on round ${le}.`);
-          else if (w === qe && (oe.push(`${he} ${A(_).event} on round ${le}.`), Cn))
-            for (let [ot, vn] of Object.entries(Cn))
-              oe.push(`${vn} ${z(Number(vn), le < G)} transferred to ${ot} on round ${le}.`);
+  function Se(w, X) {
+    const le = [], me = w === "exhausted" ? Y() : w;
+    let ce;
+    w === "exhausted" ? ce = Rt(1) : ce = A(B).results[0].tally[w], le.push(`${me} started with ${ce} votes.`);
+    for (let oe = 1; oe <= X; oe++) {
+      oe === X && (w === "exhausted" ? ce = Rt(X) : ce = A(B).results[X - 1].tally[w], le.push(`${me} has ${ce} votes at round ${X}.`));
+      const qe = A(B).results[oe - 1].tallyResults, Ct = _e(oe);
+      for (let Nt = 0; Nt < qe.length; Nt++) {
+        const Cn = qe[Nt].transfers, pn = qe[Nt].eliminated, De = qe[Nt].elected;
+        if (!Ct) {
+          if (pn)
+            pn === w && le.push(`${me} will be eliminated on round ${oe}.`);
+          else if (w === De && (le.push(`${me} ${A(_).event} on round ${oe}.`), Cn))
+            for (let [lt, vn] of Object.entries(Cn))
+              le.push(`${vn} ${z(Number(vn), oe < X)} transferred to ${lt} on round ${oe}.`);
         }
-        const Ct = Kt || qe;
-        if (Ct) {
-          const ot = Number(Cn[w]);
-          ot && oe.push(`${ot} ${z(ot, le < G)} transferred from ${Ct} on round ${le}.`);
+        const kt = pn || De;
+        if (kt) {
+          const lt = Number(Cn[w]);
+          lt && le.push(`${lt} ${z(lt, oe < X)} transferred from ${kt} on round ${oe}.`);
         }
       }
     }
-    return [oe, he];
+    return [le, me];
   }
   function Ge() {
     let w = 0;
-    for (let G = 1; G <= A(B).results.length; G++) {
-      if (ye(G)) continue;
-      const oe = A(B).results[G - 1].tallyResults;
-      for (let he = 0; he < oe.length; he++)
-        oe[he].elected && w++;
+    for (let X = 1; X <= A(B).results.length; X++) {
+      if (_e(X)) continue;
+      const le = A(B).results[X - 1].tallyResults;
+      for (let me = 0; me < le.length; me++)
+        le[me].elected && w++;
     }
     return w;
   }
   let se, Pe = /* @__PURE__ */ xe(0);
-  function me(w) {
-    var ge;
-    return !((ge = A(B)) != null && ge.results) || w < 1 || w > A(B).results.length ? ["Eliminate", "Transfer", "Consolidate"] : [A(B).results[w - 1].tallyResults.some((le) => le.eliminated) ? "Eliminate" : "Surplus", "Transfer", "Consolidate"];
+  function ge(w) {
+    var ce;
+    return !((ce = A(B)) != null && ce.results) || w < 1 || w > A(B).results.length ? ["Eliminate", "Transfer", "Consolidate"] : [A(B).results[w - 1].tallyResults.some((oe) => oe.eliminated) ? "Eliminate" : "Surplus", "Transfer", "Consolidate"];
   }
-  function ye(w) {
+  function _e(w) {
     return u() && A(B).results && w === A(B).results.length;
   }
-  function at(w) {
-    return ye(w) ? [] : se ? se.getEliminatedCandidates(w) : [];
+  function ot(w) {
+    return _e(w) ? [] : se ? se.getEliminatedCandidates(w) : [];
   }
   function Ce(w) {
-    return ye(w) ? [] : se ? se.getElectedCandidates(w) : [];
+    return _e(w) ? [] : se ? se.getElectedCandidates(w) : [];
   }
-  function Tt(w) {
+  function Rt(w) {
     return se ? se.countExhaustedVotes(w) : 0;
   }
-  function Rt() {
+  function St() {
     se && se.animateOnePhaseFn && se.animateOnePhaseFn();
   }
   function Y() {
@@ -5857,7 +5860,7 @@ function bp(e, t) {
   function Me() {
     return se ? se.pieColors : {};
   }
-  var Xt = {
+  var Wt = {
     get electionSummary() {
       return r();
     },
@@ -5873,14 +5876,14 @@ function bp(e, t) {
     get requestRoundChange() {
       return s();
     },
-    set requestRoundChange(w = (G) => {
+    set requestRoundChange(w = (X) => {
     }) {
       s(w), j();
     },
     get requestSkipToRound() {
       return a();
     },
-    set requestSkipToRound(w = (G) => {
+    set requestSkipToRound(w = (X) => {
     }) {
       a(w), j();
     },
@@ -5932,9 +5935,9 @@ function bp(e, t) {
     set showCaptions(w = !1) {
       y(w), j();
     }
-  }, ae = wp(), Wt = mn(ae), Rn = He(Wt);
+  }, ae = xp(), Ut = mn(ae), Rn = He(Ut);
   {
-    let w = /* @__PURE__ */ Nn(() => me(i()));
+    let w = /* @__PURE__ */ Nn(() => ge(i()));
     Tl(Rn, {
       get labels() {
         return A(w);
@@ -5943,13 +5946,13 @@ function bp(e, t) {
         return A(Pe);
       },
       disabled: !1,
-      onAdvance: Rt
+      onAdvance: St
     });
   }
-  Oe(Wt);
-  var Ut = Ze(Wt, 4), Tr = He(Ut), Sn = He(Tr), Ji = He(Sn);
-  _i(
-    El(Ji, {
+  Oe(Ut);
+  var Gt = Qe(Ut, 4), Tr = He(Gt), Sn = He(Tr), Zi = He(Sn);
+  mi(
+    El(Zi, {
       get jsonData() {
         return A(B);
       },
@@ -5982,127 +5985,127 @@ function bp(e, t) {
         return A(I);
       },
       set mouseEventType(w) {
-        pe(I, w, !0);
+        de(I, w, !0);
       },
       get mouseData() {
         return A(K);
       },
       set mouseData(w) {
-        pe(K, w, !0);
+        de(K, w, !0);
       },
       get mouseX() {
         return A(V);
       },
       set mouseX(w) {
-        pe(V, w, !0);
+        de(V, w, !0);
       },
       get mouseY() {
         return A(Q);
       },
       set mouseY(w) {
-        pe(Q, w, !0);
+        de(Q, w, !0);
       },
       get displayPhase() {
         return A(Pe);
       },
       set displayPhase(w) {
-        pe(Pe, w, !0);
+        de(Pe, w, !0);
       }
     }),
     (w) => se = w,
     () => se
   ), Oe(Sn), Oe(Tr);
-  var Ke = Ze(Tr, 2);
+  var Ke = Qe(Tr, 2);
   {
     var Rr = (w) => {
-      var G = mp(), oe = mn(G), he = He(oe);
-      Oe(oe);
-      var ge = Ze(oe, 2), le = He(ge);
+      var X = yp(), le = mn(X), me = He(le);
+      Oe(le);
+      var ce = Qe(le, 2), oe = He(ce);
       {
-        var De = (qe) => {
-          var Ct = vp(), ot = Ze(mn(Ct));
-          gi(ot, 17, () => at(i()), vi, (vn, tr, jt) => {
-            var Nt = pp(), Ve = mn(Nt);
-            let ce;
-            var lt = He(Ve, !0);
-            Oe(Ve);
-            var je = Ze(Ve, 2);
+        var qe = (De) => {
+          var kt = gp(), lt = Qe(mn(kt));
+          _i(lt, 17, () => ot(i()), gi, (vn, tr, nr) => {
+            var Kt = vp(), je = mn(Kt);
+            let Ve;
+            var ye = He(je, !0);
+            Oe(je);
+            var _t = Qe(je, 2);
             {
-              var gn = (Jt) => {
-                var kt = xa(", ");
-                Be(Jt, kt);
-              }, nr = /* @__PURE__ */ Nn(() => jt < at(i()).length - 1);
-              ir(je, (Jt) => {
-                A(nr) && Jt(gn);
+              var Je = (Pt) => {
+                var jt = xa(", ");
+                Be(Pt, jt);
+              }, gn = /* @__PURE__ */ Nn(() => nr < ot(i()).length - 1);
+              ir(_t, (Pt) => {
+                A(gn) && Pt(Je);
               });
             }
-            en(
-              (Jt) => {
-                ce = Ea(Ve, "", ce, Jt), yn(lt, A(tr));
+            Qt(
+              (Pt) => {
+                Ve = Ea(je, "", Ve, Pt), yn(ye, A(tr));
               },
               [() => ({ color: Me()[A(tr)] })]
-            ), Be(vn, Nt);
-          }), Be(qe, Ct);
-        }, Gt = /* @__PURE__ */ Nn(() => at(i()).length > 0);
-        ir(le, (qe) => {
-          A(Gt) && qe(De);
+            ), Be(vn, Kt);
+          }), Be(De, kt);
+        }, Ct = /* @__PURE__ */ Nn(() => ot(i()).length > 0);
+        ir(oe, (De) => {
+          A(Ct) && De(qe);
         });
       }
-      var St = Ze(le, 2);
+      var Nt = Qe(oe, 2);
       {
-        var Cn = (qe) => {
-          var Ct = _p(), ot = mn(Ct), vn = Ze(ot);
-          gi(vn, 17, () => Ce(i()), vi, (tr, jt, Nt) => {
-            var Ve = gp(), ce = mn(Ve);
-            let lt;
-            var je = He(ce, !0);
-            Oe(ce);
-            var gn = Ze(ce, 2);
+        var Cn = (De) => {
+          var kt = mp(), lt = mn(kt), vn = Qe(lt);
+          _i(vn, 17, () => Ce(i()), gi, (tr, nr, Kt) => {
+            var je = _p(), Ve = mn(je);
+            let ye;
+            var _t = He(Ve, !0);
+            Oe(Ve);
+            var Je = Qe(Ve, 2);
             {
-              var nr = (kt) => {
-                var es = xa(", ");
-                Be(kt, es);
-              }, Jt = /* @__PURE__ */ Nn(() => Nt < Ce(i()).length - 1);
-              ir(gn, (kt) => {
-                A(Jt) && kt(nr);
+              var gn = (jt) => {
+                var ni = xa(", ");
+                Be(jt, ni);
+              }, Pt = /* @__PURE__ */ Nn(() => Kt < Ce(i()).length - 1);
+              ir(Je, (jt) => {
+                A(Pt) && jt(gn);
               });
             }
-            en(
-              (kt) => {
-                lt = Ea(ce, "", lt, kt), yn(je, A(jt));
+            Qt(
+              (jt) => {
+                ye = Ea(Ve, "", ye, jt), yn(_t, A(nr));
               },
-              [() => ({ color: Me()[A(jt)] })]
-            ), Be(tr, Ve);
-          }), en(() => yn(ot, `${A(_).caption ?? ""}: `)), Be(qe, Ct);
-        }, Kt = /* @__PURE__ */ Nn(() => Ce(i()).length > 0);
-        ir(St, (qe) => {
-          A(Kt) && qe(Cn);
+              [() => ({ color: Me()[A(nr)] })]
+            ), Be(tr, je);
+          }), Qt(() => yn(lt, `${A(_).caption ?? ""}: `)), Be(De, kt);
+        }, pn = /* @__PURE__ */ Nn(() => Ce(i()).length > 0);
+        ir(Nt, (De) => {
+          A(pn) && De(Cn);
         });
       }
-      Oe(ge), en((qe) => yn(he, `${A(B).config.contest ?? ""}, ${qe ?? ""} ${A(_).infinitive ?? ""}, Round ${i() ?? ""}.`), [Ge]), Be(w, G);
+      Oe(ce), Qt((De) => yn(me, `${A(B).config.contest ?? ""}, ${De ?? ""} ${A(_).infinitive ?? ""}, Round ${i() ?? ""}.`), [Ge]), Be(w, X);
     };
     ir(Ke, (w) => {
       y() && w(Rr);
     });
   }
-  Oe(Ut);
-  var pn = Ze(Ut, 2), Qn = He(pn), Zi = He(Qn, !0);
+  Oe(Gt);
+  var dn = Qe(Gt, 2), Qn = He(dn), Qi = He(Qn, !0);
   Oe(Qn);
-  var ti = Ze(Qn, 2);
-  gi(ti, 17, () => A(O), vi, (w, G) => {
-    var oe = yp(), he = mn(oe), ge = He(he, !0);
-    Oe(he), ps(2), en(() => yn(ge, A(G))), Be(w, oe);
-  }), Oe(pn), _i(pn, (w) => pe(x, w), () => A(x));
-  var er = Ze(pn, 2), Qi = He(er);
-  return ps(2), Oe(er), _i(er, (w) => pe(D, w), () => A(D)), en(
+  var ti = Qe(Qn, 2);
+  _i(ti, 17, () => A(O), gi, (w, X) => {
+    var le = wp(), me = mn(le), ce = He(me, !0);
+    Oe(me), ps(2), Qt(() => yn(ce, A(X))), Be(w, le);
+  }), Oe(dn), mi(dn, (w) => de(x, w), () => A(x));
+  var er = Qe(dn, 2), es = He(er);
+  return ps(2), Oe(er), mi(er, (w) => de(D, w), () => A(D)), Qt(
     (w) => {
-      yn(Zi, A(N)), yn(Qi, `"${w ?? ""}" means all the candidates ranked on `);
+      yn(Qi, A(N)), yn(es, `"${w ?? ""}" means all the candidates ranked on `);
     },
     [Y]
-  ), Be(e, ae), Bi(Xt);
+  ), Be(e, ae), Xi(Wt);
 }
 customElements.define("pie-chart", Us(
-  bp,
+  $p,
   {
     electionSummary: {},
     currentRound: {},


### PR DESCRIPTION
Two pie fixes, one found during review of the other.

## 1. Surplus slivers close smoothly instead of leaving a white gap

When an elected candidate's surplus transfers, the grayed-out sliver of their slice was removed at full size at the start of the consolidate phase, leaving a white gap that neighboring slices then closed over. The pie bundle now retains the transfer sub-slice as a zero-value entry in the closing transition's data, so the keyed data join tweens it shut instead of exit-removing it at full size.

**Correction to the original description (and to @artoonie's question above — sorry for the wild-goose chase):** I claimed the 2013 Minneapolis Park Board election had three surplus rounds. It has **one** (round 9→10, ~1,829 votes, about 3.9% of the pie), which is why the gap was hard to spot there. The best data for seeing the original bug is this repo's own **macomb-multiwinner (Eastpointe 2019)**: round 4's surplus transfers 50.9 of 400 votes, so the disappearing sliver is ~12.7% of the circle — unmissable. Round 2 shows the small-sliver case (10 votes).

## 2. Residual surplus no longer appears as a candidate (the overlapping-labels screenshot)

The overlap @artoonie found while testing turned out to be a second, separate bug, and this branch now fixes it too.

rcvis injects residual surplus into the tally as a `Residual Surplus` pseudo-candidate. The component only knew the lowercase `residual surplus` form that raw RCTab files carry (as a transfer destination), so the title-cased tally entry walked past every check and was treated as an ordinary candidate: it got a slice, a color, a label, a place in the active-votes denominator — and a position in the slice shuffle. `Inactive Ballots` is pinned to the end of the slice order; whenever the shuffle happened to seat `Residual Surplus` in the last active position (~1-in-5 for this field size), the two near-zero slices sat adjacent at 12 o'clock and their labels superimposed. That's the screenshot.

The component now recognizes residual surplus case-insensitively and drops it entirely: no slice, no label, excluded from the live-votes denominator, transfer references absorbed silently. A stranded rounding remainder (0.0224 votes here) is held by nobody; a wedge too thin to see shouldn't get a label pointing at nothing.

One caveat for completeness: the label overlap-suppression logic measures text with `getBBox()`, which returns 0×0 when the chart is initialized while hidden (e.g. load on the Bar tab, then switch to Pie) — so on that path suppression is inert for *any* coincident labels, independent of this fix. With the residual gone this election has no coincident pair left, but that's a separate, smaller issue; happy to address it separately if you'd like.

## Test plan

- [x] Upload `macomb-multiwinner` (Eastpointe 2019); pie shows no Residual Surplus slice or label in any round; Inactive Ballots labeled normally from round 4
- [x] Round 4 surplus animation: sliver sweeps closed (hatched) instead of popping to a white gap; round 2 same for the small sliver
- [x] Reload several times: no label collision under any shuffle order
- [x] 2013 Minneapolis Park Board round 9→10 surplus still animates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
